### PR TITLE
Update the links to the files in the vae notebook

### DIFF
--- a/notebooks/vae_celeba_lightning.ipynb
+++ b/notebooks/vae_celeba_lightning.ipynb
@@ -6,7 +6,6 @@
       "name": "VAE-celeba-lightning-edited.ipynb",
       "provenance": [],
       "collapsed_sections": [],
-      "toc_visible": true,
       "machine_shape": "hm"
     },
     "kernelspec": {
@@ -35,8 +34,8 @@
       },
       "source": [
         "!wget -q https://github.com/probml/probml-data/raw/main/checkpoints/vae-celeba-conv.ckpt\n",
-        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae_celeba_lightning.py\n",
-        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/lvm_plots_utils.py\n",
+        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae/standalone/vae_celeba_lightning.py\n",
+        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae/standalone/lvm_plots_utils.py\n",
         "!wget -q https://raw.githubusercontent.com/sayantanauddy/vae_lightning/main/data.py\n",
         "!wget -q https://github.com/probml/probml-data/raw/main/data/celebA_male_img.npy"
       ],
@@ -88,7 +87,7 @@
         "from tqdm import tqdm\n",
         "from lvm_plots_utils import get_random_samples, get_grid_samples, plot_scatter_plot, get_imrange, make_imrange"
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -99,7 +98,7 @@
       "source": [
         "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
       ],
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -153,7 +152,7 @@
         "from google.colab import files\n",
         "uploaded = files.upload()"
       ],
-      "execution_count": 5,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -197,7 +196,7 @@
       "source": [
         "!ls"
       ],
-      "execution_count": 6,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -224,7 +223,7 @@
       "source": [
         "!mkdir /root/.kaggle\n"
       ],
-      "execution_count": 7,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -243,7 +242,7 @@
       "source": [
         "!cp kaggle.json /root/.kaggle/kaggle.json\n"
       ],
-      "execution_count": 8,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -254,7 +253,7 @@
       "source": [
         "!chmod 600 /root/.kaggle/kaggle.json\n"
       ],
-      "execution_count": 9,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -265,7 +264,7 @@
       "source": [
         "!rm kaggle.json"
       ],
-      "execution_count": 10,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -289,7 +288,7 @@
       "source": [
         "from data import CelebADataset,  CelebADataModule"
       ],
-      "execution_count": 11,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -304,7 +303,7 @@
       "source": [
         "ds = CelebADataset(root='kaggle', split='test', target_type='attr', download=True)"
       ],
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -351,7 +350,7 @@
         "                              batch_size=BATCH_SIZE,\n",
         "                              num_workers=1)"
       ],
-      "execution_count": 13,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -368,7 +367,7 @@
         "dm.setup() # force make data loaders no\n",
         "batch = next(iter(dm.train_dataloader())) # take the first batch"
       ],
-      "execution_count": 14,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -402,7 +401,7 @@
         "m.load_state_dict(torch.load(\"vae-celeba-conv.ckpt\"))\n",
         "m.to(device)"
       ],
-      "execution_count": 15,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -507,7 +506,7 @@
         "axs[1].imshow(rearrange(make_grid(m(imgs).cpu().detach()), 'c h w -> h w c'))\n",
         "plt.show()"
       ],
-      "execution_count": 16,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -542,7 +541,7 @@
         "def decoder(z):\n",
         "  return m.decode(z)"
       ],
-      "execution_count": 17,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -561,7 +560,7 @@
         "imgs= get_random_samples(decoder, 5, m.latent_dim)\n",
         "plt.imshow(imgs)"
       ],
-      "execution_count": 18,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -631,7 +630,7 @@
         "  label_vector = z_present-z_absent\n",
         "  return label_vector, present, absent"
       ],
-      "execution_count": 26,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -646,7 +645,7 @@
         "feature_of_interest=\"Smiling\"\n",
         "vec2, similing, not_similing = vector_of_interest(feature_of_interest)"
       ],
-      "execution_count": 44,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -678,7 +677,7 @@
         "  plt.figure(figsize=(20,10))\n",
         "  plt.imshow(arr2)"
       ],
-      "execution_count": 45,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -737,7 +736,7 @@
         "arr = get_imrange(decoder, encoder(start_img), encoder(end_img), nums=8, interpolation=\"linear\")\n",
         "plt.imshow(arr)"
       ],
-      "execution_count": 41,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -789,7 +788,7 @@
         "batch = (imgs, df[feature_of_interest])\n",
         "plot_scatter_plot(batch, encoder, use_embedder=\"UMAP\")"
       ],
-      "execution_count": 11,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",

--- a/notebooks/vae_mnist_conv_lightning.ipynb
+++ b/notebooks/vae_mnist_conv_lightning.ipynb
@@ -17,9 +17,10 @@
     "accelerator": "GPU",
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {
-        "ee9a145b26b446fb8b7750dd319d8ab7": {
+        "e5f144d0d57c4424bc878cbc82ff9529": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HBoxView",
             "_dom_classes": [],
@@ -29,17 +30,18 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_31b52281d3f14370a4ef03c313aa78ab",
+            "layout": "IPY_MODEL_9dec8b77a2834f0abfa8cd73e25eb6e1",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_75e5c2c4af9240e59d6b08d292f0fbc2",
-              "IPY_MODEL_953251629ae34885bf7b8c9825ecf9d5"
+              "IPY_MODEL_5a34ea4ea1314be78fb096182c008b07",
+              "IPY_MODEL_724c93aa28c14ee786f4884f5efc08f4"
             ]
           }
         },
-        "31b52281d3f14370a4ef03c313aa78ab": {
+        "9dec8b77a2834f0abfa8cd73e25eb6e1": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -88,12 +90,13 @@
             "left": null
           }
         },
-        "75e5c2c4af9240e59d6b08d292f0fbc2": {
+        "5a34ea4ea1314be78fb096182c008b07": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_5340956cd6b942d2a6716e6ac706e9ac",
+            "style": "IPY_MODEL_461284948a1e474d8b20dcd227a51a16",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -108,32 +111,34 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_1b332263bb8e47e695da741e7da638b3"
+            "layout": "IPY_MODEL_fddb54483fbf426f81870d9f437b2e15"
           }
         },
-        "953251629ae34885bf7b8c9825ecf9d5": {
+        "724c93aa28c14ee786f4884f5efc08f4": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_466a6885dfea41a1a039fe7546cedae3",
+            "style": "IPY_MODEL_c04cdf7c637244b69a7cfc5732c63d02",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 9913344/? [00:04&lt;00:00, 2072080.14it/s]",
+            "value": " 9913344/? [00:01&lt;00:00, 7576438.60it/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_eb0055a420af42efa0dc8948852094ea"
+            "layout": "IPY_MODEL_d69084fdc55749548357273490160255"
           }
         },
-        "5340956cd6b942d2a6716e6ac706e9ac": {
+        "461284948a1e474d8b20dcd227a51a16": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "ProgressStyleModel",
@@ -146,9 +151,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "1b332263bb8e47e695da741e7da638b3": {
+        "fddb54483fbf426f81870d9f437b2e15": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -197,9 +203,10 @@
             "left": null
           }
         },
-        "466a6885dfea41a1a039fe7546cedae3": {
+        "c04cdf7c637244b69a7cfc5732c63d02": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "DescriptionStyleModel",
@@ -211,9 +218,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "eb0055a420af42efa0dc8948852094ea": {
+        "d69084fdc55749548357273490160255": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -262,9 +270,10 @@
             "left": null
           }
         },
-        "46b79383523848648f589d31892c40b1": {
+        "f01464a497454f1baa6ea6c5e9a1d676": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HBoxView",
             "_dom_classes": [],
@@ -274,17 +283,18 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_74cc277d7cbf4803a65dc15cae190d8a",
+            "layout": "IPY_MODEL_7a195bcfc23947068c15957fe021b905",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_c966bfac73d646c6a4f702fb87889571",
-              "IPY_MODEL_aed163e07e804b47bc50103f05de48f1"
+              "IPY_MODEL_c260727c40504f9eaccac4a67a448162",
+              "IPY_MODEL_f121c8f65e8341e99ce192edd1d30ca2"
             ]
           }
         },
-        "74cc277d7cbf4803a65dc15cae190d8a": {
+        "7a195bcfc23947068c15957fe021b905": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -333,12 +343,13 @@
             "left": null
           }
         },
-        "c966bfac73d646c6a4f702fb87889571": {
+        "c260727c40504f9eaccac4a67a448162": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_b9d04ca21e1145c19b542efed65e8bb1",
+            "style": "IPY_MODEL_3daf5f04f24b4435b95988973935d0c0",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -353,32 +364,34 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d65e0b5311ff41b18debe3706368e1c8"
+            "layout": "IPY_MODEL_49ef1b5df2ab408cac355c1ac37e3a44"
           }
         },
-        "aed163e07e804b47bc50103f05de48f1": {
+        "f121c8f65e8341e99ce192edd1d30ca2": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_39982abda2694699b92f884fbc5c544b",
+            "style": "IPY_MODEL_e8a79eeb6749492a8af208b5036c868f",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 29696/? [00:02&lt;00:00, 13953.36it/s]",
+            "value": " 29696/? [00:02&lt;00:00, 11436.30it/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_5b75469ad7504b13b8ddb4bbf42ca7d3"
+            "layout": "IPY_MODEL_9abcd6de151d4ada899ad48bbaf66e51"
           }
         },
-        "b9d04ca21e1145c19b542efed65e8bb1": {
+        "3daf5f04f24b4435b95988973935d0c0": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "ProgressStyleModel",
@@ -391,9 +404,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "d65e0b5311ff41b18debe3706368e1c8": {
+        "49ef1b5df2ab408cac355c1ac37e3a44": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -442,9 +456,10 @@
             "left": null
           }
         },
-        "39982abda2694699b92f884fbc5c544b": {
+        "e8a79eeb6749492a8af208b5036c868f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "DescriptionStyleModel",
@@ -456,9 +471,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "5b75469ad7504b13b8ddb4bbf42ca7d3": {
+        "9abcd6de151d4ada899ad48bbaf66e51": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -507,9 +523,10 @@
             "left": null
           }
         },
-        "172971207b294c8e8e919518b875c881": {
+        "1d5a5c37e1e94b50a0afcf9ab456fa8e": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HBoxView",
             "_dom_classes": [],
@@ -519,17 +536,18 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_ad59c28e9b1a4590bf9140f727681d86",
+            "layout": "IPY_MODEL_860e40800ad141f3b8a54894d65ac6d1",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_e6a349c9f1834765b8cf6205f59c5819",
-              "IPY_MODEL_040c46d4cfd84fc1bac4988c20ddd9e1"
+              "IPY_MODEL_4364ac58215740309996bca5541c659c",
+              "IPY_MODEL_f82202947585471b9f52bd37f481cf09"
             ]
           }
         },
-        "ad59c28e9b1a4590bf9140f727681d86": {
+        "860e40800ad141f3b8a54894d65ac6d1": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -578,12 +596,13 @@
             "left": null
           }
         },
-        "e6a349c9f1834765b8cf6205f59c5819": {
+        "4364ac58215740309996bca5541c659c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_4e3daf23260f4bbea2bd86be7abe2739",
+            "style": "IPY_MODEL_aeb8cbecb4ed4c43b78df37f50b0a8a3",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -598,32 +617,34 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_a901db8ef69b4b05b3fda6b7097839a8"
+            "layout": "IPY_MODEL_990bb333932b467885f48c3475120620"
           }
         },
-        "040c46d4cfd84fc1bac4988c20ddd9e1": {
+        "f82202947585471b9f52bd37f481cf09": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_136fdd91aa4f46a2a91e3c719991c89c",
+            "style": "IPY_MODEL_5625bd02cebe4e2fa6426b50b713479e",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1649664/? [00:01&lt;00:00, 1256739.15it/s]",
+            "value": " 1649664/? [00:01&lt;00:00, 1034701.43it/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_72237f8de57a473ba57b5e3dde529886"
+            "layout": "IPY_MODEL_459cd3224d1145dab597d60274d12928"
           }
         },
-        "4e3daf23260f4bbea2bd86be7abe2739": {
+        "aeb8cbecb4ed4c43b78df37f50b0a8a3": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "ProgressStyleModel",
@@ -636,9 +657,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "a901db8ef69b4b05b3fda6b7097839a8": {
+        "990bb333932b467885f48c3475120620": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -687,9 +709,10 @@
             "left": null
           }
         },
-        "136fdd91aa4f46a2a91e3c719991c89c": {
+        "5625bd02cebe4e2fa6426b50b713479e": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "DescriptionStyleModel",
@@ -701,9 +724,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "72237f8de57a473ba57b5e3dde529886": {
+        "459cd3224d1145dab597d60274d12928": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -752,9 +776,10 @@
             "left": null
           }
         },
-        "7b5e3c1eecd245f99d44b6fa50bbe79b": {
+        "b0194572ccf84deea751b10bb5f5748b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HBoxView",
             "_dom_classes": [],
@@ -764,17 +789,18 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_94de2d8ce3fe4b57bda2ec066fcd638a",
+            "layout": "IPY_MODEL_7e1d8d2ae7eb4e58babdf1592dedec60",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_d608fd9dafb34be6b52bc7cf438fe7da",
-              "IPY_MODEL_90fd288b134c4d8097d2b15671e0c75a"
+              "IPY_MODEL_5fa4727aea4349ada2be2b554572d49c",
+              "IPY_MODEL_f9ce3195d63a40b69aeaa614b7abde6f"
             ]
           }
         },
-        "94de2d8ce3fe4b57bda2ec066fcd638a": {
+        "7e1d8d2ae7eb4e58babdf1592dedec60": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -823,12 +849,13 @@
             "left": null
           }
         },
-        "d608fd9dafb34be6b52bc7cf438fe7da": {
+        "5fa4727aea4349ada2be2b554572d49c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_2a6e55aec70d40ce97ae4e272b590e6f",
+            "style": "IPY_MODEL_1a913976d83b4846bb64f2f09c56e72c",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -843,32 +870,34 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_4792f3da7d9c44a48ee88138b9caf182"
+            "layout": "IPY_MODEL_619f013601b14416b53db57d109df6eb"
           }
         },
-        "90fd288b134c4d8097d2b15671e0c75a": {
+        "f9ce3195d63a40b69aeaa614b7abde6f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_940028b22fe64b24a22f698608154f1d",
+            "style": "IPY_MODEL_b557e5fdd5e24148b8b4f583f83ad624",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 5120/? [00:00&lt;00:00, 6714.42it/s]",
+            "value": " 5120/? [00:00&lt;00:00, 18541.63it/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_b59920eeb3cb47ee82e6b6adcf7d2f02"
+            "layout": "IPY_MODEL_45c05c0cb23a41ce87b6fd352d6602c3"
           }
         },
-        "2a6e55aec70d40ce97ae4e272b590e6f": {
+        "1a913976d83b4846bb64f2f09c56e72c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "ProgressStyleModel",
@@ -881,9 +910,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "4792f3da7d9c44a48ee88138b9caf182": {
+        "619f013601b14416b53db57d109df6eb": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -932,9 +962,10 @@
             "left": null
           }
         },
-        "940028b22fe64b24a22f698608154f1d": {
+        "b557e5fdd5e24148b8b4f583f83ad624": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
           "state": {
             "_view_name": "StyleView",
             "_model_name": "DescriptionStyleModel",
@@ -946,9 +977,10 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "b59920eeb3cb47ee82e6b6adcf7d2f02": {
+        "45c05c0cb23a41ce87b6fd352d6602c3": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
           "state": {
             "_view_name": "LayoutView",
             "grid_template_rows": null,
@@ -1026,25 +1058,23 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "W5lIfMXNXOgU",
-        "outputId": "fdd7757e-fdd1-409a-8a6f-bd2e7d926886"
+        "outputId": "652a04ff-09bf-4a4e-b533-a049c13edf3f"
       },
       "source": [
         "!mkdir figures\n",
         "!mkdir scripts\n",
         "%cd /content/scripts\n",
         "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/pyprobml_utils.py\n",
-        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/lvm_plots_utils.py\n",
-        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae_conv_mnist.py\n",
+        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae/standalone/lvm_plots_utils.py\n",
+        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae/standalone/vae_conv_mnist.py\n",
         "!wget -q https://github.com/probml/probml-data/raw/main/checkpoints/vae-mnist-conv-latent-dim-2.ckpt\n",
         "!wget -q https://github.com/probml/probml-data/raw/main/checkpoints/vae-mnist-conv-latent-dim-20.ckpt\n"
       ],
-      "execution_count": 44,
+      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "mkdir: cannot create directory ‘figures’: File exists\n",
-            "mkdir: cannot create directory ‘scripts’: File exists\n",
             "/content/scripts\n"
           ],
           "name": "stdout"
@@ -1103,45 +1133,45 @@
       "cell_type": "code",
       "metadata": {
         "id": "fm7-NgBgbNir",
-        "outputId": "1baf866d-907c-46cb-a043-b56fde67b156",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 840,
+          "height": 811,
           "referenced_widgets": [
-            "ee9a145b26b446fb8b7750dd319d8ab7",
-            "31b52281d3f14370a4ef03c313aa78ab",
-            "75e5c2c4af9240e59d6b08d292f0fbc2",
-            "953251629ae34885bf7b8c9825ecf9d5",
-            "5340956cd6b942d2a6716e6ac706e9ac",
-            "1b332263bb8e47e695da741e7da638b3",
-            "466a6885dfea41a1a039fe7546cedae3",
-            "eb0055a420af42efa0dc8948852094ea",
-            "46b79383523848648f589d31892c40b1",
-            "74cc277d7cbf4803a65dc15cae190d8a",
-            "c966bfac73d646c6a4f702fb87889571",
-            "aed163e07e804b47bc50103f05de48f1",
-            "b9d04ca21e1145c19b542efed65e8bb1",
-            "d65e0b5311ff41b18debe3706368e1c8",
-            "39982abda2694699b92f884fbc5c544b",
-            "5b75469ad7504b13b8ddb4bbf42ca7d3",
-            "172971207b294c8e8e919518b875c881",
-            "ad59c28e9b1a4590bf9140f727681d86",
-            "e6a349c9f1834765b8cf6205f59c5819",
-            "040c46d4cfd84fc1bac4988c20ddd9e1",
-            "4e3daf23260f4bbea2bd86be7abe2739",
-            "a901db8ef69b4b05b3fda6b7097839a8",
-            "136fdd91aa4f46a2a91e3c719991c89c",
-            "72237f8de57a473ba57b5e3dde529886",
-            "7b5e3c1eecd245f99d44b6fa50bbe79b",
-            "94de2d8ce3fe4b57bda2ec066fcd638a",
-            "d608fd9dafb34be6b52bc7cf438fe7da",
-            "90fd288b134c4d8097d2b15671e0c75a",
-            "2a6e55aec70d40ce97ae4e272b590e6f",
-            "4792f3da7d9c44a48ee88138b9caf182",
-            "940028b22fe64b24a22f698608154f1d",
-            "b59920eeb3cb47ee82e6b6adcf7d2f02"
+            "e5f144d0d57c4424bc878cbc82ff9529",
+            "9dec8b77a2834f0abfa8cd73e25eb6e1",
+            "5a34ea4ea1314be78fb096182c008b07",
+            "724c93aa28c14ee786f4884f5efc08f4",
+            "461284948a1e474d8b20dcd227a51a16",
+            "fddb54483fbf426f81870d9f437b2e15",
+            "c04cdf7c637244b69a7cfc5732c63d02",
+            "d69084fdc55749548357273490160255",
+            "f01464a497454f1baa6ea6c5e9a1d676",
+            "7a195bcfc23947068c15957fe021b905",
+            "c260727c40504f9eaccac4a67a448162",
+            "f121c8f65e8341e99ce192edd1d30ca2",
+            "3daf5f04f24b4435b95988973935d0c0",
+            "49ef1b5df2ab408cac355c1ac37e3a44",
+            "e8a79eeb6749492a8af208b5036c868f",
+            "9abcd6de151d4ada899ad48bbaf66e51",
+            "1d5a5c37e1e94b50a0afcf9ab456fa8e",
+            "860e40800ad141f3b8a54894d65ac6d1",
+            "4364ac58215740309996bca5541c659c",
+            "f82202947585471b9f52bd37f481cf09",
+            "aeb8cbecb4ed4c43b78df37f50b0a8a3",
+            "990bb333932b467885f48c3475120620",
+            "5625bd02cebe4e2fa6426b50b713479e",
+            "459cd3224d1145dab597d60274d12928",
+            "b0194572ccf84deea751b10bb5f5748b",
+            "7e1d8d2ae7eb4e58babdf1592dedec60",
+            "5fa4727aea4349ada2be2b554572d49c",
+            "f9ce3195d63a40b69aeaa614b7abde6f",
+            "1a913976d83b4846bb64f2f09c56e72c",
+            "619f013601b14416b53db57d109df6eb",
+            "b557e5fdd5e24148b8b4f583f83ad624",
+            "45c05c0cb23a41ce87b6fd352d6602c3"
           ]
-        }
+        },
+        "outputId": "a857a3e0-f2fb-4534-d916-38e3b38e2566"
       },
       "source": [
         "mnist_full = MNIST(\".\", train=True, download=True,\n",
@@ -1169,7 +1199,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ee9a145b26b446fb8b7750dd319d8ab7",
+              "model_id": "e5f144d0d57c4424bc878cbc82ff9529",
               "version_minor": 0,
               "version_major": 2
             },
@@ -1200,7 +1230,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "46b79383523848648f589d31892c40b1",
+              "model_id": "f01464a497454f1baa6ea6c5e9a1d676",
               "version_minor": 0,
               "version_major": 2
             },
@@ -1231,7 +1261,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "172971207b294c8e8e919518b875c881",
+              "model_id": "1d5a5c37e1e94b50a0afcf9ab456fa8e",
               "version_minor": 0,
               "version_major": 2
             },
@@ -1262,7 +1292,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "7b5e3c1eecd245f99d44b6fa50bbe79b",
+              "model_id": "b0194572ccf84deea751b10bb5f5748b",
               "version_minor": 0,
               "version_major": 2
             },
@@ -1311,7 +1341,7 @@
         "m = ConvVAE((1, 28, 28), encoder_conv_filters=[28,64,64], decoder_conv_t_filters=[64,28,1], latent_dim=20, kl_coeff=5)\n",
         "m2 = ConvVAE((1, 28, 28), encoder_conv_filters=[28,64,64], decoder_conv_t_filters=[64,28,1], latent_dim=2, kl_coeff=5)"
       ],
-      "execution_count": 12,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -1321,14 +1351,13 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "81f6667c-f8fc-4d2b-e32a-80f78bd42b21"
+        "outputId": "17ae11cc-c4d8-4d57-9f4c-22d887bf3e9c"
       },
       "source": [
-        "\n",
         "m.load_state_dict(torch.load(\"vae-mnist-conv-latent-dim-20.ckpt\"))\n",
         "m2.load_state_dict(torch.load(\"vae-mnist-conv-latent-dim-2.ckpt\"))"
       ],
-      "execution_count": 13,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1340,7 +1369,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 13
+          "execution_count": 7
         }
       ]
     },
@@ -1351,7 +1380,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "A9nSoqrh8Lcu",
-        "outputId": "d6256a07-35b4-4c1d-c6e6-76ccdc25e2d5"
+        "outputId": "a343d68b-8ca1-4c25-af79-6c4542571b45"
       },
       "source": [
         "m.eval()\n",
@@ -1359,7 +1388,7 @@
         "m2.eval()\n",
         "m2.to(device)"
       ],
-      "execution_count": 14,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1396,7 +1425,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 14
+          "execution_count": 8
         }
       ]
     },
@@ -1423,10 +1452,10 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 254
+          "height": 255
         },
         "id": "L5kTXWrK7B_m",
-        "outputId": "1442ff8f-ee64-4242-a0db-156f4212fb6a"
+        "outputId": "3a3afca2-76c8-4a9e-fdc9-6b7e7294368c"
       },
       "source": [
         "imgs, _ = batch\n",
@@ -1439,12 +1468,12 @@
         "plt.savefig('../figures/vae_mnist_conv_20d_rec.pdf')\n",
         "plt.show()"
       ],
-      "execution_count": 82,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAADuCAYAAAAgAly4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9aXBc55Wm+dzc9x1AIrHvGwECIAgCBFdRVGmz7Laq1bbL3VVlR7ijOip6pmcmxl0T0R0T0TMRPdEdM1P1p6bdU6Wuii63SyqPLcmStVAbF4kUAQIgQADEvgMJ5ALkitznB3WvQYmSKBKZAO18IhQkIQD55c17z3e+c95zjpDJZMiTJ0+ePI8esv1eQJ48efLkeTDyBjxPnjx5HlHyBjxPnjx5HlHyBjxPnjx5HlHyBjxPnjx5HlHyBjxPnjx5HlEeyoALgvCkIAi3BUGYFgThX+/VovLkyZMnz1cjPKgOXBAEOTAJnAeWgevAdzOZzNjeLS9Pnjx58nwRD+OBdwPTmUxmNpPJxIGfAd/cm2XlyZMnT56vQvEQP1sCLO369zJw7LPfJAjCj4AfffrPIw/xenny5Mnzu4onk8kUfPaLD2PA74tMJvMT4CcAgiDk6/bz5MmT5+uzcK8vPkwIZQUo2/Xv0k+/lidPnjx5csDDGPDrQJ0gCFWCIKiA7wCv7s2y8uTJkyfPV/HAIZRMJpMUBOFPgbcAOfDXmUzm1p6tLE+ePHnyfCkPLCN8oBfLx8Dz5MmT50EYyGQyXZ/9YtaTmHl+gyAI6PV6ioqKKCwsRKFQEI/H2dzcxO12E4lEyPdnz5MHZDIZBoOB6upqCgsLSSaT+Hw+FhYW2N7eJp1O7/cSDwSPvAGXyX4TxlcqlSiVSuRyOXK5nFQqRSwWQ6FQoNVq0Wg0AOzs7BCNRtnZ2SGZTOZsnVqtlurqatrb22loaECr1RIMBpmammJoaIiJiYmcredBkcvlqNVqLBYLW1tbxGIxUqnUfi8LmUyGSqVCr9ej0+kACIfDhMNh4vF4fmP8CgRBQBAE5HI5CoUCuVxOOp0mGo3uy7VTqVQ4nU7OnTtHc3Mz8Xic27dv88477xCJRIjFYjlf02cRBAGZTCb9p1KpMJvNCIJwz+/PZDIkk0l2dnbY3t7ek+v6SBlw8SbbfeFUKpX0/y0WCxaLBb1ej0ajIRKJsLm5iV6vp7KyEqfTSSaTYXl5mYWFBdbW1tje3s7JujUaDcXFxZw6dYqzZ89y6NAhdDodgUCA0dFRdDods7Oze2rAxRtprx5AcRMqKiri6NGj9Pf3SyeH/TbiGo0Gh8NBfX09VVVVpNNppqenuX37Nh6P58BvjPuF+CwplUoUCgU6nQ6j0YjBYCAajbK0tMTOzk5Ojbh4n1VUVPCNb3yDrq4u4vE4H330EZOTkywtLe27AZfJZGg0GtRqNSqVCrVajcPhoL29Hblcfk8jnkwmCQQCrKysMDw8vCeb44E34DKZDLlcLhlrrVYrXTStVovdbpe+t7q6mpqaGpxOJ0ajkfX1dYaGhnC5XDz99NN0dnYSi8V48803+fWvf83ly5ezbsAFQUCr1VJeXk5fXx///J//c2pra5HL5WQyGQoKCigrK6O0tJTXX3+deDxOKpV6qA9WfCBVKhWZTIZwOLwnD6BSqcThcHD8+HF+/OMf8+/+3b/j2rVr0pr3C9Fb6+7u5vvf/z5PPPEE8Xicn/3sZ7z44osEg8G8Ab8H4mnKarVis9kwGo04nU5KS0txuVysra3x5ptvsrS0RCQSyem6dDodTqeT2tpalEolGo0Gp9NJYWEhGo2GYDC4LycDQRBQKpUYDAZKSkooLCzEZDJhtVppbW3lRz/6EWq1+p4/u7Ozw8LCAleuXOEv/uIvmJmZIRaLPVQ46EAbcJlMhs1mw2q1otfrKSsro7m5mbKyMgoKCnA6nRw58pviTtGbAAgGg8zNzVFXV4fD4aCmpoatrS1mZma4ceMG09PTbG1tZXX9giBgMBhoamrimWee4Tvf+Q5lZWVS7HtnZ4dEIgGA3W6ns7OT4eFhPB4POzs7D/zBGo1GioqKqKioIJ1Oc+nSJeLx+EO/H6VSicViobq6mrm5OSKRyIGIRZaWlnL8+HG+8Y1vcPr0aQRBIJPJ7NsDvjsMIZPJJG8smUzetZEIgkAymczp5ieuTwyDVVdX8/zzz3P48GHKysqwWCyo1WoEQWBpaYmCggJeeuklRkZGcnY9U6kU4XCYlZUVJiYmMJvNaLXanLz2VyE6YydOnOD8+fPU19djNptRq9XYbDaUSuUX/qxaraa6uhqz2YxKpeI//sf/yNzcHNFo9IGfowNrwGUyGS6Xi2eeeYZTp05RUlKCXq/HaDRKRxe1Wv25DzaTyZBIJJiamuLtt98mEAggl8tRqVRsbW2xubnJxMQEa2trBAKBrK1foVBgMploa2vj+eefp6+vj+LiYpRKJYIgEAqFmJmZYXl5mUwmw1NPPcWf/dmf8fbbb/Phhx8yMDDwwOvT6XSUlpbS0dFBMpnk6tWre2LARc+oqKgIu92OSqX6wnhfLtFqtZjNZiwWy10htVyjUCgwGo3U1tZy7NgxqqurKSoqwmKxIJPJuHbtGsPDwyQSCTQaDUqlkv7+fubm5nJ2QtDr9dTV1dHZ2Ul7ezttbW2UlZVhNptJp9PE43Gi0SgajYaioiK6uroYHBxkeXkZv9+fEyOeTqdJJBIEg0G8Xu++h+d243A4OHv2LN/+9rdpamrCaDSiUCikU++XIQgCCoUCm83G2bNnee211/B6vSQSiQd+Pg+sAYc7xthut1NfX09tbS0ajeauODjc+bDFi6DRaNBqtaTTaebn57l06RKhUIhMJkM6nSYcDhOJRPD7/Xd5v3uNRqPB5XLR09NDT08PfX19VFZWSuuHO95sJpMhGAyytbVFKBSisbGRtbU15ubmGB0dfeDXNxqNlJaW0tTUxNLS0p4YWZlMJh1rm5qapETMzs7Ovj5gFouFqqoqamtrKS4uJplM4na7GRgY4JNPPmFzczMnxlHMDTQ0NHDmzBk6OjpwuVxoNBopDCgmsVOpFAqFgmQyiUwmY2Vl5aHDZl+GIAjodDpKSkpoa2vj8OHDHDp0iNraWsrLy1Gr1USjUW7evMni4iLxeJy6ujq6u7spKirC4XCg1+vZ2trKiQEXT9JimHS3UGG/EUMoFosFm82GTCYjHo+ztbXF2tqadPoDpJyC3W7HZDLd9ew7HA6MRqPk0D0oB9aAZzIZQqEQPp8Pr9eL0+kkkUjc9aGmUikikQhDQ0MEAgGsVisFBQVotVoWFxe5desW4XBY+n2pVIp0Ok0ymcza0V8mk2EymWhpaeH555+ns7MTm82GQqEgGo0Si8XQ6/XS6UEQBLxeLzMzMxw+fBibzYbFYkGhePCPRpQqlpeXs7KysicGXKvVUlxcTH19PQ0NDVy8eBGv17uvCUy1Wk1tbS0dHR20trbidDoJh8MMDw/z05/+lJGRETY2NrK2UYsoFAoKCwtpbW3lzJkz/N7v/R4mk4lEIsHm5iZerxeZTEZRURF9fX2o1WrS6TR+v5+1tTV+9atfZTVRqFarKSwspKenh+eee46mpibsdrt0H6ZSKebm5nj33XcZGRkhnU7z5JNPcvz4cUnVI4ZVcoFovE0mEw6HA7lcLn1drVajVCql5z/XRKNRFhcXmZmZwWAwABAKhVhbW2NoaOguA65WqykoKODw4cM0NTVJHno6nWZnZ0dScD3M536gDXg4HObmzZsYjUY2NzeBO/HOlpYWzGYzkUiE2dlZ/vIv/xKv14vJZKK8vJy6ujqmp6clDzGX6HQ6XC4Xhw8fljyYTCaDz+djcXGR6elpjh49itVqJRgMsr6+ztjYGGazmZaWFlQqFSqV6qG8DoVCgUajkeR0e0FhYSHd3d2cOHECnU7H6uoqoVCIRCKxb7Hm0tJSnn76ac6cOUN9fT1arZa5uTnee+89+vv7WV9flzbtbCGXy7Hb7XR0dPDYY4/x+OOPU1hYyMzMDFeuXGF0dFTaRJ9++mnOnz9PQUEBMpmMSCRCMBgknU5n9RpaLBYaGxs5e/YsJ06cwGQySQ5CMplkc3OTn/70p3zwwQe43W5sNpsUvtstIsgVuxOFopcLSEquoqIitre39yUHs729TX9/P+FwGKfTCSCdRhcWFu4y4EqlErvdzje+8Q1KSkqkUFokEmFsbIz5+fmHTrAfWAMOd26usbExvF4v169fJ5VK0d7eLh3xdnZ2eP311/nwww8JBoMolUrMZjNFRUVZDZF8ESaTiY6ODk6dOsVTTz2Fw+EgkUiwtLTEtWvX+OCDD0gmk2xvbxOPxxkfH2d0dJSFhQWSySQ/+MEPKCkpobq6GpfLhdfr/dobkF6vx2q1YrVaJd37Xr23iooKqqqqiMfjjIyMEAwG9837lsvl9PT0cOrUKZqamjAYDPj9fgYHB3n77bdz4nkLgkB1dTVPPPEEp0+fpqWlBavVys2bN3nxxRcZHh5mdXWVRCJBWVmZJD2DO17b0tISFy9eJBaLZdWAFxUVSfFuu90u3YN+v5/l5WXefPNNfvnLX7K2toZaraakpASDwbBv+Q3RQ93c3GR2dhaXy4VSqaSwsJDHH38cv99PMBiUJI65JBaLsbq6isfjucujTiaTn5M2arVaEokEsVjsLklvNBplenoat9v9UGIFOOAGHCAQCBCNRlldXSWdTqNSqWhpacFut6PRaIjH41JIJBaL4fF4pGRLLo2LXq+nqamJvr4+Tp06RUNDA/F4HI/HQ39/PxcuXOCDDz7AbDazubmJ3+/H7Xbj8XiIx+Osra1JssKmpiaOHDnC6uoqKytfr8Gjw+GgtLSU4uLiPTPgYvLSZDKh0+lIJpPMzs7umwpFjMefOHGCqqoq9Ho9oVCIqakprly5wsLCwp4kbb8MMZ799NNP8+STT1JaWko8Hufjjz/m7bff5q233iIQCJBIJLDZbBw5coT29nbsdjuxWEzy0MfGxrIeo49Go2xsbDA1NUU4HGZzc5ONjQ3cbjcLCwtcvHiRlZUV4vE4er0ek8mE0WjM6pq+jHQ6LZ2uL1y4QGdnp6RPb2hooKamBpPJJIVW9mN9sVjsS7XoRqORkpISOjo6aGpquivsGwwGuXbtGoFA4KFt1IE34OLFEo/qHo+H1dVV/H4/lZWVNDU1YTabicfjJBIJUqlUzr1CQRCoqqqiu7ubw4cP43K5iEQiLC8vs7i4yMDAAFNTU3g8Hra3t9nc3CQWi0lxMJlMJj3ESqWSoqIimpqauHz5Mqurq1/LO7PZbDidTmw2G8CeVCGazWZKSkooKChAo9EQjUbx+/0kk8mch0+USqWk9GhtbcVms5FIJFhdXWV0dJTh4eGsVl6KCcHy8nIee+wxnnjiCaqrq9ne3mZ8fJyLFy/ywQcf4PP5SKVS0jG6tbWVsrIy0uk0y8vLDA0N8fHHH0shlGzi8XgYGhoC7nyWy8vLeL1e/H4/Pp+P9fV16RSgUqkwGAxSfHe/SCQSeDweRkZGpM1YlD+KIcb9VEDd6/4SBEHShJeVlUlqn5qaGslbj8fjeL1eBgYGCIVCD/3ZH3gDLiK+Ua/Xy/T0NOXl5RQXF9PS0kJVVRXJZJJQKCQVleTKMxQEAZVKRUdHB8eOHZOKdKanp7ly5Qrz8/NMT0+zurpKLBYjGo1+qTxQJpNJu7der//a6xFvIIPBQCKReOC+Ebv1zOXl5TQ3N1NcXIxMJsPr9RIKhbKqnLgX4kmgvLycs2fPUlFRgVqtZmVlhenpaYaHh5mdnc16zLu4uJgjR45w9uxZmpubicViTE9Pc+3aNa5cucLMzAyZTAadTofNZqOqqoq6ujrMZjNer5exsTEGBgYYGRnJiUImEAgwPT1NKBRCrVazubkptRgQr5UovzQajdhsNsxms3SKzeXzJCKGGjY2NkilUnfFlvdburr72di9kSgUCurr62lubqauro6amhpJHQV3TkI+n09y7PbC0XhkDLjI2toa/f396PV6nE4nvb29nDx5EqVSidvtZnt7m+3tbUKhUE7WI5fLMZlMnDt3jt7eXpRKJQsLC7z33nu8/PLLuN1uBEH4Wh+WUqlEr9d/pa70XojJS6VSSSQSYW1t7Ws9fLslXHq9HovFQk9PDydOnKCsrIxIJMLExMS+GHCFQkFBQQHt7e1897vfxWazSeGIgYEBBgYGpGR3tlCpVDQ3N/PUU09x4sQJBEFgcHCQS5cucenSJcbHx0mlUuh0Oqqqqqivr6ejo4PKykpSqRTj4+NcvnyZa9eusbq6mtW1iogx791Vx6LEzWw232WESktLKSsrk2LlYj+ZbMfpv4z9Nti7EfXeZrNZyjOJpfMqlYrz589z7tw5KisrsdlsUlVmMBhkbW2N2dlZbt68uWeqo0fOgKdSKclAJpNJOjs7+ZM/+RPOnDnD7Ows4+PjfPTRRwwPD2f9iC+Wybe0tHD06FEKCwv55JNPePXVV/nFL37B4uJi1l77q0ilUoRCIRYWFj4XUhKz+rsb8ezWqGo0GgoLC2loaKCvr48zZ85QU1NDPB5naGiIl156SQqh5ApBEDAajdTX19Pd3U11dTUKhYKxsTEuXrzIhx9+yPj4eFbXIJ6O2traOHnyJHq9nv7+fv7rf/2vXLlyhfX1dZRKJSaTibq6Ov7Fv/gX9PT0UFJSgkKhYHh4mLfeeov33nuPmZmZrK71ixCLSURlSl9fn6RVz2QyOBwOqqursdvt+P1+RkZGGB0dlQrOco1Yw7H7tfdzIxHltMePH+fUqVOUl5ej0+mk63r48OG7eqFkMhlisRi3bt3iF7/4BVevXmVqaopAIPC7acABKel35coV/sN/+A/8q3/1rzh69ChdXV2sr6/T0tLCSy+9xNDQENvb21kzNHK5nKKiIv7kT/4Ep9PJ+vo6t27dYnR09IG8q88WKT0Mu6VYu3+fQqGQesUUFBRQUlJCUVERJpMJjUbDqVOnMBqNUjc6sd2AmGX3+/1MT0/nPM9gt9s5efIk3/72t3nsscdQKpXcvn2bF198kUuXLjE/P5/1xKV4TfV6vRQj/uUvf8nNmzelRKVY4VhbW0tRURE6nU4q2hkbG2NkZCRnxUWfXbtCocBut9Pe3s7p06fp6emhpaXlrntOlA0mk0kuX77MX//1XzM+Pp7v5ghYrVY6Ojp44YUXOHv2LHa7XdKki3y2fiOdTrOxscHVq1e5cOECU1NTe5qj+UoDLghCGfC3QBGQAX6SyWT+XBAEG/D3QCUwD7yQyWT8e7Kqr0Dc1dbW1njnnXfQaDScPn2a2tpa7HY7J06ckI6xQ0NDbGxs7Hn3MlHW1NLSQktLCxqNhpWVFRYWFh64+53YvyMajeLxeIhGo1/7d6TTaSl5VlRUxD/7Z/+MY8eOSetRKBSUlJRI/SXEzo2ZTIatrS38fj/z8/N4PB7cbjerq6scOXIEi8WCIAiEw2FJMZMLBEFArVbT2trKt7/9bY4dO4bVakUQBDY3N1laWsLj8eSs2VIqlSIejxOLxdBoNDz77LO0tbWhUqmwWq1S5aLYzliUMkajUWZmZpifn5eKy3KBmHQtLi6mu7ub3t5eSktLKSkpweFwkEwmWVtbkzxJhUIh3YfiSUyv1+d7cHPHYdNoNFLzL4PB8Dl9/Gc7gMpkMqlauKSkhLW1NTwez56t6X488CTwP2YymRuCIBiBAUEQ3gH+CHg3k8n8e0EQ/jXwr4Ef79nKvgKxCnN+fp4333yTWCyG2+2mrq6O4uJienp6iEajyOVyhoaGmJ+f39PXF3uduFwu7HY7mUyGhYUFlpaW8Pvvfx8T+2dUVFQgk8kIhUIsLi4yNjb2QKXLm5ubzMzMSEqWuro6LBaL9PCJXpgo1RKLEAKBAJubm/h8PjweDxsbG2xubpJIJKitrZXCUeFwOKed4GQyGQ6Hg8OHD0sKH6VSSTKZZGpqKqftbEXHYX5+ntHRUdrb22ltbaW6upqdnR12dnakIo1IJEJVVRXFxcVotVo2NjZYWlpia2sr6ycFEUEQMJvNVFVV0dHRwblz56irqyMSiUjJNLGY7Omnn5ZCPTKZDIVCQVFREZ2dnWxsbBCJRNje3t4X3f/uE6QYShPDPrlEVJDcvn0bp9OJwWCQZgrsTrBmMhkpf2S329HpdBQUFEh/30u+0oBnMpk1YO3TvwcFQRgHSoBvAmc+/ba/AT4ghwYcfhPnvX37NvF4nLm5OY4cOcLjjz9OY2MjmUwGpVJJLBZjeXl5z3tti4k+UY8+Pz8vPaT3g2i8q6ur6e3tBZAkZlevXn2ghNzCwgLXrl1jZ2eHQCAgFROJN5hY3r2+vs7y8rJkqDc2NohGo4RCIaLRKNFolGQySVVVFQ6HA4VCISXCcvkQq1QqysvLaW9vp7CwUCpDj0QiUrVlroo5xH46w8PD2Gw2SRGTSCTwer0sLS0xPT3NxMQEqVSKf/yP/zFmsxm487mIa81VPxGj0UhNTQ3Hjx/nzJkztLe3s7GxweDgILOzs1JBik6nk1o+iL05kskkTqeTkydPsrW1RSKRYHp6mkAgID1H94pPZ+N9iH9mMhnkcrkkkxWbqeXKmRAdxgsXLhAIBNBoNHi93nt2E3S5XDQ1NXH06FHq6uqkBnx7rV3/WjFwQRAqgQ7gGlD0qXEHWOdOiOVeP/Mj4EcPvsSvJhKJMDk5idvtJhgMUl1dzZEjR6ivryedTrO+vs7IyIhUDLQXfHawRDgclgpz7ueILJPJsFqt1NXVcebMGZ588kkikQjXr1/n0qVL3Lp1i2Aw+LXX5ff7GR0dleLxFovlnt/n9Xrxer0EAgFCodA9VTt6vZ7y8nJqampIp9Osrq6ytLT0tdf0oKhUKmw2G83NzbS2tkqNysLhsDTFSCyEyhXiZJhgMMjy8jJ2u12Sa3q9XtbX1/F4PFRWVkobfDKZZGVlBZ/Pl5MwhBh26u3t5dy5c3R3d1NTU0MqleL69ev88pe/ZHFxkXA4jEaj4YUXXsDhcNzVsTMYDOJyuWhoaEAul1NTU8PQ0BDXrl3D5/NJOZFIJJJVxZdonHc3iBKb242PjxMMBnM23CGRSLCxsSF99gqFgmAweJccU6SgoIAjR45gtVqpra3N2pru24ALgmAAfg7895lMJrD7WJPJZDJfNLA4k8n8BPjJp79jz7dKQRCwWCy4XC5Jcyt6PWIbWYVCkVUpkjjlRzTeX+WhGo1GysvLaW1t5ciRIxw9epRYLMbf/M3fcOXKFcbHxx+q81soFCIcDku9Gb5ozbv/vBcymQyz2YzZbCYQCHD79u2sKz1243A46O3t5amnnqK8vBy5XI7f72dycpKXXnqJ+fn5nE+LEcNI09PTzMzM3HPqkV6vx26343Q6MZvNuN1uZmdnJU1zNhFDe52dnfzgBz+gs7MTQRCYnZ3lxo0bvP7664yNjaFWq6mvr6enp4c//uM/xm63SxK30dFRNjc3qauro729neLiYo4dO0ZbWxsdHR34/X6pqdPIyAiffPJJ1t7Pzs4OU1NTUkhCEAScTift7e3SRrq2tvbVv2iPEB2I2dlZ4IufH0EQ8Pl8D5TH+jrclwEXBEHJHeP9d5lM5v/79MtuQRCKM5nMmiAIxcBGthb5WXbrlAsKCmhubqalpYWysjLKy8tpaGhAEAR2dnbweDysra3hdrv33PvZnb0XPYEvew25XI7D4aCtrY2jR4/S3NyMy+UiHo/z+uuv8/LLL+P1eqXK04fhfgz0/SC+R7Gowu12P9Tv+zo4HA66urro7e2V4o3z8/NcvnyZN954Y18Ta180MEIQBCm0J8ZGxRBetj1wpVKJzWajoaGBf/JP/gm9vb2Ew2Fu3brF9evXGRwclAyzOJu1p6cHgMHBQS5evMiNGzeYmpoiGAwyNDTE0NAQ9fX1UhfK7u5uZDIZbrcbtVqdVamsuFkODQ1JyimxDXNxcTElJSVMTU1l3YCL8lGxr8lX1T+IEs329nZKS0uzurb7UaEIwF8B45lM5v/c9b9eBf4Q+Pef/vlKVlZ491pQKBQYDAbsdrsUG+3q6pKE80ajEb1eTzgcZmNjg5WVlawfswVBoLCwELvdjtFolDTSouxMPAXo9Xra29t5/PHHaW5ulrL7g4ODvPXWW3sep99LxKq8XK1PrVZLjclsNhtyuZydnR1mZ2cZGhpifX09583K7gdxoIh4z4mGfi825a9Cr9dTUVHB8ePHOXnyJBaLhYmJCcbHx6Uk/uHDh2lsbKSuro7S0lIMBgOffPIJV69eZXh4mMXFRam/fjgcZmtri/n5eclQtra2otPpmJycZHx8nOXl5ay+p1gsxtzcnBS2EU/TBoMBk8kktWTOxilMPMGbTCZqamrY3NzE7XZ/YQm86Fg2NTVx4sQJjh8/Tnl5OfDFG/7Dcj8eeB/wT4ERQRCGPv3a/8Idw/2SIAg/BBaAF/Z8dbsQk4Y2m42ysjKpF0Zvby/Nzc2Sdnn3OKaRkREGBgayHrcVBAGXy0V9fT3Ly8vE43GCwSAymQy73U5hYSFmsxmHw0FPTw+9vb3o9XrW19eZnZ3lo48+4ubNm1ld48Mi3sxfNO9vrykoKKC8vJzCwkJJ2razs8Pi4iKTk5P7PtT2q9iPk4HJZKK2tpYTJ05QU1MjxajhTjvgmpoaDh06RFNTEw6Hg3g8zsTEBL/+9a+l4Re7E3KRSIRIJCIlvNfX11lcXESn0zE1NSVNlMomYghlfX2daDSKSqVCLpdLvf/F8WR7fT/snj7V3NzMkSNHGBoakkYhftaRETtNFhUVSUU+ra2tOBwOyfHJRkuC+1GhXAa+KIB8bk9Xcw/ERKFCocDhcNDR0cGJEyc4evQohw4dwuFwAHcKTUTlxeLiIu+++y6vvfYaExMTWRudJu6qmUwGg8HAqVOnUKlUFBUVMTs7i0qlor29XcpEFxcXS/0wbt++zdDQkNQT46CjUqkwGo2YTKasv5ZcLpfa8jY2NkqqiFAoxOrqKsvLywdWkyxW6zU3N99TJ5xNRAPe3d0N3DEqosctKp5ExZTP5+PmzZu8+uqrvPbaa18aqxWnXnm9XoAN6GgAACAASURBVK5evZqrtwPcyed8/PHHHD9+nLa2NgwGA3K5XHLgxsbGGB0d3XMDrlarcTqdnD59mu9///scPnyYn/70p1Jce7fySRw04XA4OHHiBM8//zy1tbWYTCYpDOTz+aT++XvJga/E1Gq1WCwWysvLef7553nqqadwuVzodLq7JDmifO7y5ct8/PHHTE9P53Raukwmo6Ojg4aGBr797W8TCARQKBQUFxdLXkMikZD6drz++usMDQ0d6LDJbjKZzJ5ViX4VZWVltLa20tzcLHkwCwsLvPPOOwwPD+9ZGXI2EMNm4ji1XJJMJqVmaVarVVoH/GYien9/P4ODg4yOjjI3NyfJRw8y6XRakr6Kz9Nu5ykbWK1Wurq6+NM//VMaGhpQKBS0t7dLBWS7n1mlUonVaqW9vZ2Wlha0Wi1yuZxoNMrS0hIffvghr776KgMDA3i93j1d54E04KLE7pvf/CYNDQ24XC5cLheVlZWSFlicJzk3N8c777zDjRs3mJ+fZ21tTdols/mQx+NxaUDy1NQUDQ0NqNVqDAYDWq0Wm80mxeyj0SgrKysMDQ3x8ssvMzc3h9vtJhAI5FQC9zCIY9rEKSTZRKfTYbFYMJlM0rzGkZERXnnlFW7evHkgY98iYrx7amoqZ9WhIisrK7z++ussLy/T1dVFWVkZ8XiclZUVZmZmJIPt9/ulPvuPwv2XTCYZGRmRZp/mole52FJAbFYFSLbos6XwYoMrk8mEwWCQ5hfcunWL999/n4sXL7K6upoVx+PAGHC1Wo3FYqGoqIiamhoqKio4c+YMpaWl0sOs1+tRKBTSDLqJiQkuX77MwMAACwsLbG9vE41GczLmK5VKEQgEmJqa4uc//zmnTp2iubkZu90uCfYDgQCTk5NMTU0xNTXF+Pg4AwMD+P1+EonEI+F5i4g3cy68SrlcjlKplBJW4rVeX1/PaRXogyAacLGlgmjExfmT2Sw6ikajLC8vS3FrsVRe1Kf7fD5pUpU4BOUgX0sRsZZjdnYWj8cjadazSSQSkbznZDJJRUUFer0erVZ7l+cvtlaIx+PSz0xMTEgFXTdv3mR2dlZSr+w1B8aA6/V6ysrKaG9vp6+vj4qKCmpra6UsczKZZGtri3A4zPLyMpOTkwwODnLlyhVpPmM2hxV/lnQ6Le20Fy5cYGdnh62tLSm8Iw6fuH79OqOjo9LpIBejvvYKMXEoaq3FoqVsk0gkPjf0VSwceRQ2vWQyicfjYW5ujqqqKinJXVBQIL2vbBhOMU8Qi8UIBoNS4dPOzo40UPug5g6+DHEA9OzsLAMDA1IB0szMjKRO2WvE8Mf7778vjUwrLi6WpIyxWIxQKEQgEMDn80na+IWFBYaHh5mbm2NlZYWNjY2s9r45MAbcYDBQVlZGW1sb3d3dUq9dcfrL6uqqVAE1NjYmNQaam5vbt7mMyWSSQCDA6OgooVCIyclJLBbLXSGe2dlZVlZW9mXA8sOSSqUkHb1Op7tn9j0biP051tbWsNvtCIKwr/2ovy6ZTIZQKMTQ0JCkmDp06BDNzc2EQiG8Xm/WQhf3M+7rUUO8nhMTE/zDP/wDhYWFKJVKVlZWmJ2dzcpztbOzw/r6OpcvX8bn8xEMBjly5AhVVVUYDAY8Hg+zs7PMz8+zuLjIysoKwWAQj8fD8vIyfr8/Jz16DowBj8VibG5ufm5GoJjBXVtbIxAIsLKywuLi4p7Mk9sLxO6B4+PjOa1SzAWJRILJyUleeeUVSktLcbvdTE9PZ/11fT4fV69eJRAIcP36dZRKJcPDww/UWmC/SCQSfPTRRxQUFGCz2WhtbeX3fu/3CIfD3Lx5E4/H80h6w/tFLBZjcXExZz32xX47kUhE0n/fvHmTysrKuwz40tIS6+vrbG5u7ouDJuTSq/myUnpRLiiXyz93TN/dNEf881Hxxh51xESsTCYjnU5L7WqzjVwulxrji3Hw/ZjB+TBotVqOHj3K+fPnOXXqFFqtll/96lf86le/Ymxs7JE7kf0us9s2iYVD4vOQo1zCQCaT6frsFw+MB757/l6eg4NYWZhrfhvuhZ2dHUZHR4lGo2xvb3Py5EnUajVarRalUpk34I8QoqE+aBwYA54nz28b4pCM27dvk0gkJInr2traI5PIznOwOTAhlDx58uTJ84XcM4SS25EWefLkyZNnz8gb8Dx58uR5RMkb8Dx58uR5RMkb8Dx58uR5RMmrUPLkyQPc0d4bDAbMZjN6vV7qOfQotC/4XeXrzMSUA/3ASiaTeVYQhCrgZ4AdGAD+aSaTOfitzfLkyfM5FAoFFouFlpYWurq6aGpqYmhoiL/927/NWj/9PA/P1/HA/ztgHBA7+v8fwP+VyWR+JgjC/wP8EPjLPV5fnjx5ckBfXx8dHR10dnbS1NSEyWTC4/GgUOQP6QeZ+x1qXAo8A/zvwP/w6ZzMx4DvffotfwP8r+QN+J7gdDqpr69Hr9czMTHByspKVpofKZVKDAYDFouFwsJCysrK2NrakgY0iz3PvV7vgaxCy/PgiC0STCYT3d3d/P7v/z5tbW0UFBSQTqcZHR3l6tWrv1VNsX4bud/t9f8G/mdA7KRuB7YymYwYHFsGSu71g4Ig/Aj40cMs8gt+LwqFQppbt7a2lpPuX9lEEARsNhsdHR2cP38erVYrNfnaawOu1+spKSmhoqJCapTf2trK2toaHo+HcDhMKBSiv7+f/v5+IpHII9WHZK9QKBRS+Tvc6VuvUCik4dripPJ79cMQx/yJI7gOyr0pzm90OBw0NjbyB3/wB3R3d6NUKgmHwywtLfHRRx8xODi4bwZcJpOh1WpxuVxotVo2Njbw+XyPxACKXHI/U+mfBTYymcyAIAhnvu4LZDKZnwA/+fR37ZkFUCqVGI1GampqOHbsmDTVPddTUPYKcdJ2S0sLPT09dHV1EQgE0Gg0WRljZrVaaWtr48iRIzQ3N1NWVkZFRQU+n49AIEAsFpMmiCwtLbG2tib1Bf9dQZyyIk4ikslkWCwWNBoNBoOB0tJSgsEgW1tbxOPxz51SotEoXq+XjY0NNjY2pJmI4nDb/bqWCoUCm81GQ0MDZ86cobe3l+LiYqanp7l9+za3bt1iYGBgXxOYCoWCoqIizp8/T2FhIVeuXGFwcBC/339gNsKDwP1OpX9OEISnAQ13YuB/DlgEQVB86oWXAivZW+bdiB5ESUkJTz75JE899RSTk5M5GaWWLVQqFZWVlTz22GOcPn2akpISlpeXCQQCWQlfmEwmmpubOX36NIcPH5Ym7VgsFul7IpEI0WiU6elpdnZ28Hg8j6wH9NlN8H7uEaPRSGVlJW1tbbS1tSGTySgqKkKv12OxWGhsbMTr9UrT3HcbFnGY7crKCnNzc9IEd4/HI02O2i/jKA7e7ujo4Omnn6akpAS5XM7c3Bwff/wx/f39TE5O7utnrVarKS8v57vf/S6VlZUIgsDa2hqhUOiRMeC77znx7+J9t1c26n6m0v8Z8GefLuIM8D9lMpk/EAThZeD3uaNE+UPglT1Z0X0gekKdnZ3823/7b/F6vRQWFmIwGNje3n7kGgUJgoDdbud73/sezz77LGVlZfh8PiYnJ3G73Vl5P3Nzc9y+fZv29nYaGxslAy4OL4Y77VDPnz9PPB4nmUxy48YN1tfX93wt2UBsQyuG2lQqFTKZTOp6mUgkvtJAVVdXc/78eZ577jmOHTsG3P0AptNpTCYTVVVV0s+IrY7FtqOCIBCPx3G73Vy7do0LFy7Q39/P/Pw829vb2bsAX4AgCGg0GgoKCqipqeHQoUPAndOCz+djeXmZ2dnZff2cxcHQVquVqqoqTCYT1dXV1NXVsbKycuC7OCqVSunzF9vQinM1xelSezWl52FSzD8GfiYIwv8GDAJ/tScr+pqIcWOHw4HBYECpVD6SBlyj0dDU1ITNZiMcDjMxMcGHH37I/Px8Vt7Pzs4ON2/epKCgAJVKxblz51AqlWxubqLX66VhrhqNhqqqKhoaGlhYWHgkDLhSqcRms6HRaLDb7XR3d/Pss8/icrnY2tpiYmKC999/n5dffvlLf4+YTK6urr7r6+L4vNXV1buMiTgVfnt7m9LSUvR6PQUFBdjtdkpLSyksLESr1Uo/vx8G3Gg00tvby3e/+11Onjwpff3P//zPeeONN5icnMTv9+d8XbvJZDLE43G2trZYW1tDr9ej1+sxGAySITzInD17lpKSEiwWCw6Hg/b2dpqbm6Uxi5988gk//vGP98SIfy0DnslkPgA++PTvs0D3Q6/gIREE4a5G6wcJg8FAXV0dzc3NeDwerl69SjAYvCskIsYju7q6qKioIJVKcfv2bd58801mZ2ezdszOZDKsrKwwNDREYWEh7e3tFBUVEYlEUKlUqNVqAOnoOjk5icfjycpa9gKVSoXVaqWmpoa2tjZaW1uxWq0YDAYKCwspLy9Hr9dLk5zuZ7LQ7du3eeWVV5icnMRoNLK1tUU6nSYejxMKhdjc3LxrcxVnJ8bjcQwGAzqdjjNnzvDEE09QUVGBRqPB5XJRVVXF1NQUCwsL2bwkn0MQBEpKSujo6KCiooJ4PM6lS5d44403ePfdd1lYWDgwk64SiQRut5uPP/6YsrIyLBYLdrv9wMkaNRoNNpuNoqIiCgoKpDCo0+lEp9Oh1Wqx2+1YrVYymQxmsxmNRsO/+Tf/hr/4i79gY2PjoZ7xg3U1HgJx4O5BMeIymYyCggLOnj1Le3s7ExMTTE1NEYlE7jLgYjyyt7cXm83G4uIi169f58aNG/h8vqzG88PhMKurq1LiSqvVolKppGnw4uSRcDiM3+8/kEfXiooKCgoKcDgcuFwuGhsbaWxspLa2FoPBQDqdJhAIsLS0hN/vx+PxMD8/z/z8/Ff+brfbTTKZZGVlBZVKxfb2thSCEYfafjbuLf6nVCpxuVwcPnyYVCol3ZficOZcnxI1Go1kXNrb29FqtczPz/Puu+/y5ptvsri4SCQSOTBVl6lUSuqlnkqlcDqdlJeXYzKZ2NjY2BdZq0KhwGw2U15eTkFBAUqlEp1OJxlw0VEoLy/HarWi1+tRqVQolUpp45HJZBQXF3PixAlefPHFh3aKfmsMuFqtlmJPBwFBECgsLOTkyZPU19eTTCax2+13NfMXQycul4vu7m4MBgPT09MMDQ0xOzubdUVNKpXC7/czPT3NlStXMBqNVFVVSSPURORy+YG6tnDnQTAajXR3d0sqmqKiIoqLi6UTRCKRIBAIMDExwdzcHFNTU6yurkqJx68iHA4Ti8XweDzIZDJJUifGv79oxJtCocBqteJ0OqXcjFwuZ3t7m4WFBZaWlvD5fHt+Tb4IuVyO1Wrl2LFjPPPMM1RUVBAMBhkbG+PixYvMzMwcuOR/Op2WHIx0Oo3T6aSqqoqCggIWFxdz7kyoVCpsNht1dXWcOHGClpYWNBoNarUavV6PyWRCr9ezs7NDOByWwkA6nQ6NRoNer5ciBWJoby9OE4+8ARdvOqvVislkQqVS7fOK7iCTyTAYDJSVleFwODCZTBgMhruMoEqlwmKxUF5eTm1tLQqFAq/Xi9vtJhgM5uQoGw6HmZ2d5Y033mBra4sf/vCHaDSau66jy+WioaGB1dXVfY+Pwm96dpw4cYJvfOMb1NfXS+oZv9/P9evX8Xq9Ujx6enpamnK/vb193xPuxbFu96uFFsN5VquVJ554grNnz3LkyBGsVivpdJrr16/z1ltvMTQ0xMbGxkNdg6+DwWCgsrKS48ePc+zYMcLhsHTqmp2d/ZzxFk8L4glsPwz7Z5N9JpOJ0tJS6urqmJycvO/PcC+QyWS4XC6OHTvG8ePH6e3tpbKyEpVKJSUqxWT1f/7P/5nFxUUUCgVGoxGr1cqhQ4fo6upCr9cjk8lIJpP4fL49Oe08sgZ8t5pAqVTidDqx2+2SmmI/UalUOJ1OmpubMRgMRKNRtra27oovymQy7HY79fX1dHZ2SsUKS0tLbGxs5PyILYYK7vW6BoMBu90uFbPsJzKZDKvVytGjR/njP/5jSkpK8Hg8DA8Ps7S0xMLCAkNDQ/h8PqmaNBwOZ30zVKvVWCwWiouLOXz4MD/84Q9pbGzEZDIRi8W4efMmP//5z7lw4QIbGxs5k+iJeurm5mbq6uowmUx4vV5WVlZYWloiGAzeZQiNRiN2u52CggLUajWRSIT5+fmcnhjuhUwmk4rP9Ho9Xq83ZwZcqVRy+vRpnn32Wbq6uigqKkKpVJLJZNje3mZtbY2FhQVWV1f5T//pP+Hz+RAEAavVSnNzMw6HQ9L9R6NRlpaWeOWVV/ZE0/5IGvB0Ok0ikSAUCrGxsUFxcTEGgwGtVrvvSQ5R4tjW1sb58+fR6/WMj48zPDx8l4G02+0cOnSIvr4+Ojs72dra4s033+TatWssLS1lvQJOqVTicDioqKigtraW5uZmysvLqaiokDwFEY/Hw8LCAltbW1ld0xchCIKk6BDjjc3Nzeh0Ovr7+7l27RpjY2MsLS2xs7NDLBYjlUpJD3i246VqtZqKigoOHTrE0aNH6ezspKOjQ3ImAoEAV69eZWhoCL/fn9M4s0KhwG63U1ZWht1uRxAEYrGYlA8IhUIAklEqKyujubmZQ4cOYTab2d7e5saNGwwPDzM1NbWvxVy7vd1coVAopFBoS0uLFPpIJpO43W5GRkYYGBjgxo0bLC8v3/WM6/V67HY7lZWV6PV6UqkUGxsbDA0N8ctf/vJ324CLlYIrKysUFRVJH+5+IsZlS0tLaW1tpa6uDr/fz0cffcTAwADb29uk02k0Gg3Nzc309vZy9OhRCgsLmZyc5OWXX2ZycjInZetGo5GOjg6piVFpaSlGoxGj0fg5qVYoFJKKpHKNmCeorq7m2LFjVFZWIpfLuXXrFm+//TYTExPMzMxIYaf9MC5Wq5XW1lbOnj3L6dOnKSgoQKfTIQiCtJGkUinUajVmsxmFQiElMrN9MhATb06nE7PZTCaTIRKJsLm5id/vlxKubW1tOBwOqqqqaGpqoqWlBaPRSCwWo7W1latXr/Lf/tt/Y25ubl/j5WJyPReI5fwtLS00NDRIictEIoHP5+PatWu89957DA8PMz8/Tzgclk5WCoUCrVaLzWbDYrEgCAKRSITl5WXGx8dZX1//3Q6hpFIpdnZ2JKO434il8FVVVXR2dtLV1YXRaKS/v5+BgQGmpqakuF1JSQlHjhzh6NGj1NbWSkUyAwMDkkeUbQwGA7W1tRw9epSuri5MJtMXPhwqlQqdTodSqczJ2nYjk8lwOBx0d3fz2GOPYbfbWVhYYHJyknA4zPr6OsFgkHg8vm9GxeFwUFdXR2trK42NjXc5EoIgoNVqqa2tpa+vj8LCQqnfjFiVmc3712g0UlRUhMvlwmQySYldn89HMBiUEq6tra3U19dTWVlJWVkZxcXFyGQyUqkUZWVl6PV6KeQiltgfpKRnNhDzWF1dXRQXF6PVaqXE/+joKB9++CFXrlxhfn7+rudWzG25XC5JAik2hpudnWVycnLPTjKPrAH/LLsr3/YDrVZLZWUlZ86c4dy5c/T09LC9vc3Y2BjLy8tSMkahUHDkyBFOnjxJc3MzGo2G4eFh3nvvvZyWLqvVajQajaQ4+bLrVlpaSnNzM7Ozs6yuruZsjXAn1FNXV8dzzz1Ha2srMzMzjI2NMTExIfVq2W/sdjsOhwOdTiflZEQjLuY6nnzySdrb2xkbG2N0dJSxsbG73sfukM9eIQgCxcXFVFdXS6Exv9+P2+1ma2uLRCKBTqejvr6e5uZmenp6cDqdKBQKQqEQHo+HZDJJaWkpNTU1vPDCC4yPj+Pz+bKy3oOGTCZDp9PR0dGBTqeTJKljY2O89tprvPPOO1LYbjdms5mGhga6u7tpb2/HZrPh8XgYHR3lxo0bkjRyL/itMeCiXGc/KrUUCgWnTp3iBz/4AUePHqW4uFhax5EjR0gmk1y6dIlr166h0Wjo6uqipqaGZDLJyMgIv/rVr3j33XdzmricmZnhjTfekLrliZWY93ootVotBoNhXxQ+KpWKlpYWHnvsMfx+P+Pj41y/fv1AdUecn5/n+vXrqNVqZDIZVVVVUrhCRBAEnE4nBQUF9PX1SX1S/uEf/oG/+7u/w+1273l8WavV4nA4sFgsklEeHR3lo48+YmZmBoDGxka+973v8cQTT6DT6fD5fExNTXHx4kU++eQTampq+MM//ENaWlrQ6XT78nztl1MmetuvvvqqJBWcmpri5z//OZcuXfrCoqfe3l6ee+45+vr6KC8vJxQKcfHiRV588UWGh4f3tFjqt8aANzY2UllZidFo/Opv3iMEQcBoNHL06FH+5b/8l7S1tWGz2RAEgXA4TCKRoKOjg5qaGk6cOMHc3Bwmk4m2tjYsFgujo6NcuHCBX/ziFzlXnaTTaWZnZ9nZ2WFycpJLly6h0+mAO55HeXm5tNGI73U/HqR0Os329jZutxuLxcKpU6dQKBSkUimGhoYORIfE9fV13nvvPYaGhvj7v/97iouLsVgsGI1GysrKaGhooKOjg8LCQqkVrVKpRKvV8kd/9EdUVVXxV3/1V9y6dWvPpt/I5XKampp4/vnn6evrw2q1MjIyws9+9jM+/PBDMpkMvb29fPOb3+TcuXMYjUZmZma4evUqV65cYXx8nPr6ep555hmcTidut5vR0VGWl5fZ2dnJadhyvz7fVCpFIBDgzTffZHBwELlcTjQaZWNj455GWKFQ0NHRwQsvvCA5cgDT09NcunSJ2dnZPa90fWQNeCqVIhKJsLS0RDqdljzwXKlQRBVHU1MT3/ve9yRVxOLiolTpp9Pp6OnpwWazSRIojUaD1WpFJpPhdDppaWnh2LFjXLhwgVAolNObdWdnR+qj7na7JQ9bEARqamqkI7ZYDmyxWNBqtVlPZtrtdhKJBDs7OyQSCW7dusXLL79MZ2cnJSUl9Pb2kkwmCQaD0ia0n3mQeDyO3+8nFArhdruZn59Hq9VKn3VlZSVzc3McO3ZMqiZUKpVSEVdfXx8TExMkEgkmJyf3xIjLZDIqKiqoqKjAbreTTCa5efMmH3/8MYIg0N3dzalTp+jp6aGgoIALFy5w7do1bt++jdfrpbGxkW9961vU1taysbHByMgIv/71r9nc3Ny3UnvxOudSA55MJvF6vQSDQeA3CrjPXgMx1/H9739f2qwTiQQTExO89dZb9Pf3S6GnveSRNeDpdJpoNMrKygqpVEqqFhTjj7mQjpWUlEiyMbER/sTEhFQgIcZF29vbpWZbCoUCuVxOJpPBYrFQVlZGTU0N77//flbXey/EayhKMsW4rdgNbmtri2QyKYVQxERmNgy4WKFWU1NDeXk5Xq+XtbU1vF4vi4uLUojp8ccfp6GhgRMnTvDaa6+xurp6z17cuUQsOhHL5CORiNSBbnV1VSogCgQCdHd3U19fj8PhQKVSodFoKC0tpampidnZWVZWVvbMgDscDoxGI4IgsL29zczMDGtra9TV1XH48GE6OzspKipifX2dDz74QDrROJ1Oenp6aG1tZXt7m8HBQWnAg1hluB/E43F8Pl/OqzDFz/aLEGPl1dXVnDx5EpfLhU6nY3Nzk6mpKT755BMWFhay8tw80gZ8Z2dH6ougVCqlySkqlSrrH7JarcblctHc3IxKpaK/v5/h4WEmJiaYn5/H4/HgcDgwm83YbDaMRiNms1nyLEUpZDqdlqq49uPBEJsz7U6gqtVq5HK5tG4xdCL2m9lrdhdpfOtb38Llckna+XA4jM/nY2RkBIvFQkdHh1ThajabUSqVB6b/DfzmeoqEQiECgQDBYJCNjQ3JuIvl1HBHL+x0OnE4HHtWiCaG98RnYWNjg9XVVRKJBEVFRVRXV1NaWopcLmdwcJDR0VE2NzcpKSnh0KFDdHZ2kslkGBgY4P3332dwcJDl5eUDcdLJpQd+P4in8e7ubmpqatDpdKRSKWnTvH37dtbURo+sARe9HjHsIAgCKpUKrVaLUqnMugEXdefhcJhXX32VDz74gJGREbxeL7FYTDLKk5OTbG9vS7LHwcFByWvc2tpicXFRGll2UCgrK+PQoUMcOnQIh8PBzMwMKysreDyerBQYabVaqqqq+Ef/6B/xne98h7W1NVZWVqTNIp1O39UQKh6PS0UoiUTiQD3M9yKRSLC+vo7b7Uar1VJSUoLT6cRms0nfk42SdfE0Kk4GCofDaDQazGbzXa2XFxYWaGxspK2tjfLyciorKwmHw1y4cIGLFy8yOjp6IDpRimHTg9JwS0StVuN0Ojl9+rQktd3Y2GB8fJxbt26xubmZtY3vkTXgogcu6oCVSuVdBQtizCpbRCIRxsfHCQaDjI+P4/F47jImcrlcavZfWlqKwWBgfX2d//Jf/gv9/f1Eo1Hi8TjRaDSr2m9xYysrK0OtVrO9vY3H4/nCDU6lUnH8+HFpKhDcGf5w/fp1qYhjrxGnrzz55JO4XC6mpqak1qd6vZ5kMonT6eTcuXOUl5ezvLzMW2+9xdTU1L5NaBGva0FBATKZjEgkQjgc/tLrIzY42tnZuctLz2QyuN1uabLPXpDJZKTfZzabsVqtUltT0TMXw44dHR1861vfQqPRSB0AX375ZV555RUikciBmsK0n1LhzyIWmRUWFlJbW0tLSwtyuRyfz8fHH3/M22+/zSeffLJnwxvuxSNrwJPJJNvb24yOjjI7O4tWq8VsNuNyubBarSwvL2f19Xd2dpifn2d1dfVz47HEZkt1dXV0dXVhs9nw+/2MjIxw48YNZmZmSKfTUn+EbB5LVSoVNTU1PPfcc1itVm7fvs3FixdZXl6WNhyZTIZSqUSlUlFaWkpXVxctLS2YzWYikQgLCwvMzMxkrZFVLBZjaWmJt99+G7vdTktLC42NjdI1Er0ui8VCOBxmcHCQV199VWr3mmsPXCztr6iooK+vj0gkwtTU1JducGJRXw7F/gAAIABJREFUiMvlklQqIrFYjOXlZdbX1/fsJJZKpZiYmMDn81FVVUVNTQ3d3d3I5XKam5ux2+1S6+DOzk5UKhWhUIjV1VX6+/u5fv261P/8IJxwMpmMNEg6W3mYr4MYoqqoqKCtrY3Tp09TXV2N3+/n6tWrXLx4kYGBAdxud1av330ZcEEQLMD/CxwCMsAPgNvA3wOVwDzwQub/Z+9NYyNPzzux38u67/tiVfFukt09Mz0z6pmR5RljfCVeWco4gGE4CdZ2YkBfsgsvkkVW9n7xhwTwBsgmzsLYQIltaCMh2k28gQzBmmgiaRxZlkYzPdN3N28WWWQV677vqn8+kM/Tb1Wzpw9WFcme/w8oNFlNst7/ezzvc/ye51GUsZaqIybCxsYGwuEwEokEtra2xmLukQ/7OJcCBTg///nP48qVK9BoNLh58ya+/e1vj7UlFGWHvvnmm3jrrbfg8XgQDodRKBQghOAgpU6ng8/ng8/nw1tvvYVXX30Vfr8fwKH2fffuXaRSqZGNmwTY9773PYRCIUxNTbGQMxgMsNlsnAFIAbW7d++iXq+fik/WaDQiGo3iS1/6Et5++2386Ec/wvr6+rF7gQLCFosFly5dwtWrV7GwsMACvNfrIZVKIRaLIZVKDVUDL5fLqFQq6HQ6cDgcXNrY7/cjGAxyMN1oNKLVamFvbw/379/HrVu3sLOzc+qNHeT66gDY/WSxWE6tbAJBq9Vifn4eb7/9Nl577TXumfr+++/ju9/9Lm7cuIFYLDbys/6kGvifAnhXUZTfFELoAZgB/BGA7yuK8idCiK8C+CoO26yNFb1ej5ud7u3tcV2M0wJpWnNzc/i5n/s5RKNR7O7u4sMPP8T3v//9sbfR0uv1CIfD8Pl8iEQicDqdKBaLXJu80WiwDzoajbKbwmw2o1Kp4MaNG7h+/ToL+1GAymt+/PHH8Hg8mJ6extTUFLxeL0wmE4QQqFQqWF9fx89+9jPcvHlzJJSsJ4FGo4Hf78crr7yCX//1X8crr7yC27dvc/CSSrACh8LbbrfD7/djdnYWb731Fr7whS9wViS5VG7evInNzU3kcrmh5QOQAN/e3kY4HOaektQDk9q/FQoF7od5/fp1fPDBB7h///6ptHsbBM0pWWDkrqA9cZr1WPR6PZaXl/GLv/iLeOWVV+DxeJDL5fCd73wHP/zhD5FOp8fienqsABdCOAD8AoDfAwBFUVoAWkKIdwC8ffRjX8dhq7WxC/BBnLa5ZzKZEAwGua1XtVrFz372M1y7dg3ZbHasQkdRFJRKJfzgBz/g3pfRaBS/8zu/gy9/+ctIJBKo1+tcBoA6iJDAjMVieP/993Ht2rWR08eo1Oa7777LjWBlxgsVhCJK12mts1arxZUrV/DlL38Zy8vLMJvNcDqd3BWoUCiwINfr9Vzk6td+7ddw8eJFmM1maLVaKIqCdruNdDqNb37zm1hfXx9qILvX6yEWi+Gv/uqvsL+/jy984QtcChUAu8auXbuGWCyGtbU1LrI06vjRk4DmJ5fLIZFIwOfzsbvvtDExMQG73Y6FhQUsLi7C7XajUqlgc3MT3/ve94ZW6/tJ8CQa+CyANIC/FEJcAXANwB8ACCiKkjj6mSSAwHG/LIT4CoCvDGGsnwqDwYBoNIrl5WXs7OyMvWYH4cUXX8SXvvQlvPPOO1AUBe+99x6+8Y1v4MaNGyMvEXsc6vU6bt68iaWlJdRqNRiNRvzKr/wKZmdn4fF40Ov1MDExAYPBwMGhRqOBjz76CH/5l3+Jd999d6wJRmcpYHYcyOWxtbXFY33nnXdw9epVLlJVr9c5sSMajWJmZoYpgqQ5lstlrK+v41/9q3+FH/7whyOxcHq9Hu7cuYNYLIbvfOc7sFgszJIgFyB1HWo2m5w4ddpKEIHG2Gg00Ol0YLfbsby8DJfLNfZ+ogS9Xs/lZV977TWYzWYkEgl8+OGH+LM/+7Pxlwt+wp95FcA/VhTlAyHEn+LQXcJQFEURQhy76oqifA3A1wDgUT/zrBBCsEZEtSdosU8LVCGROupcu3YNOzs7p+az6/V6KJfL+OEPf4iPP/4YFosFxWIRFy5cgNlshtfrRSgUQiQSAXDoj/7BD36A7373u/jZz36GQqFwZg70WUC328X+/j4++eQTXL58GW+++SYcDgfMZjOi0Sjq9TpbWVqtFmazmbVuAIjH41hdXcX9+/dx8+ZN/OAHPxjpoaemFvl8/iHtVfYxn1bnnceh1Wphf38fi4uLsFgscDgcp9p1y+124wtf+ALeeecdvPTSS+h0Orhz5w7+9m//Frdu3Rq77HkSAR4HEFcU5YOj7/8vHArwAyFESFGUhBAiBGB8PaIGQFzXcrncV5P3NJBOp3H9+nVOlb5x48apC0HqtpNKpbjcADUxdrvdHNQCDg/8T37yE3zyySen1jz2LENRFBQKBdy7dw/vvvsums0mZmdn+4SK0+mEoiioVCool8vo9XqoVCooFApcTXFjYwOxWAzpdHqkh14WzKcdlHxaUEPt69evc89TKvp1GjAYDPB4PJibm8P8/Dw0Gg22t7dx+/Zt3Lt3b+ylMIAnEOCKoiSFELtCiCVFUVYA/DKAu0ev3wXwJ0f/fnukIz1+bOh2u9jc3ESn0+HWT+MuDCWDKublcjno9XpsbGyciSQdGkO1WmXqJXXVtlgsXASs2+1iZ2cHBwcHI+WvnldQQ4R4PI4f//jHaLfbWFxchMlkYl51OBzmIlztdpsbIyeTSWxvb2NnZ4cLIp2GW+08oVar4fr16wiFQpicnOSCX6ehENntdrZWXS4XCoUC7t69izt37mB3d/dULsgnZaH8YwDfPGKgbAL4zwFMAPh3QojfBxAD8FujGeKjQVH8733ve/B6vdjd3X1kX8dxoVar8QE/i6BWUCqeHZ1OB4VCAZVKhWu+UyljrVaLYDDIrqt2u801PDKZDBe9OmvZhGcV9Xodd+7cgVarhdvtxt7e3lj7Ycrw+XyYn5/H9PQ0tFot1tbW8OGHH+L27dtjbVItQ4xzIobtA1ehQoWKceGNN97AF7/4RfzGb/wGAOAb3/gG/uZv/gZbW1vjsLKvKYpydfDNc5uJqUKFChXjRDwex40bNxCNRjnxLBaLnaqLVNXAVahQoeIJoNfrYbfb4fV60Ww2OXN2TIH+YzVwVYCrUKFCxdnHsQL89NOaVKhQoULFM0EV4CpUqFBxTjHuIGYFh1UMP2vwAjj9ivjjhfrMnw2ozzweTB/35rgF+MpxfpznHUKIjz5rz60+82cD6jOfLlQXigoVKlScU6gCXIUKFSrOKcYtwL825s87K/gsPrf6zJ8NqM98ihgrD1yFChUqVAwPqgtFhQoVKs4pVAGuQoUKFecUYxPgQohfE0KsCCHWj5ogP5cQQmwLIW4JIa4LIT46es8thHhPCLF29K/rtMd5Eggh/kIIkRJC3JbeO/YZxSH+56N1vymEePX0Rv7seMQz/7EQYu9ora8LIb4o/d8fHj3zihDiPzydUZ8MQoioEOKHQoi7Qog7Qog/OHr/uV3rT3nms7nWx7VVGvYLgAbABoA5AHoANwBcGsdnj/sFYBuAd+C9/x7AV4++/iqAf3Ha4zzhM/4CDtvs3X7cMwL4IoDvAhAAPg/gg9Me/xCf+Y8B/NNjfvbS0R434LCn7AYAzWk/wzM8cwjAq0df2wCsHj3bc7vWn/LMZ3Ktx6WBvw5gXVGUTeWwq/23ALwzps8+C3gHwNePvv46gN84xbGcGIqi/H8AcgNvP+oZ3wHwb5RD/BSA86gF37nCI575UXgHwLcURWkqirIFYB2HZ+BcQVGUhKIoHx99XQZwD0AYz/Faf8ozPwqnutbjEuBhALvS93F8+qScZygAvieEuCaE+MrRewFFURJHXycBBE5naCPFo57xeV/7f3TkLvgLyTX23D2zEGIGwCsAPsBnZK0Hnhk4g2utBjGHjzcVRXkVwD8A8F8KIX5B/k/l0O56rrmbn4VnPMK/BjAP4GUACQD/w+kOZzQQQlgB/BWAf6IoSkn+v+d1rY955jO51uMS4HsAotL3kaP3njsoirJ39G8KwP+NQ3PqgEzJo39Pp4HeaPGoZ3xu115RlANFUbqKovQA/K94YDo/N88shNDhUJB9U1GUf3/09nO91sc981ld63EJ8A8BXBBCzB41Rv5tAH89ps8eG4QQFiGEjb4G8B8AuI3DZ/3dox/7XQDfPp0RjhSPesa/BvA7RwyFzwMoSub3ucaAf/c/xuFaA4fP/NtCCIMQYhbABQA/G/f4TgohhADw5wDuKYryL6X/em7X+lHPfGbXeozR3S/iMKK7AeCfj+tzx/nCIcvmxtHrDj0nAA+A7wNYA/D/AnCf9lhP+Jz/Bw7NyDYOfX6//6hnxCEj4c+O1v0WgKunPf4hPvP/fvRMN3F4kEPSz//zo2deAfAPTnv8z/jMb+LQPXITwPWj1xef57X+lGc+k2utptKrUKFCxTmFGsRUoUKFinMKVYCrUKFCxTmFKsBVqFCh4pxCFeAqVKhQcU6hCnAVKlSoOKdQBbgKFSpUnFOoAlyFChUqzilUAa5ChQoV5xSqAFehQoWKcwpVgKtQoULFOYUqwFWoUKHinEIV4CpUqFBxTqEKcBUqVKg4p1AFuAoVKlScU5xIgAshfk0IsSKEWBdCfHVYg1KhQoUKFY/HM9cDF0JocNig4VdxWOD+QwD/iaIod4c3PBUqVKhQ8ShoT/C7rwNYVxRlEwCEEN8C8A6ARwpwIYTaPUKFChUqnh4ZRVF8g2+exIUSBrArfR8/eq8PQoivCCE+EkJ8dILPUqFChYrPMmLHvXkSDfyJoCjK1wB8DVA1cBUqVKgYJk6ige8BiErfR47eU6FChQoVY8BJBPiHAC4IIWaFEHoAv43Dbs0qVKhQoWIMeGYXiqIoHSHEPwLw/wDQAPgLRVHuDG1kKlSoUKHiU/HMNMJn+rAx+cCFEA+9R88phMA4n1kGjWtwfDSe0xrX8wJ5XtW5fDwG9yF9f9b242me2TOEa4qiXB18c+RBzFGBNtvExMRDL41GA51Ox4ve7XbR6XTQ6/X4+16vx69RjlEI0TcujUYDvV6PbrcLRVHQ6/XQ6XR4TIqinMkDJP9LkMd3GmOluaX11uv1aLfb6Ha7aLfbD82nisPzAjyYO3mPkqCkc0Ffj2sOaSw0Hp1Ox+vb6/V4XemsnAXQeOlrOuvyswzOq3z2T4pzJ8DlBaaDazAYYDQaYTAYoNfrodfrYTKZAACdTgedTgetVgu1Wg3NZhPNZhOtVgvtdrtPsI9inFqtlsdnNBphMplgNBr5s9vtNhqNBhqNBprNZt/lAgxPMMobTf67n/b3By8g2pgE+aDTphwn6JBbLBbY7XY4HA50u10Ui0UUCgU0Go2+i/G0cZxlSBj1+AYFtUajgVarhUajwcTEBPR6PSYmJljAkFIhn5FRCnJ5fFqtFnq9Hna7HTabDRaLBe12G+VyGblcDvV6Ha1W61QtaXke6aXT6WA0GmE2m6HT6Xh+FUXpkz101mUl41lxrgT4oOA2Go2wWq1wOp1wuVy82BaLBVarFRMTE6jVami1Wmg0Gkgmk8jlciiVSqhWq6jX6wCAdrs91M1Am1Gj0cBkMsHhcMDlcsHtdsPpdMJisaBer/OrXC4jn8+jUCjwwgIYiuAZ1ARIiBz3txVF6dMm6BloM9K/9HvyJURCfFygvWAymeDz+RCJRBCJRCCEwNbWFjY2NqAoCprN5li18Ee5JQbnf3AdRnnJDGq1ZAWS0qPRaGC1WlnYtNttFjaVSgX1ep2FzSjHScLbaDTCbrcjEolgamoKgUAA1WoV8XgcKysrbLWO+2KWzwRdMqScmc1mPuderxdWq5XnttVqIZVKoVQqsXKRyWRQLpdPLMTPjQCXhbfRaITNZoPX60UkEsHc3Bz8fj+cTiesViuMRiMsFgu0Wi0qlQpKpRLS6TQMBgOABy4VEkCdTmfomi4dFpfLhdnZWUxPTyMajcLn88HhcKBcLqNaraJSqSCTyWBrawubm5soFAqo1+toNpsnsgzkzUZaluzjHNSqZOEtaxc01yaTCWazGUajkc3wQqGASqWCSqWCdrs9Nl8lPZter4fb7cbc3BwuXryIpaUltNtt6HQ6pFIpVCoVtFot/p1RC0j6mqwV+XtZU6P/6/V6bAkOQxv7tLGR0DaZTNDr9XA6nXC73XC5XDCZTPB6vdDpdOj1eqxUpNNpJJNJZLNZXuNRXYZkrZpMJrhcLoTDYbzyyitYWFiAz+dDpVKB1+vtU8jG7dqhdTQYDLBYLHC73fB4PAgGg4hEIpifn0ckEoHT6YTRaGTXT7lcZqF9cHCAWCyGGzduYHt7m+f1Wdf+XAhweROazWZ4PB4EAgHMz8/j7bffht/vh9/v7xMuGo0GnU4HlUoF+XweExMTKBQKSKVSMBqNqFQqAEZjutJYbTYbZmZm8Mu//MtYXl6Gx+OB0+mERqNBrVZjTSeXyyEcPkxi3dnZQTab7dN2nnaMx1kAZB6TO6lerz/krqHfpY2q1WphNpvhdDpht9tht9v54Gs0GmSzWezu7iKRSKDb7aJSqYxV052YmIDdbsfFixfx8ssvIxQKoVKp4P79+9BoNJ/qshjWGI4zo/V6PWw2G2u5RqORrRe6HLvdLmq1GjKZDHK5HKrV6tC1StklQRarz+eDz+fDzMwM5ubmMDc3B4PBAL/fz+NqNBrI5/NYX19HLBbD/fv3EY/H2XIdtuCUFR6z2Qy3243JyUkEg0HMzs7CZrOxkNvY2MDW1ha0Wi263e7IlYZBS5TOUzQaxaVLl7C4uIhwOIxAIIBgMMgWKlmkrVYLer2enysQCMDtdrN10+v1UK1Wn9kLcOYF+KBvzGazwe/3Y2pqCvPz8wiFQrDb7ZiYmGD3AwU6ms0mSqUS3377+/vIZrMoFot9ZuGwD4xOp4PVakU0GsWrr76K5eVlRKNR9su3Wi32GWu1WrjdbkxNTeHixYv8N7rdbl+w5mnGKG84mi9FUTgO0Ov1+KKT2TnAAzOWNDaDwQCz2Qyz2QybzQa3241gMMhmY71eR6lU4oDTqIPChImJCZjNZkQiEczOziIajcJut/f5b0dlYstzRTEYs9kMq9UKh8PBWpnZbIbBYIBOp+N1JUun1Wohn89jZWUFtVqN/fXDHCPtA9IYXS4XFhcXMT09jZmZGYTDYXi9XlaM6DyQm4VcVOS/7fV67JIaxdyS+6ZarSKfz6NYLKLVasFkMsFms6FcLsPj8fBeG/UFTZAvF5fLhUgkgsuXL+PFF1/E5OQk7HY7TCYTnwWy+ums0UVut9thNpsRCAQwPT2NtbU1Vi6fFWdegAPo0yadTifC4TCi0Sj8fj+0Wi3a7TYKhQLK5TK/Go0G2u02KpUKBz/i8TgODg5QrVb5/4cVfJODlhaLBaFQCFevXsXly5fh8Xig1Wr50NbrdXbbkMDUarXw+/0oFAqoVqsol8t8IT2t8Ka/aTAYWGNWFAX1eh1CCDSbzT5hQlrMoPZN2iT5+Sje4PP52MKxWCwwGAx9kfdxBOS0Wi1cLhdmZmYQDAZht9uh0+k42NVqtfqEzLBdZLKLiebY6/UiGAzC4/HA7XZDp9MBAF9qsv+03W5Dq9UiHo+PRBAN7gObzYZwOIz5+Xl2OVosFhbM+Xye3RLkAqLfo9gNuQI6nU6fO+6k46RXr9djAV4oFNh1AwAGgwF2ux1utxsGg2FswpvGKFuzFHMhS7TZbKJWqyGbzSKVSiGVSrErVAgBh8OBqakpzM7Owul0wmazweFwwGQyndhSPPMCXN6IZIaEQiEEg0FYrVa+9XZ3d5FKpdgkrdVqrIWTQCThKFORhils6EC73W7Mz8/j9ddfx+zsLAwGA2q1GiqVCmKxGKrVKmvBdLMD4M1Bm7dcLj/14srzRRee0+lEt9vlgMpx2ssg44QuFTlYY7FY4HA4mO1Bmtogw2XUoPGR5UKHutPpoFQqIZfLsUY7THNf9nOTheJ0OhGJRNiEDgaD7Gdut9usXZPPni5DvV6PRqPBVsuwx0mXHLlO7HY7gsEgwuEwfD4fdDodC8pardYncEhY+v1+TExM8Lpns1m+JIftRiGtvt1uo16vo1gsIpVKIZvNot1us5VAPvuTaK1Pg8HLmggSVqsV7XYbuVwOrVYLpVIJa2trODg4wP7+PgcotVotAoEA9Ho9JicnMTEx0Rc8PinOtAAfNANNJhMHXoxGI1qtFvb29pDNZrG2tsYsEwpekTndarVYmyU/47BpeqSxOJ1OTE9P4+rVq5ienobFYkGlUkEul8P+/j7W19eRyWRYOzMYDPD5fLDb7XwxlUolJBIJZLPZp9Zq6eCSWU/MHKIvAXjkBSa7T0hTFEKwm4AYPsSxr9frqFQqaDQaY2EEyK4Lg8HAWq/FYoEQArVaDXt7e8hkMmg0GkMLTg8ySehSs9lsmJ2dxeXLlxEKhWCz2XgcBwcHKBQKKBaLaDQa0Gg0CIVCsFgsffkA7XabrYVhYHCMJHTIJw8AxWIRlUqFNcZMJsPj1Ol0cDgcCIfDfIHTXjKZTOzHH6a7hy4DOQYwMTGB/f19xONxXL58GS6Xq8+NMY4YB2EwiKkoCgqFAvL5PCsMBwcHSCQSyOfzHJgEwHMn0wbp75ElfpK1P9MCHHjgf6IAjMfjgcvlgtlsRqPRwPr6Ovb29rC1tcWat3woiNcqE+hHEYTRarVwOp14+eWX8cYbb+DVV1+F1+tFpVLB6uoq1tbWEIvFEIvF+KCQIPJ6vbh8+TIWFhag0WhQLpexu7uL3d3dx3/4wDhknyeZv263mzdUqVSCwWBAvV5/aB5kqiD9S0wJ0syJpUCHP5vNolQqjUWI08HW6XSw2+343Oc+h+XlZbhcLnZPbWxs4ODgALVabShBwUHhLcc4gsEglpaW8NJLL8Fut6NWq2F3dxf7+/u4f/8+u/K63S4zeEKhEFtcxGkeNs9a5lJT/EKn06HZbCKZTGJ9fb2PFUHMDgAwGo1oNpuw2+0PuflGQSMk193guazX68hkMojH4ygUCgiFQrBarZicnITRaByb8KYx0b7P5XLQaDRsyedyOWaUkc+eLBQ6R263GwsLC3A4HH3PJtMInxVnWoAPugN8Ph8CgQAcDgcMBgMnwFSrVbRaLQ5eyZmXsqY5bK2bxkjmsdfrxfT0NKanp2G321Gv17G2toYbN26wYMnlcuh0OhwkItPf7/ezb5pM7ZNoGTQms9kMr9fLSUJEqSQ3iuy7psCn/LJarfB4PPB6vXC73bBarVAUBZVKBQcHB8jn86hWqyPngA+60iKRCF588UW43W4IIZg1cf/+fRSLxaEFqAe58WRKk/89EokAALLZLJLJJFZWVrC9vY1UKtV3kMlv63A4oNfrUa1WUSqVUC6XWVCOIihIrJJisQhFUVAul/lz6UWXOwl9ChCbzWbWGMmSHUXC1nH5COT+bDabANDn9hu3y47YW7VaDQDQaDRQKpXY3UNCm1gxFDsiq/qNN97A0tISLBYLarUa4vE4bt68yZbic8kDl01Bg8EAh8OBYDAIn8/Hh0Gj0TC1rVwuQ1EUvh0HzedhB7PkcdI4FhcXMTc3B5/Ph4mJCeTzeaytrWFrawv7+/tMw+p2u6zRdjoddgcpisJcXbPZ/NQ+Mlkgy9xjojbJPmviqA4yKrRabd88abVaWK1W+Hw+9j82Gg1UKhWOKQwGDEcFutyITRGNRmEwGPgyWVlZwc7ODh+KYUF+LpmvTO68TqeDfD6PRCKBeDyOdDqNWq3Gc67X6zmQRcFNcmPQfhj23FEWJTEhWq0WqtUqdDod6vU6ZwNSEJP2CgXq7HY7DAYDJ7xVq1VmoIwDpHCRYiBz6McZd6FxdDodDvLKbh46y5QFrigKu1KDwSAWFxcxPz/PLJV4PI67d+9iZ2dnKNTRMyvAAfBiEbnf7/fD5XKxALdarQiFQsyoMBqNyOfzEEL0+ZtGBVn79vv9LFRsNhtarRaSySQ2NzeRTCY5tZu0GHo2EuLy7U1BjmcN1Mi1V0hYA4Ber+/LxKPIv8xl1ul0PBbKiqMMM8rWI9YP0TFHVY6AILsvzGYz/H4/lpaW4HK5IIRAsVjE7u4u1tfXOeg1Sgqh7EYxmUysydKckNZI7iyHw4HJyUlMTU3B6XSiVquhXq8zI2kUbgkKCA4GB4k9JFMtaf0pOcXn8zHDgqinpGmOEzR2ObhO+3rc4+h0Ovy9zEohnj8JcFnhiUQimJmZgdPpRKPRwN7eHu7fv487d+7g4OBgKIrPmRXg8kEh9onH4+FMS61WC4fDAafTCa/XC5vNhkQigWQyyTQtAH2bdFTat9lsxuzsLC5cuAC/3w+NRoNMJoPNzU3EYrE+3/zgjSubziRYScg+q9Ugz51cPIv4tMT5pQNOFwdxgDudDnPIaX5JIyNqZiqVGhmf/jiQ+4Q02UuXLsFgMKDVaiEej2N1dRWbm5sj88XL2aqydQiAhaPsAqN1dDqdmJycxPLyMsLhMCwWCwqFAtLpNOLxOAvwYUPWYGXK32Dwmiw0or5OTU1hamqKcwdIeJMLDvj0mi4nhfy3aYyyVUlBVPr/cVgEg3NJ7hKj0Qiv18svSnazWCyctEcMtHg8jk8++QS3b99m/vdzWwtl0H1iMpmYadBqtfrMKbvdzibq7Owsp6Xfu3cP29vbyGQyfWb+MMdIt3A4HMYbb7yB6elpmM1mFAoFrK+v49atW0gmk8yKkfnAslZBBZmAB5uSkhqednHlOg0y04Hm02KxwOl0QgjRp2kbDIa+zDby81ItCr1ej2aziWKxyBF3+blGpYHL/nmHw4GLFy/i85//PObn56HT6ZBIJHDjxg3cuHEDBwcHfZrSqMZD+4/yCYQQTB/tdDrsqjAYDAgGg5ibm+N8ALLMtre3sb9Qhcs8AAAgAElEQVS/z66zYQijQbfCIHuC/NuDv2M2mzE5OYmlpSXMHPHqzWYzxziIpUL7SH4Bw3VLyollpBzJ8SKn0wmHw9GXzDNOtw5weKFYrVZEIhEsLS1henqa6Zl0cQNgS3V/fx83b97ErVu3sLOzg0KhMDS342MFuBAiCuDfAAgAUAB8TVGUPxVCuAH8WwAzALYB/JaiKPkTjab/c/vMJuBB9FZOULBarej1erDZbKwlyjfhxsYGkskkB3GG4W+UtQGr1YrZ2VksLCzAYrFw0ax79+5hf3+fo9XyYsmmoF6vh8ViYSohcVyfJYmHIF9w9MzEBSa/HfHkiWpmMplY+LVaLdYe/X4/R8/J17y7u4tsNjty94nsn9fr9fD5fLhw4QKWl5dhtVpRrVZx79493Lt3D/F4fCw+2kGXBDE2DAYDXC4XQqEQrzWNmXjiBoMB2WwW6XSaFYtR1z8hBUiOq8jWmUajweTkJGvfRMvs9XpMf5XZNPJnDBNysPg4dhSNm5QTuozGKcCB/hhIKBRCNBrF9PQ0QqEQB6h7vR4ajQa7ye7fv4/V1VUkEglmqgzrzDyJBt4B8F8rivKxEMIG4JoQ4j0Avwfg+4qi/IkQ4qsAvgrgnw1jULLwpgh4LpfDzs4O+6NkzZGKGlHGmMfjYcpbs9nsC8IMC6R9ezwezM3Nwel0otfrYW9vD3fv3sX6+jrS6fQjE0pkzTsQCCAUCjGFK5fLIZlMPpNAooCL7OOUk3KEEPD5fGg2m6wtyFxVRVHYFSDzvonxQwlJ5BMdp+uE0penpqag0WgQi8Xw0UcfYXt7G6VS6SEBM0pWR6lUQiaTQSKRgM/nY6FJ5QXImqFxTEwcVsYk7Xtvb2/oAUxZsZCtLZvNxi+K2cjc/mAwiEAgAI/HwwXfqOQyAK4BQvuD5nkUzK5Bt6Gs6dOlZLVaH3ruUe7BQUuGLAFK6KHCVXIZB5lEQe7Q49ynJ8VjBbiiKAkAiaOvy0KIewDCAN4B8PbRj30dwPsYggCXzTPSvBuNBtLpNEfNZd8tBdqovoBGo+FIP0V99/f3h6oxyO4Ir9eLyclJZkPs7+8jFoshmUw+slykbEFQgCscDkOv1yOXy3E6rmxePwno54iBIDc3IG2LzH1K8CC6oNFoZOYEJXyQZq7T6TijsFwuc6BuHDXAaa59Ph+WlpYQjUbZ0lldXcXKygrS6fRY6kPL9LZSqYSDgwOYzWaOGdDPkLJgNpthsVjYsqGSqMlkEvl8vu+CHpb7hGiORLsNBoNcwthsNqPb7bLSQzERn8/XlxBFQogCtQ6Ho48UIKfSD7MAF51p2vNUDIriLMQyo2DhODVwmWZrMpm4rgm5dSuVCmq1Go+JmD8Uw5N998PEU/nAhRAzAF4B8AGAwJFwB4AkDl0sx/3OVwB85Qn/fp/wpokgUzWZTLJGS8KDFrRYLGJiYoLLt1K9AavVymbNsEAmvd1u5+puADjxYG9v7yEhNxgAo8NB3PFQKMTPGI/HkclknsmFQhufkplI6FKZVdrwxDWXtXN5HWjMtPEoeEl1y0etfcv7wGg0YmZmBgsLC/B4POh2u8jlcrh58yZ2dnZQqVQe8n2Palx0MCuVCldhbDabfanRVL7B4XBwMwKq1rizs4NMJsNa+rACcbJ2SNz9qakpLvJFrKN2u81uFcrUdblc7FcmIU0KCs03vUdB7lqtxkKcCAPDBO3jWq3GiWJU458sCBKIo/DFE+R9OBiT0+l0XKuFzruiKLBYLDxGrVbLwp7iUsNUJp9YgAshrAD+CsA/URSlNBAtVsQj+l0qivI1AF87+hufOsPyRFG6Nm1+SocfTHqgW1FOB6ZN2O12uWnCsA4LbWSr1Qq/349wOIyJicNStWtra1hfXz/W9y3PF7lO/H4/C6ZOp4P19XX89Kc/xe3bt9kl8LTjJeFNqfP5fB5Wq5XTuckvXiqVUK/X++qdUHICAE6YIcZPqVRCNpvlAkPHtYAbNsjN5PP58Eu/9EuYn5+H2WxGtVrF9vY2PvnkE6RSqYeoeKMaD7kMOp0O+/9rtRry+Tyb0cADIR8MBjmJqlqt8gUv1+oZxlhlv6zD4WB/diAQgMvl4jyATqeDZrPJQoS47KShK4rCVNder8caOwD+2XQ6DSFEXyLQsDM0aZ5brRaXxpCVGZvN1ldAbZSUUdK8ydIni1RRFA7mk3zK5XLQ6/UIBAKYm5tDKBRiRW16eprpxNVqdWhjfCIBLoTQ4VB4f1NRlH9/9PaBECKkKEpCCBECkDrJQOTEEzLvZJ/jcRQ8Eop0M1K9XSorWqlUkE6nuYLaMLRwWSu0Wq2wWCzodrtYXV3F3bt3sbu7+0gNlQSSzWbD8vIyXn75ZVy+fBmBQADlchk/+clPcOPGDezu7j4TvUymO7VaLS7KL9erppRoSiCS/YuU4EGcYK/Xy1o6VVyrVCp9zSZGJTRpns1mMxYWFvDCCy/A4/Gg0+lgZ2cH3//+97G5ucmCcByJRMCDOZZNfPlylBlUdrud/eI6nQ65XA7ZbJZ938MaM/m1qXTwzMwMpqen2e9O54eUGmJR0H6kF8U5qAQz1fUgpg0VR5Nr6lBC0LBA80F7NJfLYXt7GxcvXoTH42EXEWVjy+dkmOsvC29ym9B5p4Yh2WwWhUKBlSG6HCORCLstZ2dnEQgEUCwWYbPZ2AoeFp6EhSIA/DmAe4qi/Evpv/4awO8C+JOjf7/9rIMYDBCQiUIbZNA8ls0aYku88MILWF5eZn90JpPBysoKVwYbZqo3aae0mOVyGYlEAgcHB6yR0DhJK6Pf8fl8uHz5Mt566y1Eo1FYrVZUKhXcvHkTd+7cQSqV6gt8Pi1kFwpph51Op8//RoHK434HADfN0Ol0iEQifRcDaffyJTpK4R0KhfDSSy/B5/NBq9UimUzi9u3b+PDDD8cuvAnypUUvOdWbLkpi8dhsNhSLRaytrfVVShwWZIodVUX0er1oNBooFArHUvPIL0uJOiSMyuUyF7oqFoscBCdSANXFAXCsdTksyC6UTCbDVh/FQ7xeLydR0VkZ1l6U5REJb9K+iZabyWQ4FiIXTiO6rRCCa7CPInhJeBIN/OcB/EMAt4QQ14/e+yMcCu5/J4T4fQAxAL91koHIRasoYk4TIdc0kYU3+aGXlpa4/RKVTqXMvHQ6PdRsN/niIB8XpdnK9CDZ10WHxuPx4MqVK3j99dextLQEg8GAcrmMra0tfPDBB9jd3X3IXHxayJohuXZIgyKQKS1rLnJ6MJmoNA7SMuVM0lG6TkiDdTgcmJ6exsWLF2E2m7n65NraGnOoxy28CfJnDgoyGr/X64XH44HJZEI6ncbBwQH764c5fySYiRJKjSQ6nU4f+0iux2K1WjnQLwdXKRhHWaJ0kVK3K0r/pwJYo6CRylo4ZTAmEgnMzMzws5E2O4rAoOzGJUtbzo4m15mcoSqvP42P5lhuoj7smkFPwkL5OwCPumJ/eVgDIYFM1CeXy4Vms8mbjwqnA+gzo6LRKF577TXW0jQaDfL5PO7cuYPt7W12Z4xS2JD2RfxUomJRENBqtXLt6jfeeANXrlyByWRCNptFLBbD9evXcePGDWSz2aEUDJJrN1AQmMYKgAOc8mdQQJg2L1k9FPgiBtCo2R40n1Rmd3l5GXNzc9BoHrRw29zcRLFYHAsL5nGQtSqZ8kaJHmQ5lMtlLl407HHLe5C+lwORFJwkHrjNZoPRaESv1+PYhpy30Gw22ZIkOikF4YgRUi6XH6qkOGyQ8nBwcMBJReTSI3KC/NzDVNDI50210CkWJFtd8sVN822z2RAKhbjonhCCA7GUjT3M+ToTmZg0AeTHc7vdiEajaLVasFqtzK2t1Wp9bdVmZmbw8ssv4+LFi3C73ej1eshkMrh37x7+/u//HvF4/NjCVicBLRz5i3u9Ht+4fr+fk2NIA7Zardx7cGFhgZNQqCLZxx9/jFu3biGRSLBWfJKxytoLMSTIZzm48QZjCWSiAuCgGAWy5Ma7owQdBJfLhQsXLuD111/nDMZ0Oo2trS1sbW0NvWDVSXCc9k1ZesFgEN1ulxsEDzsjmD4TAFPuyMdOLBP6GRJ45JqsVquIxWLY3NzE6uoqstksuwPInUbWJlH3aO+0Wq2RaZVA/z6mBg+VSgVCCGbOyDkKw3afyA1MKAmLuN5UqphAxcDMZjNmZmbw+uuv4+LFi/B6vVzobHd3l7seDXP9z4QAlyeeEmT8fj/0ej2i0Whf93jKfJyamuIC+TqdDqVSCRsbG7h+/Tref/993L59e+jCm0DNkqmessPhwMLCAux2O6anp9lMdrlciEajWFhYgN/v5xrmGxsbeO+993Dt2jVsbW2xH22YZjW5Uo7zvT3qc0gQkTVEGhsdarlHp4xhHx6z2Yzp6WlOUzaZTCgUCrh79y7zvkddvvZpILunSFBS81qtVotisYh4PM6VAYcNuWQsxZAURYHH44HNZmMrttc7bKBL/m2qx7K3t8eW6qB7jHjf7XabGUwyV3zUVhBdFhRUJQuAAopUa2SY9Y7kM+BwOBCJRDhoqihKX89OulTsdjv3wF1cXITL5UKv18Pu7i5u3bqFWCzGWZjj9oGPBTJ7otvtcoKB3DuObkbZz0fpvnfu3MFHH32E27dvY3t7e2TCmzTYZrOJfD6P/f19BINBRCIRuFyuPmoTmXpUdKlYLGJlZQXvvfcebt26hVQq1TfOYQpv+esnDfDIDBsym4UQqFarSKVSx3ZPH9a4ZX68z+fD3NwcJicnAQC1Wg3r6+u4ceMG9vb2xl4V70kgx0ZsNhvm5+c5OSqTyTCvf1SFtsjtARwK9HK5DIfDwZcw+ZPJv03Ch3rGPmpsstUm76HjLLlRol6v9/U6JQWDfPOjCKSSNeV2uzE5OQmPxwOj0ciKDFm2ZK1SQSuNRsN5AteuXcONGzewv78/VOoo4UwJcOLLFotFZLNZ2O12AGCtgig4VI+6VqshFothdXUVGxsb2NnZ4QzIcRTJz+fziMfjXGCHEiKo+zwxQZLJJLLZLKfZ3759m/nLo2JRHHcQZQwKdNmPR53USdtIp9NMKRvU0kbhy6W+gxRkK5VK+Pjjj7G1tYVCoXAmfN8EmjeK01BNFDK7yV9M4yYMc/yKovTVq6aCWqTkyFUT6eyQr5tcIY/bg3KhM/lzRxlbon9JCyf3EJVyAB7UFRoW6GKiBhb0otwNm83WVyROrlGu0+nQarWQzWaRSCSwtbWF27dvc7KZ7D57rnzgNGmU7ZfNZrGzs8MNVGu1Gt9sivKgH10mk+EuLKlUijmroxLeBKJTlctlaDQabG5ucjlOKm0rhEClUuHqfXt7e9jZ2cH29jay2exDWZqjwKCAHsSg6S8XD+t2u6hWq8jlcsylJ+bBo1wzwwBZL7VajTnshUIBd+7cQTKZ5AJQZw10+VFVQqrXQQ2DR1W4CnigVMjnqF6v95UmpnmVA9KyW+y4fTgYHHycUjAqULPqRCKB7e1tNBoNtl5H5X+nC5EsfOJxE9OHLGzggTygMsE7OzuIxWLY2dnB7u7uQ022h4kzIcCBw0lrt9uoVqs4ODjAxMQESqUSZ4o5nU5ORiDhfXBwgHQ6PXJtdhB0EGjcdHBSqRQHV4g1cXBwwCY0ZTGOMnL/KMiBtkHIWiSxTigJiiyIwWbRoxDeALjtGyXpOBwO5HI5rK6uIpfL9dEfzwpk5gLRRYl9QNUHqc7MKCC7M2TtcbCaJwDOmqSz8mn78DStHNnt12w2sb+/z2yebreLZDLJ8zrss0QCnHpg7u7uQqPRoFarcXVORTksuUwXInkOqEcvsWbkTPBRuJzOjAAfzG6rVqvY3d3ta7ILHB4WSqunKDjxlce14eQAId3UtHhGo5HrTlALNdJ2TkNwD44beLQ2Lmu/dCkCQCKRYD75KP24tPZU7Ik0SKo9MqqejMMAuVDIBdXr9dj6SiaTfaURRqWFy+srN3IYXG/5Z8/iXMogdyWVhF5dXe0rkSFbhMPA4Nkm4by7uwu73c6uUnKZ1Ot1jiOQtj44rlHGCs6MAAf6tVlauOM24ePYFOMeKy00FdSSf2YcNTqeFse5Vug9uc4HabxEmxq1ywd4cGApiYvGdpoX35NA3gvVahWrq6vQaDRIJBKcXTvOdH/5X+B4IX7WQXNKilq1WmUmjOw2GoUyIcshcpfKGZqDY5Rf4zzvZ0qAyzhrQu/TIG+i44I9Zxk0ThI+RA2jgzLoJx0H5FIE8hjPIugAA+DU6u3tbW6yTXS903KdyeM8j6CzRdbh4P+N6/OJhfNpP3caEOP8YPGYaoQqTg9yFqG8UUdRKOh5BLlQiEZInGFqKEJB67Pmv1dxbnBNUZSrg2+eWQ1cxXhxmu6o5wFkrVBMZNDlp86tilFAFeAqVAwZqsBWMS4Mv5SXChUqVKgYC1QBrkKFChXnFKoLRYWKzziOY1eoLqDzAVWAq1DxGYPMOCJes9wOjkCU0mEXLlMxPDxNU2MNgI8A7CmK8iUhxCyAbwHwALgG4B8qinL2ysSpUKGCQXRHuQCTxWLhDGJZkJfL5b6emsclq6g4XTyNBv4HAO4BsB99/y8A/I+KonxLCPG/APh9AP96yON7LJ4kXfisY7ColIxx8YYfNY+E85RYpeLRkFP+qSQr1S73eDx93aSSySQ3IqBuMnJNnXHsBcp+lKFaAw/wpF3pIwB+HcB/B+C/Eocr+EsA/tOjH/k6gD/GGAS4XDWP6k5otVqueUxp7WetbsagYDyu/dVgeyjqhDOKDi7yPNKBpr5/NBZFUbgC4XHV684iHnURkRCQM+ue9W/T18d9Lzf8pc+jr087iUceI5VEpW7rgUAAoVCI67i0220Ui8W+LuqjqLn9aWOknpRer5eL3VEnoVFV9ztveFIN/H8C8N8AsB197wFQUBSF+grFAYSP+0UhxFcAfOUkg5T+Vt/moy7vDocDExMT3Hopm81ytcDThlzlTwYJa3oeaqJAhYjk/pPDbBwrf6bBYIDBYIDZbObOI9TlhLIIS6US0uk0dwaXzWng9DXy4y7G4+ac+kI+q0AlhYEKq8n9T+Ua6rSu1PiCmkFTRuaoSx0/DnLdcqvVCo/HA7/fj8nJSbjdbkxMTKDRaKBer/c15iaMctxyXXXKaA0EApifn4eiKFxq+uDggK2Bs6xMyDjOypbH/azP8FgBLoT4EoCUoijXhBBvP+0HKIryNQBfO/pbzzzTg4XzyXcXDAYRjUahKApyuRz77sahLTzJmEnLHRQosg/SYDDA4XDA5/Ox1ksdU6jn4DDqq8javslk4upqbrcboVAI8/PzLMCp4wi1qqPfJcsAOF23ynEaMIA+q0LeM9Slnaw04MkFOGmDFosFdrud583hcLDbgdLnCcVikSvVlUol5HI57OzsoFQqnZp1KK+/xWLhdZ+cnITX64Ver+eLhtwmo67/ftwYqfOWw+FAKBTC3Nwcl5c2GAy8L89SWz3CoLUyqEwMniO51suzzOuTaOA/D+A/EkJ8EYARhz7wPwXgFEJoj7TwCIC9p/70Z4AswKl4/vz8PDqdDvR6PZdCHWaXjmcZI4A+9wQJFFos6rlnNBq5k/X09DTa7Tay2SxrwBRwOqnWJl9+dDiCwSCCwSAmJycRjUa5/yR13261Wmg0GmzdUOneVqv1kFUwLmE0yKA4jlFBzyhbORaLhccvd6553LhpzkwmE3w+HyKRCMLhMCYnJzE5OYnp6WmYzWbY7Xbo9Xo+lOVyGdVqFeVymYX3j3/8Y2xubqJYLHJtlHFh8PL2eDyYnJzE1NQUIpEIDAYDms0mcrkcEokEEokE8vk8qtUqC/FRXzqDFrbdbofP5+N+slQLPJ1Oc5nh0xbixwnsQeuarDfggSuPqn4OKkNPi8cKcEVR/hDAHx4N7m0A/1RRlP9MCPF/AvhNHDJRfhfAt59pBE+A424zenW7XW6/VS6XuV/maUEeG5nWFOHXaDQsNGiTWiwW+P1+RCIRzMzMoFKpcBW7TCYz1FrCg+ap1+tlYeR0OmE0GrlUJo3dbrcjEokgm82yQKJNKF9IwOiF+KDvXta25bgI+XbJ5UF7glwb1N7sSQQA/U2Hw4FwOIzXX38d09PTCIVCmJqagt1uZzeKEILXiy44ugTz+Ty3qdvc3EQ+nx+7+U+a7eTkJC5cuICZmRmEQiHYbDasrKxgf3+fG5BUq1XU63UuJXxSTfFxGNRSAfQ1TdHpdDCbzdywmeb7tDAoh+S9SHXsjUYjyyZqswgcWn6FQoFr7p+kd+9JeOD/DMC3hBD/LYBPAPz5Cf7WYyEvrhzg63Q6MJvNfQ0hRtHM+GnGSdq1xWKBz+eDy+XidkzUmJUEvNVqRSgUQjgcht1uR7fbZV+q/NzDGhcJpImJCe5STg2LC4UCALDQs9lsMJvN3MvvuMtkVAf6uPHLLieTycSXo9FohE6n4xe5OCgoazQaWePJZrNciP9xbc4GXXbUJFin06HT6SCbzaJUKvWV3aVuOBRfMJlMMBqNsNvtWFxcRCwWQ6lU4tZ/49IghThsGO1yubC4uIjl5WUEg0Gem62tLcRiMd6f1P1q0AU4SiFOkNvCUYMEalXocDi4L6U8pnFCDrLSObfb7bDZbBxTsNlssNvtcLvd0Gg0sFgsfbXFNzc38Xd/93c4ODg4kZL2VAJcUZT3Abx/9PUmgNef+hOfEscFUeglHxa65UgrPy2/LN3ANpsNCwsLiEajbF6T60Gj0bCgJg3c5XJxNxzqFt5sNjlYc9JxyS85QKkohz1GtVotDg4OIIRg/7jb7Ybb7e7rQzmY1DEOShfNKwlCp9MJl8sFt9vNLApymZCPmjQf2j+pVAp7e3vPpPUqioJ6vY6DgwPcuXMHiUQCFouFg2i5XI5dS1SJkHzks7OzmJubg8/ng9PphM/n4/1AvUdHDVIWzGYzIpEIlpeXEYlEoNfrUSqVEIvFsLW1hXQ63WfW6/V6nqtxabs0pyTsyCcvhOBg+2m7R0kJorMbCoUQjUYRDofhcrng9Xq5FymNlazbdruNQqGAUqkEk8l0bKD4aXAuMjGPM9FlQUJsANLETiMyTYeEhHcwGMTy8jKi0SiEEBwYkg85aYxWqxVOpxOZTIY7mJfL5aFTpehwkHZTLBbRbrfZvUMXoM1mY+ugUqlwMgdRCccpuGW/vc/nQyAQgN/vRzAYZEFoNpvZpCZrR/bjU1C4VCqhVCpxcPhJxk+KAvUGbTQasFgs7IOlrvNUSpYuaKfTyb0x6WuZ9jqo1Y4SZBE6nU5cuHABs7OzcLlc3LR6fX2d9x7NC805xRR6vd5DsZhhj10OkpKFTXuOnoHcE6fBBZeFt9lsRjgcxuzsLGZmZjA1NQWfzweTycQd64lJBgAWi4W18Ha7zS0i5ed+FpwLAS77Wel7AmlmRO8i7Xbci0smlc1mg9/vx9zcHJaWluDz+ZBOp1mAEDvBYrHAZDKx5WC1WpFIJFAsFpHP59mUHdZGpb9BG4i0ml6vx0KFNFbqPjIxMcEt1YrFYl9ASx7TKH2iJEicTiemp6cxNTWFUCiEYDAIvV6PXq/HfntFUWA2m2EwGLg1G9Egt7a2uGs4BREfx0KhC4/cL71eD+VymQNSFBSVL1m6yIFDrYtol/Tzw6SEPglk1kkkEsHly5cRDoeh1Wq50zu5TmhO6HIhV57cCHlwfoYJ+nv0WRRwJhYWxTT0ev1QP/dJIAtvk8kEv9+P5eVlXLx4EdFolLXubreLYrGIQqHAXZj0ej2sViusVisrGrQvRh7EPG0M+txkzZuCMrI522w2mWUwLsgmfjgcxoULF3Dx4kUsLCyg3W4jk8lge3sbiUQCyWQSiqKw28dsNsNsNnM39lwux9H/YSXNyHMHgJOdyN1DmpbVauV/SRBSwCWdTnNj41E2aSXI7ii73Y75+XlcvnwZs7OzCAQCMBgMEEIgn8+zptNoNFjAUo/Sg4MDbG1tcV9KSgJ5UtcU7Su6uGq1Wp/mLAtuOuAajYatsHA4DK/Xi16vh3Q6jWQyyWs7jj1KZ8Tv9+O1117DpUuXYLPZUCqVcHBwgLW1NWQyGRaUg3kW8t7pdDojd6UMukjJ8qPApdFoPBXNWz7jHo8HV69exRtvvIELFy5w7CqVSiGdTuPu3btIpVKo1WqYmJhAKBSC3+9nC7dSqWB/fx+1Wu3EXZrOvAAHjtfA5QmlQAxpYuN2oZC24vV6MTs7i0uXLmFhYQFCCKyvr+PevXusAVarVWg0GiiKAqvVCofDgVarhXg8jrt37yIWi3Ez4WFqarK2TH+XtFubzQan04lgMNgXmAGAXC6H3d1d5HI5ZiSMen4HYwlzc3O4fPkyLl68CJ/Px3TRarWK9fV1ZkxUq1XW2prNJnOwi8UiCyiKQzyNAKWfI/74IGNCDg6bTCYEAgG88MILuHLlCmZmZmC321GtVrG3t4dEIvHQRTgqkNZKVNsrV67A4/Gg2WxiY2MDd+7cwe7ubh+nms6Uy+Xqy6/I5XIA8JDAGaZ7j8Ysv0cWKrn5yC027jNO8+L1erG8vIyrV69iaWkJVqsVtVoN8XgcN27cwNraGrNLhBCw2+0IBAIADueOOtzHYjHW0E9yIZ0LAQ48LMTpkJvNZlgsFuTzedTrdTZ1xwU6wA6HA/Pz8yy8rVYrdnd3ce/ePcRiMaTTafaHGY1GzM/PY2lpCeFwGEajEXt7eygUCn1BpFGBtDKn04lQKIRQKMQcZzoklMiTyWTYIhhFWv9xIOFNiRwLCwt48cUX4XK5AAClUgn5fB6rq6uIx+OoVCq89vRqtVrso5YvnWe1ao7z+5K2Si4wt9uNSCSCpaUl/PzP/zxCoRAzpAqFAgfkxsVfpn25tLSE119/HTMzMxBCYG1tDdevX8fKygqKxSJ6vR50Oh20Wi1cLhdCoRBmZmYQCATQ7XaRSCRY8yXFYrRyvU4AABg7SURBVNTjJ6HWbrd5jvV6PVuP44LMnQ8Gg5ibm8NLL72ExcVF6PV6HBwcIBaL4e7du7h58yby+TznThARYHJyEi6XC51OB8lkEuvr60ilUjyXz70P/FEgIU5BFvJJjutmlvnebrcb09PTiEQicLvd6HQ6SKVSODg4QK1WY9+i0WhEJBLB4uIi5ubmYLPZUC6XkUqlUCqVOMFjVM8gU6CsVitzwaempuD3+wEA1WoVxWIRtVoN9Xp9rHUn5IvZ4/FgamoKU1NTHBCk7MZCoYBcLodyucyBVnpR0tFxGYQnNb9lRUKIwwxPr9eLaDSK2dlZLC0tYWFhgS9xRVF4/YEHbqxBWuywQfsyGAzyeEjR2djYYLcS0QUpyBmJRDA3N4f5+Xn4/X70ej04HA7OZC0Wi6yIjBrke6fnofgM+cTHwYyR96PP50M0GkU0GoXVauW5XFlZwerqKgtlAHyh054wGAxIJBKsfZdKpaHQnc+NAB/UvmUzW06ioADcuMZEppXf70c4HIbT6YRGo0GlUkEul0OlUgEAprl5vV5mAvj9fgghkMlkkE6n+5ImRjVe4IGGS/xVt9sNn88Ht9vNAq9SqXD2HQn9QSriKMZH1gFl4QWDQXg8HqZgUVBVvhSBBz5a+plHadrDGrd8sIPBIBYXF3Hx4kUsLS0hEonA6XRCq9XyeEgjczgcyOVyzAMflTAkOmgkEsH09DT8fj8URUEikcDW1hb74icmJmAymdgam5mZwezsLKampuB2uwEc5gVQjCYWi6FarY6Vfy0TFGgfjoMHTvvRaDTC6XTC7/cjEAjAbrejXq9jf38f6+vr2NzcZIYSAHa1TE9P48KFCwiFQuz3jsViSCQSbGl/ZgQ4cHyWo91u56w7eTHHsbjk+7bb7YhGo/D7/dBqtX3CWwjB9ZaNRiMWFxfx8ssvIxwOw2w2M+e7UCiwb4/+/iggF7KiAKrM5iChSAkzFGitVCp9dTGGPbeDFC232w2v1wun0wm9Xs8XisyNdzgc7B4hZg1R3UYdaKU96HA4EI1GMT8/j5mZGfh8Plgslj4BQ5TM2dlZJJNJPrh0QQ7buiEB53Q6MT8/j2g0yqno6+vr2N7eRqFQQK/X4zIAs7OziEajmJycRDAY5MxcIQTcbjdqtRqy2SysViuKxSLHA0YBWjfaE7RPyY1CgeJRUjHl/UiuvGAwCIfDgW63i83NTdy/fx+bm5useRNDxuPx4MKFC3jppZewvLwMnU6HXC6Hzc1NbG1tcd7AMPbouRLggw9L2poQgrWvbrfbd3jo90YBEnQOhwN+vx9GoxEAeBwulwszMzMcjXY6nbhy5QouXboEt9vN7gnZTTGq4MzghUAblHzd+XweAFh7JVPQ5XLB5/P1FfSXBc4wxkprJZcQJYol+V1lzYvYETLtkfje40jyoLHSRUhJOZ1OB5VKhbU2AvmLp6en0Wq1OCFlZWUFW1tbqNfrAIZrHWi1WnbVhUIhtvRWV1dRKBSY3kaZmfPz8wgEArBarTAajWg2m8xVprkmuu4oLVzZRUVfk/Yts8xkZW7Ubii73Q6v1wuLxYJms4lYLIZCoYDt7W2USiUAh1p3r9eDy+XChQsX8Oqrr+LSpUvwer3I5/OIxWLY3t5mdsqwLu1zJcDlBZOjwoMCe9R+cJmfTFFmShxpNpusJZpMJrhcLgSDQdhsNvh8PiwuLsLpdKLVaiGTySAWi3F236CWCwz38pHnr9vtIpvNcnU3Sioi9wq9AoEAm/kkKIdZiEkWhlTci+iLlUoFyWQS9Xqd68nIWi3NE/2enHkJjO7iJg2/2+2iUChgdXUV1WoVsVgMfr+frRd6PvIvBwIBTE5OssY7MzOD73znO4jFYn0a2UlAe9Nms+HChQvwer3M+b558yZ2d3fR6/W4oNXy8jKmpqYwMTHB5VpbrRazaRwOByfPkNU7DhclzYNOp2NrAABnvI66NC/NIykRlUoFOzs7SKVS0Gq1yOfzSKVSfDYo0SgQCDA5gQT+9vY2fvrTn2J7e5uT54alAJ0rAQ48XNCI/Ih0oGS/KP28jGFpjHJ96ImJCeTzecTjcY6UywFJ0hpdLhccDge0Wi1zlHd3d5FMJjlxR6a4jUoAkSaTy+XQ6XSQTqcBPPCN+3w+fnk8HtZuc7ncUH2PsvAm85NiBa1WiwNmhUKB045l1xm5cshHOtgUY9QgWtj+/j5KpRJ2d3e5kBqlyVO5BK/Xi8997nOcQUo8+/X1daTTaS5iBjz7HpWtGLPZDK/Xy0lN1WqVS8SShRMMBtmnW6lUkM/nuYQD5QKYTCaumTPIRBrlBUmgAnAkKEmBGGUSmQwqb5FOp5HP51moN5tNro5I+9BgMCAQCCAajcLlckEIgUKhgNu3byMWi/F+HqaVfe4EONAvQCl1Xp6UUfu/gQelTGmByQ9G46H6IXQz0wJrtVreEPF4HPF4nKlHMt1tVJo38ECAk/uEqINk1ZDfnv6lWiPDNp9lgUMVBOlzKH2dCn/R+1QPhYpKyWV6B/fBKCFTLUlAZjIZNvXJyiEKGhU1evHFF5nCSewfi8XCvPCTWja036i4khACrVYL1WoVzWYTQhzWaaHMQOJVE2depujRZdput1GtVrkI1zjnmFhmclxjXOtMgXH5LNMLAF8kFAimstA+nw8GgwGVSgVbW1tYWVnhhLNhxzvOpQAHHpT5pOwmeVKO+3oUQQ7a/Pl8njmelEZNApKqp5EprSgKstksdnZ2sL29jd3d3WMzHEcpxMkVQloNfQ4FEMnFQ8JATlUf5rjIv0kBVUo1pnkic7nX66Fer7NPlio7mkwm5v3Lbd/GcbhpHuSKgvSZMleeLIRisQgAzPigYlfhcJippCetTigzsyi4T9mjckEol8vF9WPIZ0+mPSXOOBwOuFwuaLVappXmcrm+wmajhMy1l5N4ZNbRKNeYLgqKaxC3W671TQwtSoYjOqnL5UK328XBwQFu3bqFzc3NkTHMzoUAH/Rr0sEh077T6TxUj5l+Z1SaOC0upWxTVF8WkiSINBoNV9HTaDRIpVJYW1vDxsYG4vH4Q5rNsIWkXKuYhLFca1nmKFOdCTrIGo0GjUajj189LMhxBKfTyfMzKIypmBEAFk4ejwdWqxWNRoPjB6RljlNDHFQW5PdoHxLThCh8xPig5C+3241sNsvBuWG4pmRFgs4KBdzJuiLhSIweKntKl4vJZEKhUMDu7i7W1tawubnJbKBxzS+VSKB9R3TScV3S5CKRWTckxBVF6as/TyU07HY7dnZ2sLm5iVu3buHg4IB99oN5CSfFuRDgdBDocMgEf9IkKEouR8oHaYXDWnBaWOCBIB/Uusi0p1TwcDiMXq+HtbU1/OhHP8LKygri8TjTB4fN7JAhNzqg4J9skg5SIiORCCYnJ2GxWNBqtZDNZpHNZocaPZcpYpT9Fw6HucRpvV5nxkGj0eASstRBxul0ss82n89z8SAqADYqyEF0En7HmfWD/5KrjSoi1mo1eL1eWK1WmEymobFnaG9SU2KPx8PZyvPz81zWlPYD9WKlr4lWWqvVUCgUsLW1hTt37mBzc5Ppb+MQ3oPWBHUMIq131JDXjRQyGhe9J+eAvPjii/jVX/1VOBwObG1t4cc//jE+/PBDbG5ucn/UUZQgeNKu9E4A/xuAFwAoAP4LACsA/i2AGQDbAH5LUZT8UEZ1DGQhTrxf8suR3072T9HvjEooylqrbPbKGq/FYsHly5exsLAAt9uNYrGI27dv49atW0gkElwBbpRBS5nuRj5muYoefbZGo4HH48Hc3BxmZ2cRDAZhMBiQy+XYTy/XQjkp5GelKo7E1qGCU1SkqtlscinZYDAIl8sFRVG4CYFcX2TUzTzo4FIwlZ6FSsmSgKO9KruuZGuDCocNOyWdXE+5XA7JZJKLKFmtVlgsFng8noe41BSDIM2y0WggnU5jfX0dKysr2N3dRSaT6csoHcclKZ8l+f8Gz/Wog6myRU/f07nyer146aWX8Oabb8Lv96NUKuHDDz/ERx99hLW1NaZsjspieFIN/E8BvKsoym8KIfQAzAD+CMD3FUX5EyHEVwF8FYddekYOEuJUMpQEEfDwAtPPD/vzgQe3s+yvowNBHVguXboEn88HIQSy2Szu37+PRCLxUNr8KBZX1qypw47VauXgG/mXKQiztLSEpaUlzM7OcrbZzs4Okskk15oZJnVLFnyKorApSr0l5UvS6XQyFxcAstkstra2+gptjcO0lwOvMldd7rUpj0OO1UxNTWHmKNnHaDSyoKU63Cc95LLftlqt4uDgAMVikeMw1DGGhDWAPv89FQXLZrNYXV3F6uoqdnZ22Poal+uCQHke8ljHXchKvozlcWm1WthsNiwuLuLy5cuYnp7GxMQE4vE4bt26he3tbQ5cjnK8T9KV3gHgFwD83tEDtQC0hBDvAHj76Me+jsNOPSMV4IOCg9gUFPwh7WhckMci+xStViuCwSCuXLmCubk5mEwmZDIZbG1tYW1tra+p7TgEDrE3rFYrH2C5TKfBYIDb7cbnPvc5TE9Pw263o9FoIJvNcuEd8tPLF85Jx04+TnItlMvlPi44cdHlbLxms4lMJoONjQ2+DEkAjqPprswPps5F1G2pUqkwVYwOPgWGvV4vXn75ZbzwwgsIBALQ6/Wo1+t9brRhWDYkwGu1GhKJBOLxOM+l3W7v49PLVkOlUkEikWDN/fbt24jH49zSTE7kGiUGtW+5TysJ8FEE+Z9mbOQ6CQQCWF5e7qtpdOfOHaytrXF3o/+/vfOLbeo6A/jvowsVyh+SUhQSKIyFEiiCsaiaKlT1pdK28sL2MvVpaKrEy1Z1D3vo1Jc+bpM2aZOmSUzr1E3Vqml/1L5M2oaQhpDC1gyKQxyc4JBAnNghjhOHECBw9uD73Z4YO6TEPjd2zk+y7Fwb7vfdY3/3nO98f6p9s1nNDHwvMAX8TkS+DPQBbwHtxpiJ4DOTQHupfywip4BTFZA1XMbYfj7dIX748OEyP2+1/WTFyyqd6Wqbpf3793PkyBFaW1uZn59ncHCQ8+fPMzIy4jQUy76xaDJRW1tb2BdSM806Ojo4ePAgW7ZsYWZmhomJCQYGBkgkEkxPT4fJSZWUW1cC09PToZzalqqpqYnm5uYwNV5EyOfzpFIphoaG6O/vZ2RkZFksrsvrqcXAOjs72blzZ5jUoxtWusxW493d3c2xY8fC6pM6+47H4xWbqem/1S5B169fD6Mh9u3bx8LCwrIUee3PqMZ7cHCQTCYTjr+6zEoVBas2dn6AHQWl77mM94fPbI/+ltra2uju7g43oe/evcv4+Dhnz54Na327+E6uxoB/AegB3jTGXBCRX1Bwl4QYY4yIlJTUGHMaOA1Q7jNPytLSEvl8nnw+Hy7x9AfmCjUuWvJSy4keOnSItrY28vk8sViM3t5eYrHYYxvpVhI7EkfdJFqetbOz85ENOc0w6+vrIxaLMTQ0tOyHXOkYdd3L0LrIms2oG3saWqgZlpr9lslkmJ6edjLDKUavmbpFurq66OnpobW1FREJZ6ua0KNFw1pbW2lsbGRpaYl0Ok0ymeTixYv09vYuqwu9VvT/0PA3rToYj8c5d+5cKKe6W9SIa616Lb+rN5TiMXd5rdVVobXfVU79PrvI9yiWR8scHz16lAMHDrB161YWFxdJpVKcOXOGeDzutGHHagz4TeCmMeZC8PefKRjwtIh0GGMmRKQDyFRLSKV440J9j7dv3yaXy4W9JKsdiWDLY9+ZGxsb2bFjB7t376azs5OlpSVGR0fp6+sjHo8zOzvrrAu5ymfHSGvTA80O1fR/vYaZTIbBwcFw40qNZLX89PaGtG3MdSVlZ2aKSBgquLCw4DRc0Eb3XuyYbQ3Pa2lpCW82GrOuMjY0NJDL5RgdHSWRSBCPx+nv7w/TsSuph31ddZ9odnaWycnJZe3IdEzVjWIb7KgMt55T6/Hk83mmpqZ48OAB2WyWVCpV9TT6UuhNu6mpiV27dnH48GG6urrYvHkz2WyWRCJBf39/eDN2xWMNuDFmUkRuiEi3MeYq8CowEDxOAj8Onj+qqqRF6PI7lUoxODjI3Nwc4+PjYaU017MyTeW2MzNzuRwDAwNhl44ojI4a6Pn5eTKZTPgD1q7Ydu/IVCrFtWvXmJycDLvYFG8aVdrQwPI2eRrzrTHrdmdvjUr5vB11Kimv+ph1s294eJiWlhbu378fpqWri0QN/eLiYjgbTiaTDA8PMzY2RiqVemRfodKy6g1HV6daOMum1Moqihm3fW6deExOThKLxWhqaiKfz3Pjxg2nLkhYXlZWyxxv27aNhoYGZmZmSKVSYUnZ1TbLrhSrjUJ5E/ggiEBJAt8FNgF/EpE3gFHg29UR8VH0Dn3nzh0mJibCO58aHvsiuvwCagEmnVXdu3ePRCIR1spwfWOxDY6WA9XX6XR6mQHP5/PcunWLdDq9rHmxi4w3e6ff3sQqdofZYY9RGBaVV2eHMzMzJJPJ0L3T3t4eZllqX0413tpYWfuialZjNWeSpYzwSn5je0UZ1fXVc6sBn5qa4sqVK+HGuyY8uZ4I2TVmNC5dJ5AjIyOMjY2F+zEu5VqVATfGXAJeLPHWq5UVZ1WyLJsFpdPpMFNQH65DjVQe/YKpnzObzYad5isVZfB50VmtHV6WzWYZHR0N67bozcauNOgi3rdYzuLzFRubKA23LYNeM3VT5HI5hoeHaW5uDmOtNc1fa4zMzMyEm5W6kojCBfS480V9fRX9vmqIqF0CwnU4o2LXyV9cXCSXy5FMJsOMatfN1AHEsauhIiezZ2fF3XhcFjSy5dFyrNoEYdOmTWF/Rle9JFeDvbFpE+WSudYpvqbFm2vl3BOex6PXEqL7jtqRJzt27GDPnj1s3749rAmueRJ2olMV6DPGPDKJrkkDbv1/4XPUszP7pqJyRXEz8Xg8lcUu+9DY2EhzczMNDQ0sLCyEDbV1b6aKv/WSBrwmaqGUYz3NGvUGotmZeszj8dQ2+rvW6Ke5ubllRcqinKjVtAFfr3jD7fHUF7p5rdmgLuPPV8JdxovH4/HUCevBeIM34B6Px1OzuHahzFMoQ7vReBa4FbUQjvE6bwy8zm7YU+qgawN+tdROar0jIp9sNL29zhsDr3O0eBeKx+Px1CjegHs8Hk+N4tqAn3Z8vvXCRtTb67wx8DpHiNNMTI/H4/FUDu9C8Xg8nhrFG3CPx+OpUZwZcBH5hohcFZHhoIt9XSIi10UkJiKXROST4NgzIvJPERkKntuilnMtiMh7IpIRkX7rWEkdpcAvg3G/LCI90Un+5JTR+V0RGQ/G+pKIHLfe+1Gg81UR+Xo0Uq8NEXlORM6KyICIXBGRt4LjdTvWK+i8PsfabnxQrQfwFHAN+BKwGfgUeMHFuV0/gOvAs0XHfgq8Hbx+G/hJ1HKuUcdXKPRJ7X+cjsBx4O+AAC8BF6KWv4I6vwv8sMRnXwi+409TaAp+DXgqah2eQOcOoCd43QwkAt3qdqxX0HldjrWrGfhXgWFjTNIYcw/4EDjh6NzrgRPA+8Hr94FvRijLmjHG/BvIFh0up+MJ4PemQC/QGvRQrSnK6FyOE8CHxpi7xpgRYJjCb6CmMMZMGGP+F7zOA3FgJ3U81ivoXI5Ix9qVAd8J3LD+vsnKF6WWMcA/RKRPRE4Fx9qNMRPB60mgPRrRqko5Het97L8fuAves1xjdaeziHwR+ApwgQ0y1kU6wzoca7+JWXleNsb0AK8B3xORV+w3TWHdVdexmxtBx4BfA13AUWAC+Fm04lQHEWkC/gL8wBgzZ79Xr2NdQud1OdauDPg48Jz1967gWN1hjBkPnjPA3ygsp9K6lAyeM9FJWDXK6Vi3Y2+MSRtjHhhjHgK/4bOlc93oLCINFAzZB8aYvwaH63qsS+m8XsfalQH/L/C8iOyVQmf714GPHZ3bGSLSKCLN+hr4GtBPQdeTwcdOAh9FI2FVKafjx8B3ggiFl4BZa/ld0xT5d79FYayhoPPrIvK0iOwFngf+41q+tSKF1lK/BeLGmJ9bb9XtWJfTed2OtcPd3eMUdnSvAe+4Oq/LB4Uom0+DxxXVE9gGnAGGgH8Bz0Qt6xr1/COFZeR9Cj6/N8rpSCEi4VfBuMeAF6OWv4I6/yHQ6TKFH3KH9fl3Ap2vAq9FLf8T6vwyBffIZeBS8Dhez2O9gs7rcqx9Kr3H4/HUKH4T0+PxeGoUb8A9Ho+nRvEG3OPxeGoUb8A9Ho+nRvEG3OPxeGoUb8A9Ho+nRvEG3OPxeGqU/wOVy4Xz1A6a/AAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAADuCAYAAAAgAly4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9aXBc55Wm+dzc9x1AIrHvGwECIAgCBFdRVGmz7Laq1bbL3VVlR7ijOip6pmcmxl0T0R0T0TMRPdEdM1P1p6bdU6Wuii63SyqPLcmStVAbF4kUAQIgQADEvgMJ5ALkitznB3WvQYmSKBKZAO18IhQkIQD55c17z3e+c95zjpDJZMiTJ0+ePI8esv1eQJ48efLkeTDyBjxPnjx5HlHyBjxPnjx5HlHyBjxPnjx5HlHyBjxPnjx5HlHyBjxPnjx5HlEeyoALgvCkIAi3BUGYFgThX+/VovLkyZMnz1cjPKgOXBAEOTAJnAeWgevAdzOZzNjeLS9Pnjx58nwRD+OBdwPTmUxmNpPJxIGfAd/cm2XlyZMnT56vQvEQP1sCLO369zJw7LPfJAjCj4AfffrPIw/xenny5Mnzu4onk8kUfPaLD2PA74tMJvMT4CcAgiDk6/bz5MmT5+uzcK8vPkwIZQUo2/Xv0k+/lidPnjx5csDDGPDrQJ0gCFWCIKiA7wCv7s2y8uTJkyfPV/HAIZRMJpMUBOFPgbcAOfDXmUzm1p6tLE+ePHnyfCkPLCN8oBfLx8Dz5MmT50EYyGQyXZ/9YtaTmHl+gyAI6PV6ioqKKCwsRKFQEI/H2dzcxO12E4lEyPdnz5MHZDIZBoOB6upqCgsLSSaT+Hw+FhYW2N7eJp1O7/cSDwSPvAGXyX4TxlcqlSiVSuRyOXK5nFQqRSwWQ6FQoNVq0Wg0AOzs7BCNRtnZ2SGZTOZsnVqtlurqatrb22loaECr1RIMBpmammJoaIiJiYmcredBkcvlqNVqLBYLW1tbxGIxUqnUfi8LmUyGSqVCr9ej0+kACIfDhMNh4vF4fmP8CgRBQBAE5HI5CoUCuVxOOp0mGo3uy7VTqVQ4nU7OnTtHc3Mz8Xic27dv88477xCJRIjFYjlf02cRBAGZTCb9p1KpMJvNCIJwz+/PZDIkk0l2dnbY3t7ek+v6SBlw8SbbfeFUKpX0/y0WCxaLBb1ej0ajIRKJsLm5iV6vp7KyEqfTSSaTYXl5mYWFBdbW1tje3s7JujUaDcXFxZw6dYqzZ89y6NAhdDodgUCA0dFRdDods7Oze2rAxRtprx5AcRMqKiri6NGj9Pf3SyeH/TbiGo0Gh8NBfX09VVVVpNNppqenuX37Nh6P58BvjPuF+CwplUoUCgU6nQ6j0YjBYCAajbK0tMTOzk5Ojbh4n1VUVPCNb3yDrq4u4vE4H330EZOTkywtLe27AZfJZGg0GtRqNSqVCrVajcPhoL29Hblcfk8jnkwmCQQCrKysMDw8vCeb44E34DKZDLlcLhlrrVYrXTStVovdbpe+t7q6mpqaGpxOJ0ajkfX1dYaGhnC5XDz99NN0dnYSi8V48803+fWvf83ly5ezbsAFQUCr1VJeXk5fXx///J//c2pra5HL5WQyGQoKCigrK6O0tJTXX3+deDxOKpV6qA9WfCBVKhWZTIZwOLwnD6BSqcThcHD8+HF+/OMf8+/+3b/j2rVr0pr3C9Fb6+7u5vvf/z5PPPEE8Xicn/3sZ7z44osEg8G8Ab8H4mnKarVis9kwGo04nU5KS0txuVysra3x5ptvsrS0RCQSyem6dDodTqeT2tpalEolGo0Gp9NJYWEhGo2GYDC4LycDQRBQKpUYDAZKSkooLCzEZDJhtVppbW3lRz/6EWq1+p4/u7Ozw8LCAleuXOEv/uIvmJmZIRaLPVQ46EAbcJlMhs1mw2q1otfrKSsro7m5mbKyMgoKCnA6nRw58pviTtGbAAgGg8zNzVFXV4fD4aCmpoatrS1mZma4ceMG09PTbG1tZXX9giBgMBhoamrimWee4Tvf+Q5lZWVS7HtnZ4dEIgGA3W6ns7OT4eFhPB4POzs7D/zBGo1GioqKqKioIJ1Oc+nSJeLx+EO/H6VSicViobq6mrm5OSKRyIGIRZaWlnL8+HG+8Y1vcPr0aQRBIJPJ7NsDvjsMIZPJJG8smUzetZEIgkAymczp5ieuTwyDVVdX8/zzz3P48GHKysqwWCyo1WoEQWBpaYmCggJeeuklRkZGcnY9U6kU4XCYlZUVJiYmMJvNaLXanLz2VyE6YydOnOD8+fPU19djNptRq9XYbDaUSuUX/qxaraa6uhqz2YxKpeI//sf/yNzcHNFo9IGfowNrwGUyGS6Xi2eeeYZTp05RUlKCXq/HaDRKRxe1Wv25DzaTyZBIJJiamuLtt98mEAggl8tRqVRsbW2xubnJxMQEa2trBAKBrK1foVBgMploa2vj+eefp6+vj+LiYpRKJYIgEAqFmJmZYXl5mUwmw1NPPcWf/dmf8fbbb/Phhx8yMDDwwOvT6XSUlpbS0dFBMpnk6tWre2LARc+oqKgIu92OSqX6wnhfLtFqtZjNZiwWy10htVyjUCgwGo3U1tZy7NgxqqurKSoqwmKxIJPJuHbtGsPDwyQSCTQaDUqlkv7+fubm5nJ2QtDr9dTV1dHZ2Ul7ezttbW2UlZVhNptJp9PE43Gi0SgajYaioiK6uroYHBxkeXkZv9+fEyOeTqdJJBIEg0G8Xu++h+d243A4OHv2LN/+9rdpamrCaDSiUCikU++XIQgCCoUCm83G2bNnee211/B6vSQSiQd+Pg+sAYc7xthut1NfX09tbS0ajeauODjc+bDFi6DRaNBqtaTTaebn57l06RKhUIhMJkM6nSYcDhOJRPD7/Xd5v3uNRqPB5XLR09NDT08PfX19VFZWSuuHO95sJpMhGAyytbVFKBSisbGRtbU15ubmGB0dfeDXNxqNlJaW0tTUxNLS0p4YWZlMJh1rm5qapETMzs7Ovj5gFouFqqoqamtrKS4uJplM4na7GRgY4JNPPmFzczMnxlHMDTQ0NHDmzBk6OjpwuVxoNBopDCgmsVOpFAqFgmQyiUwmY2Vl5aHDZl+GIAjodDpKSkpoa2vj8OHDHDp0iNraWsrLy1Gr1USjUW7evMni4iLxeJy6ujq6u7spKirC4XCg1+vZ2trKiQEXT9JimHS3UGG/EUMoFosFm82GTCYjHo+ztbXF2tqadPoDpJyC3W7HZDLd9ew7HA6MRqPk0D0oB9aAZzIZQqEQPp8Pr9eL0+kkkUjc9aGmUikikQhDQ0MEAgGsVisFBQVotVoWFxe5desW4XBY+n2pVIp0Ok0ymcza0V8mk2EymWhpaeH555+ns7MTm82GQqEgGo0Si8XQ6/XS6UEQBLxeLzMzMxw+fBibzYbFYkGhePCPRpQqlpeXs7KysicGXKvVUlxcTH19PQ0NDVy8eBGv17uvCUy1Wk1tbS0dHR20trbidDoJh8MMDw/z05/+lJGRETY2NrK2UYsoFAoKCwtpbW3lzJkz/N7v/R4mk4lEIsHm5iZerxeZTEZRURF9fX2o1WrS6TR+v5+1tTV+9atfZTVRqFarKSwspKenh+eee46mpibsdrt0H6ZSKebm5nj33XcZGRkhnU7z5JNPcvz4cUnVI4ZVcoFovE0mEw6HA7lcLn1drVajVCql5z/XRKNRFhcXmZmZwWAwABAKhVhbW2NoaOguA65WqykoKODw4cM0NTVJHno6nWZnZ0dScD3M536gDXg4HObmzZsYjUY2NzeBO/HOlpYWzGYzkUiE2dlZ/vIv/xKv14vJZKK8vJy6ujqmp6clDzGX6HQ6XC4Xhw8fljyYTCaDz+djcXGR6elpjh49itVqJRgMsr6+ztjYGGazmZaWFlQqFSqV6qG8DoVCgUajkeR0e0FhYSHd3d2cOHECnU7H6uoqoVCIRCKxb7Hm0tJSnn76ac6cOUN9fT1arZa5uTnee+89+vv7WV9flzbtbCGXy7Hb7XR0dPDYY4/x+OOPU1hYyMzMDFeuXGF0dFTaRJ9++mnOnz9PQUEBMpmMSCRCMBgknU5n9RpaLBYaGxs5e/YsJ06cwGQySQ5CMplkc3OTn/70p3zwwQe43W5sNpsUvtstIsgVuxOFopcLSEquoqIitre39yUHs729TX9/P+FwGKfTCSCdRhcWFu4y4EqlErvdzje+8Q1KSkqkUFokEmFsbIz5+fmHTrAfWAMOd26usbExvF4v169fJ5VK0d7eLh3xdnZ2eP311/nwww8JBoMolUrMZjNFRUVZDZF8ESaTiY6ODk6dOsVTTz2Fw+EgkUiwtLTEtWvX+OCDD0gmk2xvbxOPxxkfH2d0dJSFhQWSySQ/+MEPKCkpobq6GpfLhdfr/dobkF6vx2q1YrVaJd37Xr23iooKqqqqiMfjjIyMEAwG9837lsvl9PT0cOrUKZqamjAYDPj9fgYHB3n77bdz4nkLgkB1dTVPPPEEp0+fpqWlBavVys2bN3nxxRcZHh5mdXWVRCJBWVmZJD2DO17b0tISFy9eJBaLZdWAFxUVSfFuu90u3YN+v5/l5WXefPNNfvnLX7K2toZaraakpASDwbBv+Q3RQ93c3GR2dhaXy4VSqaSwsJDHH38cv99PMBiUJI65JBaLsbq6isfjucujTiaTn5M2arVaEokEsVjsLklvNBplenoat9v9UGIFOOAGHCAQCBCNRlldXSWdTqNSqWhpacFut6PRaIjH41JIJBaL4fF4pGRLLo2LXq+nqamJvr4+Tp06RUNDA/F4HI/HQ39/PxcuXOCDDz7AbDazubmJ3+/H7Xbj8XiIx+Osra1JssKmpiaOHDnC6uoqKytfr8Gjw+GgtLSU4uLiPTPgYvLSZDKh0+lIJpPMzs7umwpFjMefOHGCqqoq9Ho9oVCIqakprly5wsLCwp4kbb8MMZ799NNP8+STT1JaWko8Hufjjz/m7bff5q233iIQCJBIJLDZbBw5coT29nbsdjuxWEzy0MfGxrIeo49Go2xsbDA1NUU4HGZzc5ONjQ3cbjcLCwtcvHiRlZUV4vE4er0ek8mE0WjM6pq+jHQ6LZ2uL1y4QGdnp6RPb2hooKamBpPJJIVW9mN9sVjsS7XoRqORkpISOjo6aGpquivsGwwGuXbtGoFA4KFt1IE34OLFEo/qHo+H1dVV/H4/lZWVNDU1YTabicfjJBIJUqlUzr1CQRCoqqqiu7ubw4cP43K5iEQiLC8vs7i4yMDAAFNTU3g8Hra3t9nc3CQWi0lxMJlMJj3ESqWSoqIimpqauHz5Mqurq1/LO7PZbDidTmw2G8CeVCGazWZKSkooKChAo9EQjUbx+/0kk8mch0+USqWk9GhtbcVms5FIJFhdXWV0dJTh4eGsVl6KCcHy8nIee+wxnnjiCaqrq9ne3mZ8fJyLFy/ywQcf4PP5SKVS0jG6tbWVsrIy0uk0y8vLDA0N8fHHH0shlGzi8XgYGhoC7nyWy8vLeL1e/H4/Pp+P9fV16RSgUqkwGAxSfHe/SCQSeDweRkZGpM1YlD+KIcb9VEDd6/4SBEHShJeVlUlqn5qaGslbj8fjeL1eBgYGCIVCD/3ZH3gDLiK+Ua/Xy/T0NOXl5RQXF9PS0kJVVRXJZJJQKCQVleTKMxQEAZVKRUdHB8eOHZOKdKanp7ly5Qrz8/NMT0+zurpKLBYjGo1+qTxQJpNJu7der//a6xFvIIPBQCKReOC+Ebv1zOXl5TQ3N1NcXIxMJsPr9RIKhbKqnLgX4kmgvLycs2fPUlFRgVqtZmVlhenpaYaHh5mdnc16zLu4uJgjR45w9uxZmpubicViTE9Pc+3aNa5cucLMzAyZTAadTofNZqOqqoq6ujrMZjNer5exsTEGBgYYGRnJiUImEAgwPT1NKBRCrVazubkptRgQr5UovzQajdhsNsxms3SKzeXzJCKGGjY2NkilUnfFlvdburr72di9kSgUCurr62lubqauro6amhpJHQV3TkI+n09y7PbC0XhkDLjI2toa/f396PV6nE4nvb29nDx5EqVSidvtZnt7m+3tbUKhUE7WI5fLMZlMnDt3jt7eXpRKJQsLC7z33nu8/PLLuN1uBEH4Wh+WUqlEr9d/pa70XojJS6VSSSQSYW1t7Ws9fLslXHq9HovFQk9PDydOnKCsrIxIJMLExMS+GHCFQkFBQQHt7e1897vfxWazSeGIgYEBBgYGpGR3tlCpVDQ3N/PUU09x4sQJBEFgcHCQS5cucenSJcbHx0mlUuh0Oqqqqqivr6ejo4PKykpSqRTj4+NcvnyZa9eusbq6mtW1iogx791Vx6LEzWw232WESktLKSsrk2LlYj+ZbMfpv4z9Nti7EfXeZrNZyjOJpfMqlYrz589z7tw5KisrsdlsUlVmMBhkbW2N2dlZbt68uWeqo0fOgKdSKclAJpNJOjs7+ZM/+RPOnDnD7Ows4+PjfPTRRwwPD2f9iC+Wybe0tHD06FEKCwv55JNPePXVV/nFL37B4uJi1l77q0ilUoRCIRYWFj4XUhKz+rsb8ezWqGo0GgoLC2loaKCvr48zZ85QU1NDPB5naGiIl156SQqh5ApBEDAajdTX19Pd3U11dTUKhYKxsTEuXrzIhx9+yPj4eFbXIJ6O2traOHnyJHq9nv7+fv7rf/2vXLlyhfX1dZRKJSaTibq6Ov7Fv/gX9PT0UFJSgkKhYHh4mLfeeov33nuPmZmZrK71ixCLSURlSl9fn6RVz2QyOBwOqqursdvt+P1+RkZGGB0dlQrOco1Yw7H7tfdzIxHltMePH+fUqVOUl5ej0+mk63r48OG7eqFkMhlisRi3bt3iF7/4BVevXmVqaopAIPC7acABKel35coV/sN/+A/8q3/1rzh69ChdXV2sr6/T0tLCSy+9xNDQENvb21kzNHK5nKKiIv7kT/4Ep9PJ+vo6t27dYnR09IG8q88WKT0Mu6VYu3+fQqGQesUUFBRQUlJCUVERJpMJjUbDqVOnMBqNUjc6sd2AmGX3+/1MT0/nPM9gt9s5efIk3/72t3nsscdQKpXcvn2bF198kUuXLjE/P5/1xKV4TfV6vRQj/uUvf8nNmzelRKVY4VhbW0tRURE6nU4q2hkbG2NkZCRnxUWfXbtCocBut9Pe3s7p06fp6emhpaXlrntOlA0mk0kuX77MX//1XzM+Pp7v5ghYrVY6Ojp44YUXOHv2LHa7XdKki3y2fiOdTrOxscHVq1e5cOECU1NTe5qj+UoDLghCGfC3QBGQAX6SyWT+XBAEG/D3QCUwD7yQyWT8e7Kqr0Dc1dbW1njnnXfQaDScPn2a2tpa7HY7J06ckI6xQ0NDbGxs7Hn3MlHW1NLSQktLCxqNhpWVFRYWFh64+53YvyMajeLxeIhGo1/7d6TTaSl5VlRUxD/7Z/+MY8eOSetRKBSUlJRI/SXEzo2ZTIatrS38fj/z8/N4PB7cbjerq6scOXIEi8WCIAiEw2FJMZMLBEFArVbT2trKt7/9bY4dO4bVakUQBDY3N1laWsLj8eSs2VIqlSIejxOLxdBoNDz77LO0tbWhUqmwWq1S5aLYzliUMkajUWZmZpifn5eKy3KBmHQtLi6mu7ub3t5eSktLKSkpweFwkEwmWVtbkzxJhUIh3YfiSUyv1+d7cHPHYdNoNFLzL4PB8Dl9/Gc7gMpkMqlauKSkhLW1NTwez56t6X488CTwP2YymRuCIBiBAUEQ3gH+CHg3k8n8e0EQ/jXwr4Ef79nKvgKxCnN+fp4333yTWCyG2+2mrq6O4uJienp6iEajyOVyhoaGmJ+f39PXF3uduFwu7HY7mUyGhYUFlpaW8Pvvfx8T+2dUVFQgk8kIhUIsLi4yNjb2QKXLm5ubzMzMSEqWuro6LBaL9PCJXpgo1RKLEAKBAJubm/h8PjweDxsbG2xubpJIJKitrZXCUeFwOKed4GQyGQ6Hg8OHD0sKH6VSSTKZZGpqKqftbEXHYX5+ntHRUdrb22ltbaW6upqdnR12dnakIo1IJEJVVRXFxcVotVo2NjZYWlpia2sr6ycFEUEQMJvNVFVV0dHRwblz56irqyMSiUjJNLGY7Omnn5ZCPTKZDIVCQVFREZ2dnWxsbBCJRNje3t4X3f/uE6QYShPDPrlEVJDcvn0bp9OJwWCQZgrsTrBmMhkpf2S329HpdBQUFEh/30u+0oBnMpk1YO3TvwcFQRgHSoBvAmc+/ba/AT4ghwYcfhPnvX37NvF4nLm5OY4cOcLjjz9OY2MjmUwGpVJJLBZjeXl5z3tti4k+UY8+Pz8vPaT3g2i8q6ur6e3tBZAkZlevXn2ghNzCwgLXrl1jZ2eHQCAgFROJN5hY3r2+vs7y8rJkqDc2NohGo4RCIaLRKNFolGQySVVVFQ6HA4VCISXCcvkQq1QqysvLaW9vp7CwUCpDj0QiUrVlroo5xH46w8PD2Gw2SRGTSCTwer0sLS0xPT3NxMQEqVSKf/yP/zFmsxm487mIa81VPxGj0UhNTQ3Hjx/nzJkztLe3s7GxweDgILOzs1JBik6nk1o+iL05kskkTqeTkydPsrW1RSKRYHp6mkAgID1H94pPZ+N9iH9mMhnkcrkkkxWbqeXKmRAdxgsXLhAIBNBoNHi93nt2E3S5XDQ1NXH06FHq6uqkBnx7rV3/WjFwQRAqgQ7gGlD0qXEHWOdOiOVeP/Mj4EcPvsSvJhKJMDk5idvtJhgMUl1dzZEjR6ivryedTrO+vs7IyIhUDLQXfHawRDgclgpz7ueILJPJsFqt1NXVcebMGZ588kkikQjXr1/n0qVL3Lp1i2Aw+LXX5ff7GR0dleLxFovlnt/n9Xrxer0EAgFCodA9VTt6vZ7y8nJqampIp9Osrq6ytLT0tdf0oKhUKmw2G83NzbS2tkqNysLhsDTFSCyEyhXiZJhgMMjy8jJ2u12Sa3q9XtbX1/F4PFRWVkobfDKZZGVlBZ/Pl5MwhBh26u3t5dy5c3R3d1NTU0MqleL69ev88pe/ZHFxkXA4jEaj4YUXXsDhcNzVsTMYDOJyuWhoaEAul1NTU8PQ0BDXrl3D5/NJOZFIJJJVxZdonHc3iBKb242PjxMMBnM23CGRSLCxsSF99gqFgmAweJccU6SgoIAjR45gtVqpra3N2pru24ALgmAAfg7895lMJrD7WJPJZDJfNLA4k8n8BPjJp79jz7dKQRCwWCy4XC5Jcyt6PWIbWYVCkVUpkjjlRzTeX+WhGo1GysvLaW1t5ciRIxw9epRYLMbf/M3fcOXKFcbHxx+q81soFCIcDku9Gb5ozbv/vBcymQyz2YzZbCYQCHD79u2sKz1243A46O3t5amnnqK8vBy5XI7f72dycpKXXnqJ+fn5nE+LEcNI09PTzMzM3HPqkV6vx26343Q6MZvNuN1uZmdnJU1zNhFDe52dnfzgBz+gs7MTQRCYnZ3lxo0bvP7664yNjaFWq6mvr6enp4c//uM/xm63SxK30dFRNjc3qauro729neLiYo4dO0ZbWxsdHR34/X6pqdPIyAiffPJJ1t7Pzs4OU1NTUkhCEAScTift7e3SRrq2tvbVv2iPEB2I2dlZ4IufH0EQ8Pl8D5TH+jrclwEXBEHJHeP9d5lM5v/79MtuQRCKM5nMmiAIxcBGthb5WXbrlAsKCmhubqalpYWysjLKy8tpaGhAEAR2dnbweDysra3hdrv33PvZnb0XPYEvew25XI7D4aCtrY2jR4/S3NyMy+UiHo/z+uuv8/LLL+P1eqXK04fhfgz0/SC+R7Gowu12P9Tv+zo4HA66urro7e2V4o3z8/NcvnyZN954Y18Ta180MEIQBCm0J8ZGxRBetj1wpVKJzWajoaGBf/JP/gm9vb2Ew2Fu3brF9evXGRwclAyzOJu1p6cHgMHBQS5evMiNGzeYmpoiGAwyNDTE0NAQ9fX1UhfK7u5uZDIZbrcbtVqdVamsuFkODQ1JyimxDXNxcTElJSVMTU1l3YCL8lGxr8lX1T+IEs329nZKS0uzurb7UaEIwF8B45lM5v/c9b9eBf4Q+Pef/vlKVlZ491pQKBQYDAbsdrsUG+3q6pKE80ajEb1eTzgcZmNjg5WVlawfswVBoLCwELvdjtFolDTSouxMPAXo9Xra29t5/PHHaW5ulrL7g4ODvPXWW3sep99LxKq8XK1PrVZLjclsNhtyuZydnR1mZ2cZGhpifX09583K7gdxoIh4z4mGfi825a9Cr9dTUVHB8ePHOXnyJBaLhYmJCcbHx6Uk/uHDh2lsbKSuro7S0lIMBgOffPIJV69eZXh4mMXFRam/fjgcZmtri/n5eclQtra2otPpmJycZHx8nOXl5ay+p1gsxtzcnBS2EU/TBoMBk8kktWTOxilMPMGbTCZqamrY3NzE7XZ/YQm86Fg2NTVx4sQJjh8/Tnl5OfDFG/7Dcj8eeB/wT4ERQRCGPv3a/8Idw/2SIAg/BBaAF/Z8dbsQk4Y2m42ysjKpF0Zvby/Nzc2Sdnn3OKaRkREGBgayHrcVBAGXy0V9fT3Ly8vE43GCwSAymQy73U5hYSFmsxmHw0FPTw+9vb3o9XrW19eZnZ3lo48+4ubNm1ld48Mi3sxfNO9vrykoKKC8vJzCwkJJ2razs8Pi4iKTk5P7PtT2q9iPk4HJZKK2tpYTJ05QU1MjxajhTjvgmpoaDh06RFNTEw6Hg3g8zsTEBL/+9a+l4Re7E3KRSIRIJCIlvNfX11lcXESn0zE1NSVNlMomYghlfX2daDSKSqVCLpdLvf/F8WR7fT/snj7V3NzMkSNHGBoakkYhftaRETtNFhUVSUU+ra2tOBwOyfHJRkuC+1GhXAa+KIB8bk9Xcw/ERKFCocDhcNDR0cGJEyc4evQohw4dwuFwAHcKTUTlxeLiIu+++y6vvfYaExMTWRudJu6qmUwGg8HAqVOnUKlUFBUVMTs7i0qlor29XcpEFxcXS/0wbt++zdDQkNQT46CjUqkwGo2YTKasv5ZcLpfa8jY2NkqqiFAoxOrqKsvLywdWkyxW6zU3N99TJ5xNRAPe3d0N3DEqosctKp5ExZTP5+PmzZu8+uqrvPbaa18aqxWnXnm9XoAN6GgAACAASURBVK5evZqrtwPcyed8/PHHHD9+nLa2NgwGA3K5XHLgxsbGGB0d3XMDrlarcTqdnD59mu9///scPnyYn/70p1Jce7fySRw04XA4OHHiBM8//zy1tbWYTCYpDOTz+aT++XvJga/E1Gq1WCwWysvLef7553nqqadwuVzodLq7JDmifO7y5ct8/PHHTE9P53Raukwmo6Ojg4aGBr797W8TCARQKBQUFxdLXkMikZD6drz++usMDQ0d6LDJbjKZzJ5ViX4VZWVltLa20tzcLHkwCwsLvPPOOwwPD+9ZGXI2EMNm4ji1XJJMJqVmaVarVVoH/GYien9/P4ODg4yOjjI3NyfJRw8y6XRakr6Kz9Nu5ykbWK1Wurq6+NM//VMaGhpQKBS0t7dLBWS7n1mlUonVaqW9vZ2Wlha0Wi1yuZxoNMrS0hIffvghr776KgMDA3i93j1d54E04KLE7pvf/CYNDQ24XC5cLheVlZWSFlicJzk3N8c777zDjRs3mJ+fZ21tTdols/mQx+NxaUDy1NQUDQ0NqNVqDAYDWq0Wm80mxeyj0SgrKysMDQ3x8ssvMzc3h9vtJhAI5FQC9zCIY9rEKSTZRKfTYbFYMJlM0rzGkZERXnnlFW7evHkgY98iYrx7amoqZ9WhIisrK7z++ussLy/T1dVFWVkZ8XiclZUVZmZmJIPt9/ulPvuPwv2XTCYZGRmRZp/mole52FJAbFYFSLbos6XwYoMrk8mEwWCQ5hfcunWL999/n4sXL7K6upoVx+PAGHC1Wo3FYqGoqIiamhoqKio4c+YMpaWl0sOs1+tRKBTSDLqJiQkuX77MwMAACwsLbG9vE41GczLmK5VKEQgEmJqa4uc//zmnTp2iubkZu90uCfYDgQCTk5NMTU0xNTXF+Pg4AwMD+P1+EonEI+F5i4g3cy68SrlcjlKplBJW4rVeX1/PaRXogyAacLGlgmjExfmT2Sw6ikajLC8vS3FrsVRe1Kf7fD5pUpU4BOUgX0sRsZZjdnYWj8cjadazSSQSkbznZDJJRUUFer0erVZ7l+cvtlaIx+PSz0xMTEgFXTdv3mR2dlZSr+w1B8aA6/V6ysrKaG9vp6+vj4qKCmpra6UsczKZZGtri3A4zPLyMpOTkwwODnLlyhVpPmM2hxV/lnQ6Le20Fy5cYGdnh62tLSm8Iw6fuH79OqOjo9LpIBejvvYKMXEoaq3FoqVsk0gkPjf0VSwceRQ2vWQyicfjYW5ujqqqKinJXVBQIL2vbBhOMU8Qi8UIBoNS4dPOzo40UPug5g6+DHEA9OzsLAMDA1IB0szMjKRO2WvE8Mf7778vjUwrLi6WpIyxWIxQKEQgEMDn80na+IWFBYaHh5mbm2NlZYWNjY2s9r45MAbcYDBQVlZGW1sb3d3dUq9dcfrL6uqqVAE1NjYmNQaam5vbt7mMyWSSQCDA6OgooVCIyclJLBbLXSGe2dlZVlZW9mXA8sOSSqUkHb1Op7tn9j0biP051tbWsNvtCIKwr/2ovy6ZTIZQKMTQ0JCkmDp06BDNzc2EQiG8Xm/WQhf3M+7rUUO8nhMTE/zDP/wDhYWFKJVKVlZWmJ2dzcpztbOzw/r6OpcvX8bn8xEMBjly5AhVVVUYDAY8Hg+zs7PMz8+zuLjIysoKwWAQj8fD8vIyfr8/Jz16DowBj8VibG5ufm5GoJjBXVtbIxAIsLKywuLi4p7Mk9sLxO6B4+PjOa1SzAWJRILJyUleeeUVSktLcbvdTE9PZ/11fT4fV69eJRAIcP36dZRKJcPDww/UWmC/SCQSfPTRRxQUFGCz2WhtbeX3fu/3CIfD3Lx5E4/H80h6w/tFLBZjcXExZz32xX47kUhE0n/fvHmTysrKuwz40tIS6+vrbG5u7ouDJuTSq/myUnpRLiiXyz93TN/dNEf881Hxxh51xESsTCYjnU5L7WqzjVwulxrji3Hw/ZjB+TBotVqOHj3K+fPnOXXqFFqtll/96lf86le/Ymxs7JE7kf0us9s2iYVD4vOQo1zCQCaT6frsFw+MB757/l6eg4NYWZhrfhvuhZ2dHUZHR4lGo2xvb3Py5EnUajVarRalUpk34I8QoqE+aBwYA54nz28b4pCM27dvk0gkJInr2traI5PIznOwOTAhlDx58uTJ84XcM4SS25EWefLkyZNnz8gb8Dx58uR5RMkb8Dx58uR5RMkb8Dx58uR5RMmrUPLkyQPc0d4bDAbMZjN6vV7qOfQotC/4XeXrzMSUA/3ASiaTeVYQhCrgZ4AdGAD+aSaTOfitzfLkyfM5FAoFFouFlpYWurq6aGpqYmhoiL/927/NWj/9PA/P1/HA/ztgHBA7+v8fwP+VyWR+JgjC/wP8EPjLPV5fnjx5ckBfXx8dHR10dnbS1NSEyWTC4/GgUOQP6QeZ+x1qXAo8A/zvwP/w6ZzMx4DvffotfwP8r+QN+J7gdDqpr69Hr9czMTHByspKVpofKZVKDAYDFouFwsJCysrK2NrakgY0iz3PvV7vgaxCy/PgiC0STCYT3d3d/P7v/z5tbW0UFBSQTqcZHR3l6tWrv1VNsX4bud/t9f8G/mdA7KRuB7YymYwYHFsGSu71g4Ig/Aj40cMs8gt+LwqFQppbt7a2lpPuX9lEEARsNhsdHR2cP38erVYrNfnaawOu1+spKSmhoqJCapTf2trK2toaHo+HcDhMKBSiv7+f/v5+IpHII9WHZK9QKBRS+Tvc6VuvUCik4dripPJ79cMQx/yJI7gOyr0pzm90OBw0NjbyB3/wB3R3d6NUKgmHwywtLfHRRx8xODi4bwZcJpOh1WpxuVxotVo2Njbw+XyPxACKXHI/U+mfBTYymcyAIAhnvu4LZDKZnwA/+fR37ZkFUCqVGI1GampqOHbsmDTVPddTUPYKcdJ2S0sLPT09dHV1EQgE0Gg0WRljZrVaaWtr48iRIzQ3N1NWVkZFRQU+n49AIEAsFpMmiCwtLbG2tib1Bf9dQZyyIk4ikslkWCwWNBoNBoOB0tJSgsEgW1tbxOPxz51SotEoXq+XjY0NNjY2pJmI4nDb/bqWCoUCm81GQ0MDZ86cobe3l+LiYqanp7l9+za3bt1iYGBgXxOYCoWCoqIizp8/T2FhIVeuXGFwcBC/339gNsKDwP1OpX9OEISnAQ13YuB/DlgEQVB86oWXAivZW+bdiB5ESUkJTz75JE899RSTk5M5GaWWLVQqFZWVlTz22GOcPn2akpISlpeXCQQCWQlfmEwmmpubOX36NIcPH5Ym7VgsFul7IpEI0WiU6elpdnZ28Hg8j6wH9NlN8H7uEaPRSGVlJW1tbbS1tSGTySgqKkKv12OxWGhsbMTr9UrT3HcbFnGY7crKCnNzc9IEd4/HI02O2i/jKA7e7ujo4Omnn6akpAS5XM7c3Bwff/wx/f39TE5O7utnrVarKS8v57vf/S6VlZUIgsDa2hqhUOiRMeC77znx7+J9t1c26n6m0v8Z8GefLuIM8D9lMpk/EAThZeD3uaNE+UPglT1Z0X0gekKdnZ3823/7b/F6vRQWFmIwGNje3n7kGgUJgoDdbud73/sezz77LGVlZfh8PiYnJ3G73Vl5P3Nzc9y+fZv29nYaGxslAy4OL4Y77VDPnz9PPB4nmUxy48YN1tfX93wt2UBsQyuG2lQqFTKZTOp6mUgkvtJAVVdXc/78eZ577jmOHTsG3P0AptNpTCYTVVVV0s+IrY7FtqOCIBCPx3G73Vy7do0LFy7Q39/P/Pw829vb2bsAX4AgCGg0GgoKCqipqeHQoUPAndOCz+djeXmZ2dnZff2cxcHQVquVqqoqTCYT1dXV1NXVsbKycuC7OCqVSunzF9vQinM1xelSezWl52FSzD8GfiYIwv8GDAJ/tScr+pqIcWOHw4HBYECpVD6SBlyj0dDU1ITNZiMcDjMxMcGHH37I/Px8Vt7Pzs4ON2/epKCgAJVKxblz51AqlWxubqLX66VhrhqNhqqqKhoaGlhYWHgkDLhSqcRms6HRaLDb7XR3d/Pss8/icrnY2tpiYmKC999/n5dffvlLf4+YTK6urr7r6+L4vNXV1buMiTgVfnt7m9LSUvR6PQUFBdjtdkpLSyksLESr1Uo/vx8G3Gg00tvby3e/+11Onjwpff3P//zPeeONN5icnMTv9+d8XbvJZDLE43G2trZYW1tDr9ej1+sxGAySITzInD17lpKSEiwWCw6Hg/b2dpqbm6Uxi5988gk//vGP98SIfy0DnslkPgA++PTvs0D3Q6/gIREE4a5G6wcJg8FAXV0dzc3NeDwerl69SjAYvCskIsYju7q6qKioIJVKcfv2bd58801mZ2ezdszOZDKsrKwwNDREYWEh7e3tFBUVEYlEUKlUqNVqAOnoOjk5icfjycpa9gKVSoXVaqWmpoa2tjZaW1uxWq0YDAYKCwspLy9Hr9dLk5zuZ7LQ7du3eeWVV5icnMRoNLK1tUU6nSYejxMKhdjc3LxrcxVnJ8bjcQwGAzqdjjNnzvDEE09QUVGBRqPB5XJRVVXF1NQUCwsL2bwkn0MQBEpKSujo6KCiooJ4PM6lS5d44403ePfdd1lYWDgwk64SiQRut5uPP/6YsrIyLBYLdrv9wMkaNRoNNpuNoqIiCgoKpDCo0+lEp9Oh1Wqx2+1YrVYymQxmsxmNRsO/+Tf/hr/4i79gY2PjoZ7xg3U1HgJx4O5BMeIymYyCggLOnj1Le3s7ExMTTE1NEYlE7jLgYjyyt7cXm83G4uIi169f58aNG/h8vqzG88PhMKurq1LiSqvVolKppGnw4uSRcDiM3+8/kEfXiooKCgoKcDgcuFwuGhsbaWxspLa2FoPBQDqdJhAIsLS0hN/vx+PxMD8/z/z8/Ff+brfbTTKZZGVlBZVKxfb2thSCEYfafjbuLf6nVCpxuVwcPnyYVCol3ZficOZcnxI1Go1kXNrb29FqtczPz/Puu+/y5ptvsri4SCQSOTBVl6lUSuqlnkqlcDqdlJeXYzKZ2NjY2BdZq0KhwGw2U15eTkFBAUqlEp1OJxlw0VEoLy/HarWi1+tRqVQolUpp45HJZBQXF3PixAlefPHFh3aKfmsMuFqtlmJPBwFBECgsLOTkyZPU19eTTCax2+13NfMXQycul4vu7m4MBgPT09MMDQ0xOzubdUVNKpXC7/czPT3NlStXMBqNVFVVSSPURORy+YG6tnDnQTAajXR3d0sqmqKiIoqLi6UTRCKRIBAIMDExwdzcHFNTU6yurkqJx68iHA4Ti8XweDzIZDJJUifGv79oxJtCocBqteJ0OqXcjFwuZ3t7m4WFBZaWlvD5fHt+Tb4IuVyO1Wrl2LFjPPPMM1RUVBAMBhkbG+PixYvMzMwcuOR/Op2WHIx0Oo3T6aSqqoqCggIWFxdz7kyoVCpsNht1dXWcOHGClpYWNBoNarUavV6PyWRCr9ezs7NDOByWwkA6nQ6NRoNer5ciBWJoby9OE4+8ARdvOqvVislkQqVS7fOK7iCTyTAYDJSVleFwODCZTBgMhruMoEqlwmKxUF5eTm1tLQqFAq/Xi9vtJhgM5uQoGw6HmZ2d5Y033mBra4sf/vCHaDSau66jy+WioaGB1dXVfY+Pwm96dpw4cYJvfOMb1NfXS+oZv9/P9evX8Xq9Ujx6enpamnK/vb193xPuxbFu96uFFsN5VquVJ554grNnz3LkyBGsVivpdJrr16/z1ltvMTQ0xMbGxkNdg6+DwWCgsrKS48ePc+zYMcLhsHTqmp2d/ZzxFk8L4glsPwz7Z5N9JpOJ0tJS6urqmJycvO/PcC+QyWS4XC6OHTvG8ePH6e3tpbKyEpVKJSUqxWT1f/7P/5nFxUUUCgVGoxGr1cqhQ4fo6upCr9cjk8lIJpP4fL49Oe08sgZ8t5pAqVTidDqx2+2SmmI/UalUOJ1OmpubMRgMRKNRtra27oovymQy7HY79fX1dHZ2SsUKS0tLbGxs5PyILYYK7vW6BoMBu90uFbPsJzKZDKvVytGjR/njP/5jSkpK8Hg8DA8Ps7S0xMLCAkNDQ/h8PqmaNBwOZ30zVKvVWCwWiouLOXz4MD/84Q9pbGzEZDIRi8W4efMmP//5z7lw4QIbGxs5k+iJeurm5mbq6uowmUx4vV5WVlZYWloiGAzeZQiNRiN2u52CggLUajWRSIT5+fmcnhjuhUwmk4rP9Ho9Xq83ZwZcqVRy+vRpnn32Wbq6uigqKkKpVJLJZNje3mZtbY2FhQVWV1f5T//pP+Hz+RAEAavVSnNzMw6HQ9L9R6NRlpaWeOWVV/ZE0/5IGvB0Ok0ikSAUCrGxsUFxcTEGgwGtVrvvSQ5R4tjW1sb58+fR6/WMj48zPDx8l4G02+0cOnSIvr4+Ojs72dra4s033+TatWssLS1lvQJOqVTicDioqKigtraW5uZmysvLqaiokDwFEY/Hw8LCAltbW1ld0xchCIKk6BDjjc3Nzeh0Ovr7+7l27RpjY2MsLS2xs7NDLBYjlUpJD3i246VqtZqKigoOHTrE0aNH6ezspKOjQ3ImAoEAV69eZWhoCL/fn9M4s0KhwG63U1ZWht1uRxAEYrGYlA8IhUIAklEqKyujubmZQ4cOYTab2d7e5saNGwwPDzM1NbWvxVy7vd1coVAopFBoS0uLFPpIJpO43W5GRkYYGBjgxo0bLC8v3/WM6/V67HY7lZWV6PV6UqkUGxsbDA0N8ctf/vJ324CLlYIrKysUFRVJH+5+IsZlS0tLaW1tpa6uDr/fz0cffcTAwADb29uk02k0Gg3Nzc309vZy9OhRCgsLmZyc5OWXX2ZycjInZetGo5GOjg6piVFpaSlGoxGj0fg5qVYoFJKKpHKNmCeorq7m2LFjVFZWIpfLuXXrFm+//TYTExPMzMxIYaf9MC5Wq5XW1lbOnj3L6dOnKSgoQKfTIQiCtJGkUinUajVmsxmFQiElMrN9MhATb06nE7PZTCaTIRKJsLm5id/vlxKubW1tOBwOqqqqaGpqoqWlBaPRSCwWo7W1latXr/Lf/tt/Y25ubl/j5WJyPReI5fwtLS00NDRIictEIoHP5+PatWu89957DA8PMz8/Tzgclk5WCoUCrVaLzWbDYrEgCAKRSITl5WXGx8dZX1//3Q6hpFIpdnZ2JKO434il8FVVVXR2dtLV1YXRaKS/v5+BgQGmpqakuF1JSQlHjhzh6NGj1NbWSkUyAwMDkkeUbQwGA7W1tRw9epSuri5MJtMXPhwqlQqdTodSqczJ2nYjk8lwOBx0d3fz2GOPYbfbWVhYYHJyknA4zPr6OsFgkHg8vm9GxeFwUFdXR2trK42NjXc5EoIgoNVqqa2tpa+vj8LCQqnfjFiVmc3712g0UlRUhMvlwmQySYldn89HMBiUEq6tra3U19dTWVlJWVkZxcXFyGQyUqkUZWVl6PV6KeQiltgfpKRnNhDzWF1dXRQXF6PVaqXE/+joKB9++CFXrlxhfn7+rudWzG25XC5JAik2hpudnWVycnLPTjKPrAH/LLsr3/YDrVZLZWUlZ86c4dy5c/T09LC9vc3Y2BjLy8tSMkahUHDkyBFOnjxJc3MzGo2G4eFh3nvvvZyWLqvVajQajaQ4+bLrVlpaSnNzM7Ozs6yuruZsjXAn1FNXV8dzzz1Ha2srMzMzjI2NMTExIfVq2W/sdjsOhwOdTiflZEQjLuY6nnzySdrb2xkbG2N0dJSxsbG73sfukM9eIQgCxcXFVFdXS6Exv9+P2+1ma2uLRCKBTqejvr6e5uZmenp6cDqdKBQKQqEQHo+HZDJJaWkpNTU1vPDCC4yPj+Pz+bKy3oOGTCZDp9PR0dGBTqeTJKljY2O89tprvPPOO1LYbjdms5mGhga6u7tpb2/HZrPh8XgYHR3lxo0bkjRyL/itMeCiXGc/KrUUCgWnTp3iBz/4AUePHqW4uFhax5EjR0gmk1y6dIlr166h0Wjo6uqipqaGZDLJyMgIv/rVr3j33XdzmricmZnhjTfekLrliZWY93ootVotBoNhXxQ+KpWKlpYWHnvsMfx+P+Pj41y/fv1AdUecn5/n+vXrqNVqZDIZVVVVUrhCRBAEnE4nBQUF9PX1SX1S/uEf/oG/+7u/w+1273l8WavV4nA4sFgsklEeHR3lo48+YmZmBoDGxka+973v8cQTT6DT6fD5fExNTXHx4kU++eQTampq+MM//ENaWlrQ6XT78nztl1MmetuvvvqqJBWcmpri5z//OZcuXfrCoqfe3l6ee+45+vr6KC8vJxQKcfHiRV588UWGh4f3tFjqt8aANzY2UllZidFo/Opv3iMEQcBoNHL06FH+5b/8l7S1tWGz2RAEgXA4TCKRoKOjg5qaGk6cOMHc3Bwmk4m2tjYsFgujo6NcuHCBX/ziFzlXnaTTaWZnZ9nZ2WFycpJLly6h0+mAO55HeXm5tNGI73U/HqR0Os329jZutxuLxcKpU6dQKBSkUimGhoYORIfE9fV13nvvPYaGhvj7v/97iouLsVgsGI1GysrKaGhooKOjg8LCQqkVrVKpRKvV8kd/9EdUVVXxV3/1V9y6dWvPpt/I5XKampp4/vnn6evrw2q1MjIyws9+9jM+/PBDMpkMvb29fPOb3+TcuXMYjUZmZma4evUqV65cYXx8nPr6ep555hmcTidut5vR0VGWl5fZ2dnJadhyvz7fVCpFIBDgzTffZHBwELlcTjQaZWNj455GWKFQ0NHRwQsvvCA5cgDT09NcunSJ2dnZPa90fWQNeCqVIhKJsLS0RDqdljzwXKlQRBVHU1MT3/ve9yRVxOLiolTpp9Pp6OnpwWazSRIojUaD1WpFJpPhdDppaWnh2LFjXLhwgVAolNObdWdnR+qj7na7JQ9bEARqamqkI7ZYDmyxWNBqtVlPZtrtdhKJBDs7OyQSCW7dusXLL79MZ2cnJSUl9Pb2kkwmCQaD0ia0n3mQeDyO3+8nFArhdruZn59Hq9VKn3VlZSVzc3McO3ZMqiZUKpVSEVdfXx8TExMkEgkmJyf3xIjLZDIqKiqoqKjAbreTTCa5efMmH3/8MYIg0N3dzalTp+jp6aGgoIALFy5w7do1bt++jdfrpbGxkW9961vU1taysbHByMgIv/71r9nc3Ny3UnvxOudSA55MJvF6vQSDQeA3CrjPXgMx1/H9739f2qwTiQQTExO89dZb9Pf3S6GnveSRNeDpdJpoNMrKygqpVEqqFhTjj7mQjpWUlEiyMbER/sTEhFQgIcZF29vbpWZbCoUCuVxOJpPBYrFQVlZGTU0N77//flbXey/EayhKMsW4rdgNbmtri2QyKYVQxERmNgy4WKFWU1NDeXk5Xq+XtbU1vF4vi4uLUojp8ccfp6GhgRMnTvDaa6+xurp6z17cuUQsOhHL5CORiNSBbnV1VSogCgQCdHd3U19fj8PhQKVSodFoKC0tpampidnZWVZWVvbMgDscDoxGI4IgsL29zczMDGtra9TV1XH48GE6OzspKipifX2dDz74QDrROJ1Oenp6aG1tZXt7m8HBQWnAg1hluB/E43F8Pl/OqzDFz/aLEGPl1dXVnDx5EpfLhU6nY3Nzk6mpKT755BMWFhay8tw80gZ8Z2dH6ougVCqlySkqlSrrH7JarcblctHc3IxKpaK/v5/h4WEmJiaYn5/H4/HgcDgwm83YbDaMRiNms1nyLEUpZDqdlqq49uPBEJsz7U6gqtVq5HK5tG4xdCL2m9lrdhdpfOtb38Llckna+XA4jM/nY2RkBIvFQkdHh1ThajabUSqVB6b/DfzmeoqEQiECgQDBYJCNjQ3JuIvl1HBHL+x0OnE4HHtWiCaG98RnYWNjg9XVVRKJBEVFRVRXV1NaWopcLmdwcJDR0VE2NzcpKSnh0KFDdHZ2kslkGBgY4P3332dwcJDl5eUDcdLJpQd+P4in8e7ubmpqatDpdKRSKWnTvH37dtbURo+sARe9HjHsIAgCKpUKrVaLUqnMugEXdefhcJhXX32VDz74gJGREbxeL7FYTDLKk5OTbG9vS7LHwcFByWvc2tpicXFRGll2UCgrK+PQoUMcOnQIh8PBzMwMKysreDyerBQYabVaqqqq+Ef/6B/xne98h7W1NVZWVqTNIp1O39UQKh6PS0UoiUTiQD3M9yKRSLC+vo7b7Uar1VJSUoLT6cRms0nfk42SdfE0Kk4GCofDaDQazGbzXa2XFxYWaGxspK2tjfLyciorKwmHw1y4cIGLFy8yOjp6IDpRimHTg9JwS0StVuN0Ojl9+rQktd3Y2GB8fJxbt26xubmZtY3vkTXgogcu6oCVSuVdBQtizCpbRCIRxsfHCQaDjI+P4/F47jImcrlcavZfWlqKwWBgfX2d//Jf/gv9/f1Eo1Hi8TjRaDSr2m9xYysrK0OtVrO9vY3H4/nCDU6lUnH8+HFpKhDcGf5w/fp1qYhjrxGnrzz55JO4XC6mpqak1qd6vZ5kMonT6eTcuXOUl5ezvLzMW2+9xdTU1L5NaBGva0FBATKZjEgkQjgc/tLrIzY42tnZuctLz2QyuN1uabLPXpDJZKTfZzabsVqtUltT0TMXw44dHR1861vfQqPRSB0AX375ZV555RUikciBmsK0n1LhzyIWmRUWFlJbW0tLSwtyuRyfz8fHH3/M22+/zSeffLJnwxvuxSNrwJPJJNvb24yOjjI7O4tWq8VsNuNyubBarSwvL2f19Xd2dpifn2d1dfVz47HEZkt1dXV0dXVhs9nw+/2MjIxw48YNZmZmSKfTUn+EbB5LVSoVNTU1PPfcc1itVm7fvs3FixdZXl6WNhyZTIZSqUSlUlFaWkpXVxctLS2YzWYikQgLCwvMzMxkrZFVLBZjaWmJt99+G7vdTktLC42NjdI1Er0ui8VCOBxmcHCQV199VWr3mmsPXCztr6iooK+vj0gkwtTU1JducGJRXw7F/gAAIABJREFUiMvlklQqIrFYjOXlZdbX1/fsJJZKpZiYmMDn81FVVUVNTQ3d3d3I5XKam5ux2+1S6+DOzk5UKhWhUIjV1VX6+/u5fv261P/8IJxwMpmMNEg6W3mYr4MYoqqoqKCtrY3Tp09TXV2N3+/n6tWrXLx4kYGBAdxud1av330ZcEEQLMD/CxwCMsAPgNvA3wOVwDzwQub/Z+/NYyTNz/u+z1v3fR9dfU73dPdce8zs7nCXa1Jex05CU1RWAQzBUWDJiQD+Exs2EiOm7X/8RwLIAeJEMQQHdGxBjoTITuSAhiBSVLgkw1AiZ6+5es6+767ququ6qruON390P799q6Znd46q6p7d9wsU+u76vb/j+T3P97l0faCl6iQSYWFhgZGREba2tlhaWhqIuScc9nGUgjg433rrLV599VWsVis3b97kO9/5zkBbQkl26Fe+8hW++tWvEo1GGRkZoVAooGmaclLa7Xbi8TjxeJyvfvWrvPbaayQSCeBQ+75z5w7pdLpv4xYB9v3vf59UKsX4+LgSck6nE7/frzIAxaF2584darXaiXCyLpeLsbExvvGNb/DOO+/wk5/8hPn5+WP3gjiEvV4vFy9e5I033mB6eloJ8Ha7TTqdZmVlhXQ63VMNvFwuU6lUaDabBINBVdo4kUgwNDSknOkul4uDgwM2Nja4d+8et27dYnV19cQbOxjrqwOKfvJ6vSdWNkFgs9k4e/Ys77zzDlevXlU9U3/0ox/x3e9+lxs3brCystL3s/6kGvhvAd/Tdf2vaZrmADzAPwR+oOv6b2qa9i3gWxy2WRso2u22ana6sbGh6mKcFETTmpqa4stf/jJjY2Osra3x/vvv84Mf/GDgbbQcDgcjIyPE43FGR0cJhUIUi0VVm7xerysOemxsTNEUHo+HSqXCjRs3uH79uhL2/YCU1/zoo4+IRqNMTEwwPj5OLBbD7XajaRqVSoX5+XmuXbvGzZs3+xKS9SSwWq0kEgmuXLnCL/7iL3LlyhVu376tnJdSghUOhXcgECCRSDA5OclXv/pV3n77bZUVKZTKzZs3WVxcJJfL9SwfQAT48vIyIyMjqqek9MCU9m+FQkH1w7x+/To///nPuXfv3om0e+uGzKlYYEJXyJ44yXosDoeD8+fP85f+0l/iypUrRKNRcrkcf/RHf8QPf/hDMpnMQKinzxTgmqYFgV8A/iaArusHwIGmae8C7xz92u9y2Gpt4AK8Gydt7rndboaGhlRbr2q1yrVr1/jwww/JZrMDFTq6rlMqlXjvvfdU78uxsTF+7dd+jV/6pV9ia2uLWq2mygBIBxERmCsrK/zoRz/iww8/7Hv4mJTa/N73vqcawRojXqQglIR0ndQ622w2Xn31VX7pl36J8+fP4/F4CIVCqitQoVBQgtzhcKgiV1/72te4cOECHo8Hm82Grus0Gg0ymQy///u/z/z8fE8d2e12m5WVFf7wD/+Qzc1N3n77bVUKFVDU2IcffsjKygoPHz5URZb67T96Esj85HI5tra2iMfjiu47aVgsFgKBANPT08zOzhKJRKhUKiwuLvL973+/Z7W+nwRPooFPAhngdzRNexX4EPg7QFLX9a2j39kGksf9saZp3wS+2YOxfiqcTidjY2OcP3+e1dXVgdfsELz88st84xvf4N1330XXdf70T/+U3/u93+PGjRt9LxF7HGq1Gjdv3uTcuXPs7e3hcrn4K3/lrzA5OUk0GqXdbmOxWHA6nco5VK/X+eCDD/id3/kdvve97w00weg0OcyOg1AeS0tLaqzvvvsub7zxhipSVavVVGLH2NgYZ86cUSGCojmWy2Xm5+f5Z//sn/HDH/6wLxZOu91mbm6OlZUV/uiP/giv16uiJIQClK5D+/v7KnHqpJUggYyxXq/TbDYJBAKcP3+ecDg88H6iAofDocrLXr16FY/Hw9bWFu+//z6//du/PfhywU/4O68Bf1vX9Z9rmvZbHNIlCrqu65qmHbvquq5/G/g2wON+51mhaZrSiKT2hCz2SUEqJEpHnQ8//JDV1dUT4+za7Tblcpkf/vCHfPTRR3i9XorFIjMzM3g8HmKxGKlUitHRUeCQj37vvff47ne/y7Vr1ygUCqfmQJ8GtFotNjc3+fjjj7l06RJf+cpXCAaDeDwexsbGqNVqysqy2Wx4PB6ldQOsr6/z4MED7t27x82bN3nvvff6euilqUU+n39EezVyzCfVeeezcHBwwObmJrOzs3i9XoLB4Il23YpEIrz99tu8++67vPLKKzSbTebm5vjxj3/MrVu3Bi57nkSArwPruq7//Ojr/4tDAb6jaVpK1/UtTdNSwOB6RHVBYl3L5XJHTd6TQCaT4fr16ypV+saNGycuBKXbTjqdVuUGpIlxJBJRTi04PPB//ud/zscff3xizWNPM3Rdp1AocPfuXb73ve+xv7/P5ORkh1AJhULouk6lUqFcLtNut6lUKhQKBVVNcWFhgZWVFTKZTF8PvVEwn7RT8mkhDbWvX7+uep5K0a+TgNPpJBqNMjU1xdmzZ7FarSwvL3P79m3u3r078FIY8AQCXNf1bU3T1jRNO6fr+n3gLwN3jl6/Dvzm0cfv9HWkx4+NVqvF4uIizWZTtX4adGEoI6RiXi6Xw+FwsLCwcCqSdGQM1WpVhV5KV22v16uKgLVaLVZXV9nZ2elr/OqLCmmIsL6+zk9/+lMajQazs7O43W4VVz0yMqKKcDUaDdUYeXt7m+XlZVZXV1VBpJOg1V4k7O3tcf36dVKpFMPDw6rg10koRIFAQFmr4XCYQqHAnTt3mJubY21t7UQuyCeNQvnbwO8fRaAsAv8FYAH+raZpvwGsAL/SnyE+HuLF//73v08sFmNtbe2xfR0Hhb29PXXATyOkFZSJZ0ez2aRQKFCpVFTNdyllbLPZGBoaUtRVo9FQNTx2d3dV0avTlk14WlGr1Zibm8NmsxGJRNjY2BhoP0wj4vE4Z8+eZWJiApvNxsOHD3n//fe5ffv2QJtUG6ENciJ6zYGbMGHCxKDw5ptv8vWvf51f/uVfBuD3fu/3+OM//mOWlpYGYWV/qOv6G93ffGEzMU2YMGFikFhfX+fGjRuMjY2pxLOVlZUTpUhNDdyECRMmngAOh4NAIEAsFmN/f19lzg7I0X+sBm4KcBMmTJg4/ThWgJ98WpMJEyZMmHgmmALchAkTJl5QDNqJWeGwiuEXDTHg5CviDxbmM38xYD7zYDBx3DcHLcDvH8fjfN6hadoHX7TnNp/5iwHzmU8WJoViwoQJEy8oTAFuwoQJEy8oBi3Avz3g9zst+CI+t/nMXwyYz3yCGGgcuAkTJkyY6B1MCsWECRMmXlCYAtyECRMmXlAMTIBrmvY1TdPua5o2f9QE+XMJTdOWNU27pWnadU3TPjj6XkTTtD/VNO3h0cfwSY/zeaBp2r/SNC2tadptw/eOfUbtEP/L0brf1DTttZMb+bPjMc/8jzVN2zha6+uapn3d8LN/cPTM9zVN+49PZtTPB03TxjRN+6GmaXc0TZvTNO3vHH3/c7vWn/LMp3Otj2ur1OsXYAUWgCnAAdwALg7ivQf9ApaBWNf3/gfgW0effwv4Jyc9zud8xl/gsM3e7c96RuDrwHcBDXgL+PlJj7+Hz/yPgb93zO9ePNrjTg57yi4A1pN+hmd45hTw2tHnfuDB0bN9btf6U575VK71oDTwLwHzuq4v6odd7f8AeHdA730a8C7wu0ef/y7wyyc4lueGruv/L5Dr+vbjnvFd4F/rh/gZEDpqwfdC4THP/Di8C/yBruv7uq4vAfMcnoEXCrqub+m6/tHR52XgLjDC53itP+WZH4cTXetBCfARYM3w9TqfPikvMnTg+5qmfahp2jePvpfUdX3r6PNtIHkyQ+srHveMn/e1/1tHdMG/MlBjn7tn1jTtDHAF+DlfkLXuemY4hWttOjF7j6/ouv4a8FeB/0rTtF8w/lA/tLs+17GbX4RnPMI/B84Cl4Et4H882eH0B5qm+YA/BP6urusl488+r2t9zDOfyrUelADfAMYMX48efe9zB13XN44+poH/m0NzakdMyaOPJ9NAr7943DN+btde1/UdXddbuq63gX/BJ6bz5+aZNU2zcyjIfl/X9X939O3P9Vof98ynda0HJcDfB2Y0TZs8aoz814F/P6D3Hhg0TfNqmuaXz4H/CLjN4bP++tGv/TrwnZMZYV/xuGf898CvHUUovAUUDeb3C40ufvc/5XCt4fCZ/7qmaU5N0yaBGeDaoMf3vNA0TQP+JXBX1/V/avjR53atH/fMp3atB+jd/TqHHt0F4B8N6n0H+eIwyubG0WtOnhOIAj8AHgL/DxA56bE+53P+HxyakQ0OOb/feNwzchiR8NtH634LeOOkx9/DZ/7fj57pJocHOWX4/X909Mz3gb960uN/xmf+Cof0yE3g+tHr65/ntf6UZz6Va22m0pswYcLECwrTiWnChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyhMAW7ChAkTLyieS4BrmvY1TdPua5o2r2nat3o1KBMmTJgw8dl45nrgmqZZOWzQ8B9yWOD+feA/03X9Tu+GZ8KECRMmHgfbc/ztl4B5XdcXATRN+wPgXeCxAlzTNLN7hAkTJkw8PXZ1XY93f/N5KJQRYM3w9frR9zqgado3NU37QNO0D57jvUyYMGHii4yV4775PBr4E0HX9W8D3wZTAzdhwoSJXuJ5NPANYMzw9ejR90yYMGHCxADwPAL8fWBG07RJTdMcwF/nsFuzCRMmTJgYAJ6ZQtF1valp2t8C/gSwAv9K1/W5no3MhAkTJkx8Kp45jPCZ3myAHLimaQzy2Z4GmqZ1fOwe52kd92mHzCeYc/g0MO7H7jmU10mPyzgm48cvED7Udf2N7m/23YnZDxgX1mKxdHwEsFgsWK1W2u02mqbRbrdptVodG7Ldbg9kc8rY5KVpGjabDavVis1mQ9M0NbaDgwNarZYaW7vdpt1u93w8ghf9EIjAsVqtOJ1OXC4Xuq6zv7/P/v5+x5qb6ITMnbxsNpvanzJfshdlPwJ9n08Zj8ViwWaz4XQ6cbvd6LpOs9nk4OCA/f19Go3GqbhYjOMVuSPfM8ob41zKme7F+F8oAd49WTabDYfDgc1mU0JRBKPT6QToWPiDgwMajQYHBwc0m02azWZfD7kIF7vdjt1ux+l04nQ68Xg8uN1unE4nVquVRqNBvV6nWCyyt7enxieb9HnGdpwWY9T8jf9b1/VHLBfj3xl/7zRA0zTsdjs+n49IJEI8HsdqtbK9vU06naZWq9FsNk/FeI+bRxj8XHYLHTkzDocDu92uxtlut2k0Guqc9EP4HDc247n2er3EYjFGRkZot9uUSiV2dnbI5XIdis6g0H25GM+2w+HA6XTi9XqVYtZutzk4OKBer1Or1ajX6x1zKrLnefDCCHDjxMkCezweAoEAbrcbl8ulBKTD4cDtdmO322k2m+zv77O3t0cul6NcLlOtVtWEGjW1fozXbrfj9Xrx+/0EAgFCoRDRaJRwOIzX68VqtbK/v08+n2dzc5N0Oq0EudFSeJb3B5RW1a01GLWDbkHeLezl97spn5M2ry0WC263m1QqxeTkJFNTU/j9fj766KNHNPCTOOjdX3fPfT+F4ePGJftBFB2Hw6HOkigUcKh912o1Zc10C/N+jNtoTfn9fpLJJOfOnePy5cu0Wi3W19e5ceMG+/v71Ov1ga6rcd5EUHs8Hnw+H36/X72i0SgulwtN02g2m1SrVdLpNLlcjmKxSKVSYW9vj2q1qizu53mGUy/Ajbee3W7H7Xbj8/kIh8MkEglGR0eJRCJqAt1uN1arFZfLpYRjqVQik8mwtLTEzs4O2WyWYrGotPNWq9WXMdtsNnw+H8PDw4yOjjI6Oko8Hmd8fByv14vb7cZms9FoNMhkMszPz3Pnzh1WV1fV7S3/72kWuXvOrFYrFssnAUcWi4V2u62evZuqMQqf7gsA6BBAJykgbTYbiUSCl156iZdffpmZmRnsdjt7e3usrq5SKpU4ODgYiD/kOHO6W1jK1zLvjUaDRqPRd02yW+MWa9DtdhMIBAgEAvj9fqU9AjQaDQqFAuVymWKxSLVaZX9/X1k1vR5zt8KTSCQ4f/48r732Gi+99BK6rhONRqlWqxQKBUql0kBoUCNNJ4phJBJhbGyM0dFRxsbGGBoaIh6P4/F4CAaDypJptVrs7e0xPz/P7u4um5ubbG5usr6+zvr6OqVS6bmUNDjlArzbZHE4HEQiESYmJhgZGWF8fJyLFy/icrkIh8M4HI4OTlz4snK5jM/nQ9M09vb2qNVq1Gq1Dt6812O2Wq14PB5GRkb4i3/xL3LhwgVSqRSxWEzRO2JqNRoNwuEwPp+PVqtFs9lUY9zf33/qxTUKDa/X27GphGuXA3lwcPCI9m0U2haLBYfD0aF9P074D0qIG60Bt9vN+Pg4k5OTRKNRdSkbhUy/D7iR/7Tb7Xg8HiKRCC6XS13UQlWIQlEoFMjn85TL5b4KceNlYrPZcLvdeDwepQCNjIyoz0XpabfblMtl1tbWyOVybG5uks1mqVQqaq2FmurVmI10o8vlwuPx4Pf7icfjBAIBnE4n7XabkZERrl+/jtPppNFo9Fz56h6TjMvlcuH3+wmHw4yNjXHp0iXOnTvH+Pg44XBYWfxAh+Xn9XpxuVzs7++TzWaZn5/H4XAoTfx5KdxTLcChc2E9Hg/JZJLx8XHGx8cZGRkhGAyq265cLqsJabfb1Go1Go0GlUqFTCbD1taWMmX29vY6zMFejVU0Q4/Hw/DwMJcvX+aVV15hcnISv9+PxWKh1WopE1/QbDaJRCKMjIyQz+fV4a5Wq081BqMgcblcRCIRUqkUNptNCW8RGnJZdFMs3Yc+EAiodZDxy0UoF8BJaOBOp1Nd5ENDQ7jdbnK5HPl8nv39/Z6v73FjEK1RzOpQKMTY2BjDw8P4fD48Ho9SLBwOB9VqlZ2dHdbX11laWqJer6s1gN5egt0KkMvlIhqNEo/HGRkZYXR0lOHhYfx+P3a7Xa2jXM5DQ0NKcBoDA3rNhxv3nnDv9XqdSqVCuVxG13WcTieBQIBoNIrH41HKT7+tK+Mau1wufD4fwWAQv9+Py+Wi1WpRLBbJ5XLouk6pVKJardJsNrFareoC93g8eL1eNfcbGxtkMhllIT4rTrUAN5p9DoeDUChEMpkklUoRj8fxer2Kx67X6+ol3JII8Gq1SjabZWNjg+3tbSqVSl/4b6PwTiaTfOlLX+LKlSuMjY2pi6ZQKCg+fn9/HwCHw6GsiFAopPhx2aRP8/4yBnGWhsNhotEoNpuNVqul5qibBzf+D+Pcy8GXDWy322m1WuTzeRXdM6iIHiMsFgs+n4+zZ88yPDxMIBCg3W5TKBTY2dmhVqv1xbcBnXSJzI/sTVEuotEoVqtVvb/NZiMYDKoDu7e3x/b2ds8twO4xyvkx8spiwSaTSSKRCHa7nVKp1HF+2u02DodD0ZUi1MXBLnMrSkivhLgI8L29PUqlEsVikXq9TjAYVPPs8/me+mz0Ymwyp+JXy+fzVCoVJWv29vYoFArKUnE4HITDYUZHR5mYmFBKh9frxel09uQZTrUAh080cJmMaDRKJBLB7XZzcHBAsVgkn88rwSgT2W63lZYtEytOTNE+5dWLQ26kG0KhEJOTk3z5y19mcnKSYDCIrutUq1XW19fJZrNsbW1Rq9XQNA2Px8PQ0BDBYFA5RsScfVp0c5yhUIhgMIjFYqHZbAIowftZNIORuhInrMz7wcEBe3t7WK1W9X8HBZnrYDDI1NSUoqUkSmF7e7tDgPdaq5WPRsGYSqWYmppiZmaGeDyOpmlUq1UqlQr7+/uKVvF6veoAWyyWvjiEu7l42Q8+n09pgKIAAdTrdba3tymVSlQqFQ4ODvB6vUSjUSwWC16vtyOaQqK5ZO88D43RLcDE91Or1SiVSuRyOaXR2u125esSn0K/YQwDbDQa1Go1pSRUq1VlLYiMERmkaRput5tYLIbL5WJkZASHw6GoNKMS8Dw4tQL8OPNPNNVWq6Vuup2dHba2tqhUKir0bn9/XwlwoSuMJr8xtrVXh8ZiseB0OgkGg4yNjfH6669z5swZAoEAjUaDcrnM1tYWd+7cYXl5mVwuR71ex2KxEA6HqdfrTE5OqogA4Z2fxkzsdlTJZeDxeBSt1Gq1qFarStPqphm6nXFWqxW32004HFbmdi6XUzxuP/wIn/WMovmGw2GSySQej4dGo0E2m+Xhw4dks1m1B3r93vJRBGMoFGJ0dJSXX36ZqakpotEorVaLjY0Ntra2FK0XDoeJx+P4/X4lpHoRhfBpYzWG1EroqkQ+CXXTarUolUqsrKyQz+ep1+tYrVbC4bBSnDRN66AQxD/TaDR6SmPIXIgGLoJStFy5iMSi7DeM8fBCxTabTSqVCoVCQZ0pkTmiFOm6ri4bt9uNpmlKdgkNJZfC5z6MsNtz3mw2yeVy6uPq6qqiI2RCLBZLh/A2xn4bJ63X1EkwGOSVV17h6tWrvP766ySTSarVKvfu3WN+fp6lpSXu379PqVRSgtNms1Gr1ZTwFrPV6/U+kkTxNHMmmmE8HicWiymBIVrDcY4zowNYwjXh0FE4MTHB6Oioil/f2dnBbrcPRAs67vncbjdvvPEGZ8+exefzkc1mWVtb49atW5RKpZ7E0B+HblovEonw5ptvMjs7i8/no1qtsrq6yk9+8hPy+TzNZlNpYK+99ppyJDocjkecrb0epwheeYngzmQyWCwW5VCtVCrs7u6q0Dzhw/1+P8FgUFlhYsX10rdgzD0QoaZpGgcHB5RKJfL5PNVqlXa7jcvlUlTKoJQGEdJy2dbrdcrlMvl8/pExyN4Q6zcWizE9Pc3o6CgWi0WxA7VaTV0GsvbPegmeegEOnXwsoGJT9/b2OjKyjBEIkhBjpEv6FfImByUWizE+Ps7ExASRSISDgwOWl5e5efMmDx8+ZHNzk52dHcV9wyH/LdEm4ixqt9tKQ3paGJ9PolDC4TDlclklPQlvLWMXGKMp5NA6nU6VJBOLxRRfKub/IJMpRCg5HA5isRhXrlwhFArRaDTY2dnh3r17bGxsqMidfo1LLmyfz8fExARjY2N4PB7K5TIPHjzg5s2brK6usr+/r0x9Y8JMvV6nVCopqq+fMEYN7e/vUygUlDDa29ujUqkowSKCxLi2Rq1YYsF7HT4q7yuZ00bNVnhjY8KeMeFoEDDuc+OcGB39cl7EZzAyMsLExISywg8ODshmsywuLnL//n02Nzep1+uf7ygU4yIZNQoRMMIr2my2Dkem3NiicfdbeFutVgKBAGfPnmV6elpFfRQKBebn51lcXGR9fZ1CoaD4PKMmp2ma0iqM3PTTCkd5vu4ICWOWnRxeI1XSTQ3I/wIUdypUjMz7cfHlg4DFYsHj8ajEHZvNRiaTYXV1lYcPH5LP5/tGSxghYaLJZFJF6RQKBZaXl9nY2FDCWaInRkdHSSQSaq8KN94v+kQg50DoOqvVSrVaVQ5JyQ6UfSNONnEUyu/t7e2pV7fzv5dCXD4XYSlCXc68UEJybgYB4/MZz5goOBLyaIzwGRoaIhaL4ff7abVaZDIZ1tfXWV1dVVnCXwgKRSAPKsk8Xq+XQCBAMBhUiQbFYpFCoUCj0VB/0/3qJYxCMhaLMTMzw/j4OKFQiFarxc7ODgsLC2xsbJDL5ZTFIAJUvNDCnYs2LgdLNPBnGbcx3Vc2vlwQoj2IAJb/L98zfi7xrxLnaowLPy7Jp58wUlXnz58nkUig6zrpdJrl5WXW1taU4Ox3aJmEiIVCISWUC4UCu7u77O3tAYcWkDg4z549SzQaVRqvOAv75WSFTu3bYrEoflsSxIxhpEJRSnaz5A4IDSlaujFKpZ9WjlHblecyarwnQd0J5AwEg0HC4TCxWIxkMqkEtwQkOBwOGo0G29vbbG9vq8s9n8/3bA5PtQA/TvDa7XYikQiBQACXy0Wz2aRUKqlJ0jSNWq2mbuhBHeTx8XGmp6cZGhrC4XCozM+lpSV2d3epVCpKeLfbbTU+h8NBIBAgFovh8XiUJSGL/CzjN0bEGOs1iCCXnx13CESAiyYmyQuSfGQ0qQcZOijP5HK5SCQSXLlyBY/HQ7FYZGVlhfn5eXZ2dvpa+8Ro3Qg95fF4FF8rMcti8TidTkZHR5mdneX8+fN4PB4VeiYCvJ/otmBlvY1x3SK8RSBJvLIkRQm9J6UnxKLt9yUpAhw6s4G7C24NMnQVOumz0dFRpqamOHv2LFNTUyQSCRWWqWmaSt4pFotsbW2xurrK5uamUjJ7MfZTLcChk38CVFhTOBxWQrxSqRCJRJSgKZfLFAoFZTb2Q9CIJuD1epmYmODtt99mampKObKWl5f5+OOPVYSM3LjytyJE/X4/w8PDDA8PK8dWtVpVjs6nHbdsdAlxk3A1mbNoNEooFOoo9CR/02q1lPDxer2K+45Gozgcjg5aSqyD7hjZfvLODoeD0dFRXnvtNV5//XXlTP3444+Zm5tTqcn9hFETFPNexhaJRJicnOyolTEzM8Mrr7zC8PAwzWaTfD5PLpdTkRW9HpusfTeFJpaU0+lUl7nw8mJJSPaoRJzIhSgZu4PKuJX/L9SicczHheINUomQ6JKzZ8/yxhtv8NJLLzExMUEikcDv9wN0RMNJ3RNj7olxLp8XnynANU0bA/41kAR04Nu6rv+WpmkR4N8AZ4Bl4Fd0Xc/3ZFRH6I6/FMEs5p3cxo1GA4/HQygUIpFIMD4+3uEYNArwXiy2kY/3+/1MTk4yPT2N1+tlf3+fnZ0d7t5j539UAAAgAElEQVS9y8bGRkeqtPyt0BriVRd+1Gq1qgQG4SmfZc4Ewl02m00VdjcxMaE0qoODA3XIhQaQbFEZWywWI5FI4PP5lGNJ5nYQXDN8Mt8SDXPhwgUCgQB7e3vMzc2xtLSkKtT1G/K87XZbHVAR2FKnZ2RkRHHkExMTDA8P43Q6qdfrpNPpvkXJGP0qEg0hcedSdEn8GBJNJBathAjKxWTMiDSGm/aLNuvmmY3RGSK04RNO31hbZhBC3BhI4fF4FNcdDoc7ileJ8BaaTKxuY3az/L9e4Ek08Cbw3+i6/pGmaX7gQ03T/hT4m8APdF3/TU3TvgV8C/j7PRlVFyS6xJi9JqFPQgV4vV40TSMWiykTX2JVe12wSoS3z+cjmUxy9uxZAoEAzWaT7e1t7ty5w8LCQkc8smwy4yaQOOZEIgFANptlaWmJjY0NarXaUx9wY8iT3Pzlcpm9vT3lxY/FYh3avYzJ5XLRaDTw+XwqDVjiyCWxSHwLokUY45j7qXkbte9XX32Vl19+GavVysLCAh999BFbW1t9cwgeB+Fm9/f3yWQy5HI53G63ilWWiArREuX3d3d3WV1dZXd3VznaewWj9i0Xss/nIxqNqoJVgUBAaeNut1v5kkKhUEdpYwm9jUajylltpDDEz2CMZuo1uqOpjGMAnplefBYYhbcxIKBUKpFOpzk4OGB3d7eDKTCuezAYJJFIkE6nyWazPXXAfqYA13V9C9g6+rysadpdYAR4F3jn6Nd+F/gRfRTgEki/vb2tDo5sOofDweTkJKFQSKWgVyoV1tbWyOfzyqnUK+1btFbJbEsmk9jtdiqVChsbGywvL3ckFxkXVQ6Yz+cjkUgwPDxMIpHAYrGwubnJ4uKiCjF6lvHKZSe1JKROg1Q+lCgOIw0Ah7He9XpdWRGA8vgbq6tJJpo4ZLuL/fcDMubp6WlmZ2cZGhqi1Wpx//595ufnKRaLHc6ufo7FGOJWLpdZX1/v0MKkzIA4qiVqQ6r7bW1tUSwWe96Q4LgErkgkwtDQkMqglaQSj8ejCkYZBbuu66rMgsVi6RDsEr7XbDYVh9sPDdjo95J57k546haU/V5z4+UolkCpVGJtbY1yuYzT6VRMgK7rKo9DXsFgkGq1qtahl8lvT8WBa5p2BrgC/BxIHgl3gG0OKZbj/uabwDeffYif1EeQ8qCFQqEjhE20S+FuvV6vqo/Rj5hRic4QyiYYDNJut8lkMmxsbLC5uamy2ow8swhNKSo0OjrKmTNniMViaJrG8vIyCwsL7OzsdNAuTwOhnfb39ykWi2SzWWXay2HUdV3NnzF5R7T3bupJ/metVqNYLJLJZCiXy33NJITOgxONRnn55Zc5c+YMHo+HWq3G3Nwcm5ubHdbKICJiZJ6KxSJLS0vKYSlzKclSkoEpmYuFQoFMJqOSzHqlvRoVg27LTop8ybo3Gg3Fi4sG7vF4lPYtju52u60EvZH2q1QquN3uDod8v5J6pCqnVM6UzjxG68Z4gfRDkBvPrcgbiSypVqtqXoU+0XVdlZcdHh5W1rmU7HW5XD2NoHliAa5pmg/4Q+Dv6rpe6gpX0rXH9LvUdf3bwLeP/scTzazRXJNDYayAZzysYl5LxS+J5pDCUMYyqr2AhP1Fo1FSqRRDQ0MAKh15aWmJra0tVbDdyH2L5h6JRJRza3Z2lnA4zPb2Nrdu3WJtbU1RHM8C2UxSRnd9fR1AOTRFCzs4OFAHVdd1bDabShPe399H0zT8fj+apjE0NKT4+Wq1qmLZjRp4P4S4CA63283rr7/OlStXGB4eRtM0isUid+/epVgsdpjT/Y6MMWqGuq4r+sZInRgF2tDQEOVymXa7zcrKCul0Wl1+vRqr7EmJRR4ZGVHJRW63G0BpsiIMRcOWOuBCi1UqFVVqQS55odPa7baiZQTdBc16Bfm/RkvUGBIpzw396ZMp/9sYjivCWqKIZB8Y+Xqbzcbu7i5jY2PY7XbGx8dxuVzEYjEVdDFwDVzTNDuHwvv3dV3/d0ff3tE0LaXr+pamaSkg3YsBGYW3TJpROwQ6DonFYlHmqWy6YDBIvV5XyQi9hCySHBYJG1pbW1Mx34VCQXGyRi3S4XAQjUaZnp7mrbfe4ty5cwSDQUqlEu+//z63bt0inU5Tr9ef+UAYeXARbsViUfF3oo0JLy/+ARE+kmDgdDo7onrsdju5XI6trS2y2az6vX6Xa3U4HMTjcd544w2Gh4exWq1sbW3xox/9iLm5OXWZDDKk0SjEW60W6XS6w5QXgXpwcKAuIIvF0lGYqdf0iSQMxeNxUqkUkUhEnQsRyHDIHUskkjGLUFr6CU+bz+dVfWvj85ZKpUeETy+fxSiMRWkrl8vqPElUmTg2RTb0ej6N51YoEl3XlXUqe99ogYpsqNVqAEphkrFKfkcvz82TRKFowL8E7uq6/k8NP/r3wK8Dv3n08TvPOxij8DaGOgEdGZXdC2a1WlUZVmPxdykY1WtnkXDDcpvm83lWV1fZ2Njo0AhFUxANJhaL8fLLL3P16lUuXLiA1+sln89z48YNPvjggw6n5/NsSNn8AqMX3LjpjS/5OzFPJe47m82qEqiyAY211PupfYuvYHJykpmZGbxeL9VqlYWFBX784x8/4owdJOT9ZE8ahZrMXzgcJhwOY7fb2dzcZHl5WUUm9EroiJCRrOREIqHoE/FVyJjkXCUSCdVBRjIxJcVbHKxSLtiofWqapr7fXW+9X3ugu2SD1MERwSiV/7oYged+T3lmOetypowy6Lg1FFkkdepTqRSaprG7u6vquvTS//Ek6ulfAP4GcEvTtOtH3/uHHAruf6tp2m8AK8CvPM9AuoW3VB8Us8VY1wQ+4cvkkEvqqpTIzOfzj5jXvYCM05gc0x1aByjhbQw7mp6e5s033+T8+fMqg3RxcZGPP/6YhYUFFTr4vOM18tbAI6nz8juPE8DGmjOSfSdOGlmDfgtN0b4jkQgXL15UkTo7Ozs8ePCABw8e9OSyex4YTXujABGhGovFCIfDAOzu7qoLutd+A9mPwmn7/X5VNVCqd0qVS7vdrjIFAdLpNPl8nps3b7KysqJyFiRKxujANGqXIvj7XctFaB1j4wvRbI+rp/288yoKmrEEhcyh7H+xVo0WgVgzgUBAlRWW1om5XI6NjQ1FnxmVjucd75NEofx/wOMIm7/8XO/eBRHgstm8Xm8HfSJhgbJphMpIJpNMTU2RTCZVu6L19XUlwHu9ybpDtmTxXC4XLpdLxVdL9IQU0b906RKvvvoqkUiESqXC8vIyt2/f5s6dO+zs7PTUKWgMXTSa9tDJEx/nzYdP0qxl3h0OR4e22U9noeyDQCDAmTNnuHTpkirLu7m5ycOHD/uedfk0MI5B5sXj8ZBKpQiFQrTbbZWR1w+hZ7ycjb0bfT4fjUZDWVNinYpvSBSIxcVFbt++TT6fV+OTkFERaPISa86ogfcz4keifWq1mrpQxPHanVLfS4tGonQkll7OgbGWkFAhcoH6/X5GR0d55ZVXOHfuHMlkEl3XyWQyyv9hrELYC5yaTMzuDSjd240auFRSE9PO5/MxPj7OzMwMr7/+OvF4XFUAvHPnjuKTe6nxGKM82u22MuWSyST7+/s4nU6VBi8tlC5evMj09DTj4+MkEgkqlQq3bt3iZz/7GTdu3FBx373WzJ7mhjcKeplzeVbhcqXcrbGYUK/DyOATDnl0dJQvf/nLXLx4EZvNpmqqLy8vK2f2aYFx/iwWC0NDQ5w5c4ZQKEQ2m2VnZ0eFO/baehHHtcTmN5tN5WiXPqvCG4vwlbK3165dY3FxkVwu13G5dF9KRl5YnvNZCq497XO1222l7QPKjySXkZES7MU+NFr1kUhEVRcUx6VQskYfkJTDGB8f57XXXuONN94gFosBsL29zc2bN5mfnyeTyXRQKL2Yt1MjwKGTfxLaQbrvACopRYo/JZNJLly4QDKZxGazUSqVWFpa4s/+7M+4ceNGR8ZbryCODKkJXCqVGBoa4tKlS4yMjCinUbvdVn07I5GIir0ulUq89957/Mmf/Anz8/OP1DI/SYgQMmrnElMOnxQS8/l8yvLohwltsViUNiP0ia7rrK+vMz8/z/r6+kCyLp8GRivHZrORTCYJh8PYbDaq1SrpdLrnexE6k9wksU1i98X5BofCtlqtkslk2N3dZXt7m/X1dZaXl491rBots+6oL+P3+k2liQCXi0nTNJUlbMxtsFgsSjPuhRAX53MqlWJmZoZqtapyH6QwmAjvSCTC6Ogo58+fZ3R0FE3TqNfrbG5u8sEHH/DjH/9Yxf/3uoDZqRLg8InWKJ51SXYJBoMqekLqI7jdblV/YGNjg/n5eebm5jocgr0+6KKVlkolNjc3WVhYwO12c/HiRdWCSswrOUyShbe7u8sHH3zAD37wA5aWllQ42UnyuI+DbGIpP1oqlVR4obFBgByaXr6v3W4nGo2qUq26rquiVZubmwOpefI0MAo20d4uXbqkeGipRNkvYafrh0WnxMEoxdAkqU2UjlKpRCaTUf4hEUqfFhXRPd7jvu7XWhgpQHEgSjSV/Ly7/HGvaBTxxfn9fqamppQvwFjBU9MOk6KE7pUyFGtraywuLnLnzh3ef/99VldXO/Imeqn0nBoBLhvBWG/DWLpSajUAynkh/FI6neb+/fssLCywtLT0CHXSD3NVskLlIolEIqpfn3QOqtfrZLNZtre32dzcZGVlhbt377K0tKSsg9MqvAFFXeVyOdVAWoow9ZsDF7rGKLyl4qCxIcZpgvhEpKC/0+mkWCx2cLj9gPiIxAkuFIloqLJnJbpEYsGfRqA8bo/2c++KPCiXy6pUtM1mI51O97SiX/d7GvtcCtcvAtpI28Anaf4ii7a2tpibm2NhYYHl5WVWV1eVY7gfVvapEeDQGW8qm01ad0nzXPEAGxuMLi4usrCwwNbWlgqD6peDSzRw0azEUpC0+lAohNvtVinHm5ubrK+vs7a2xtraGjs7Ox0t1U6b8BYY+e9isahK3RaLRaW19cuEFi0ym82yvLzM7u4uDx8+ZH5+nt3d3b4c3GdFd96CZNn6/X50XVdxzM9aGuFJIAJaPkqxMokcAToaMxiLUz3NpWKkVYxf9wMiCw4ODtjZ2WFxcRE4jK1eXFwkk8k8EiLcq/FIAlGpVCKbzbK5uanOqtfrVYqFWAYyr7u7uzx48IB79+6xubmpqk4aKdIvjAAvl8vKuZfL5Uin0x3dd8Ssz+fzLC8vq+QS4+bs1waTRZMMO9F6kskkfr9flV7d3d1VlfJEg3ieJJ1BwMiZSvZepVIhnU4rAS6JSv3oLypCaHd3lzt37rC/v4/P52N9fZ2HDx8qZ9tpmz/hvr1eL7FYDIvFomgNY7/JfkH2lIS7Sey+sZxydy3vZx1Pv+dehKPw9gsLC7RaLdbW1vB4PKytrbG+vq5i6nstGCXOvVAosLKygtPpZHd3l3A4rJqbCJ1Yq9WUoE+n08zPz5PNZh+5KPtGMw3yIGhPkEovm064LnlJ+UvJvJSaHd3hhYNwrMg4jaGEkrZsbJRQLpc7SkqeBkflp6H7mcRpGQgEsNlsaq6lpIHx8PQ6CkWiXlwul3pvYyf10zKPMmcS7x+LxXj99df52te+htVq5fbt2/z85z9nbm6OYrE4kNDH7rBRQa8v236jO2muO4pGznwvBaTRojIWrQuHw0oGOZ1O9d5SXkLolj4muX2o6/ob3d88VRo4fGK6iwa4t7fXManGTThIgX3cOGUMwnc/LsxKfv9FgjyXbEygoyN5P7PwRAsXTciYOHHa5tEYuSPzUiqV+Pjjj2k2m6yvr7O7u6vCTgc1JuPHFxWyD4SyNEbA9Gs/GM81oKjabDZ7bNis8fdPYn+eOgEuME7G4xxmp2WDdi9cr+OiBwnjBSo+B+OFZLww+/2MxgzH0zyfRn9BuVxWZUalFomEip7GC+i046TPVrdAP204dRSKiZNHd1o4PNoxxUQnjKFn4ugS30iv22iZ+ELixaBQTJw8TGH99DBaLt3Nik3N20S/YApwEyZ6CFNYmxgketcawoQJEyZMDBSmADdhwoSJFxQmhWLChIljI71MKuj0wxTgJkx8AWFM9pHELWkOLinikqx1mhKnTHTiaZoaW4EPgA1d17+hadok8AdAFPgQ+Bu6rh982v8w8enodXcREyaOgzHTUNL/w+EwiUQCv9+vemQuLi6qMgAn1brOxKfjaTTwvwPcBQJHX/8T4H/Sdf0PNE37X4HfAP55j8f3mXhcd5jTvtm6Y62NpTHh0QwvEyZ6AeNek85XqVSKl19+mYsXLxIOh9F1nZ2dHYAOLRxORqkwnvHurlJf9LPxpF3pR4FfBP574L/WDmfxPwB+9ehXfhf4xwxAgBu1Bym6LlqDVBGTLtanuei/8SBJBxqHw6EyzaTDSr/6PnaPwdjIVSAxzSdZsuBJcFztD+PnxnR3+fpZnuO4/2+sWd39nt3vdVrmTmqMuN1uQqEQw8PDXLhwgcnJSRwOB8VikXq9rjJIT0qJkHEGAgHVzxNQlQLljH+RE6SeVAP/n4H/FvAffR0FCrquN4++XgdGjvtDTdO+CXzzeQZp+F9K0EihpVQqxdjYGH6/n2q1yvb2NktLS6eq1rZRWB4nNI1V7ABVA0b65/VSABiLL0nBKqfTqYrSSyNpOGxqvLu7qxo2G2uhnAYcdyE+ruyCsbv50+4LY4E1eRkLfsl8Sl1oTdNUyV0pvCafP20J135AtO9QKMTU1BQXL15kcnKSYDDI/v4+9Xqd3d3djrLBMNgLyNgVZ2pqing8jtfrRdM0tre3uX///hdeeMMTCHBN074BpHVd/1DTtHee9g10Xf828O2j//XMO8B4MI0py4lEgtnZWcLhMIVCAavVys7OjqoJfpLo1rKNReDl0EulRWkC0Gq1qFQqqm2T/G2vhLcIIrFc/H4/wWCQRCJBNBpVjiyptLayssLu7i65XE7VtT5pPvRxglsOfbcw13VddXOSZs1POn6jIAkGg/h8Pnw+nyrwHwqFAHC5XOo92u02+Xye/f191UuxXC6TTqep1WonWgveWDkxkUgwMzPDzMwMgUCAVqtFoVBga2uLjY0N1SBi0GM1rqXL5WJ4eJiJiQlCoRC6rmO321ldXaVarfa1sUiv8FljfJ65fRIN/C8A/4mmaV8HXBxy4L8FhDRNsx1p4aPAxjOP4glhFIjSBT4UCjExMaFq9VarVXw+H7lc7sSLSnVrbqLZiikomq/09xwbG6NWq2Gz2Tqqr/VyLFarFafTSTgcJpVKMTQ0xMjICFNTU6q3qLRKK5fLjI6OsrS0xPz8PFtbWxQKBdXQFQZPCxiFt/FiND6fsU+i7AF5Jml4IML8s97L2KRhcnKSVCpFIpEgFoupNWu323i9XqxWq6oBnclkqFQqFAoFdnd32dra4vr162xtbVGtVlVvxEFC5sjpdBKLxThz5gznzp1jfHycRqOh6tffv3+flZWVjga8g4bMvXGvRqNRpeBIt6HTIsAfR69103vdHP7zNqT4TAGu6/o/AP7B0Zu/A/w9Xdf/c03T/k/gr3EYifLrwHee+t2fAceZy36/n0gkQrPZVD3qTpo6MTqKpJ6xaGkiXBwOh+pcn0qlSCaTFItF1d2+l1qusdiSx+NRDaHPnTvH5OSkar5s1LZarRazs7MsLy/zs5/9jNu3b7O4uKgO9Un5GI6joropKeNLLkxN09TFaHTMPQ7GetBTU1NcunSJK1eukEwmCYVCpFIpPB6PWlNN+6TsrVwSUvB/d3eXeDzOT3/6U1ZWVigUCgMX4qJ9x+Nx9SzT09N4PB5u3brFrVu3uH//PsvLy+TzeWVtnQRNIesr3W/EagTUGsPJ+RW6hbPxc9kPQrPJ50aFQhQJI4/fFwH+Kfj7wB9omvbfAR8D//I5/tenotscllrh0qNRJk00r9Ng4svhD4VCRKNRYrEY4XBYmdhSP9zj8RCPx5UF0Wq1lHYhz/u8z2G0BJxOJ4FAgGQyydDQEJFIBI/Hoxo11+t17Ha7unBisRjtdlv19avValQqFbXhBmleHyewpQO7NP5wOp2qY7kU4LdarVQqFer1OoVCAV3XO6igx72XCO9IJKIormg0SiAQwOVyKb9AtyYlZXhlDX0+H263my9/+cu0220sFguLi4vk83kajcZA587tdjM5OcnMzAypVAqAQqHA3bt3uXv3Lpubm4/4XgaJ46xOoU1EgMuFfBJn3Kg4OByODh+SKGTSVtHv9xONRlVzErngpem09M18ns5CTyXAdV3/EfCjo88XgS891bs9B4yOFBGC8vJ6vXi9XnU4T9LRZhTe4XCYiYkJUqkUwWAQm82m2i2Vy+UOgeR0OgEUbyqaeC+bJhg3iDgsDw4OyGazFAoFqtUqtVoNv99POBwmFosRCASwWCz4fD6CwSB+vx+Xy6Ucc8aLtd/opqSkF6nf71cdkaLRKKFQiHA4jN1uV8I6nU6TyWQe0Zo+bdzGTuTSqEF4bDjsuCStvprNpir+b7VaiUajBINBhoeHSaVS+P1+kskkMzMzbGxskM1mByoo5UKKRqO89NJLTE1N4ff7qVQqPHjwgI8//pjNzc1H/Bzyt92f94ue7P6fRgrM6XSqdTspXt6oWUciERKJBENDQ6RSKeLxOB6Ph2g0qvr4Cs0jMkHTNPb391lfX1d+EZnvZ8ELl4nZfUsJRymmCnBimWPGhfL5fAwPD3Pu3Dm1oNKKTHhkGTuAx+MBUMJdeNJebVS5+CQ8sVwuk8lkaDQa2O12JXxqtRqhUIhkMkmz2VRmn2gaxrk29lvsN8TKMmo8Pp+PWCymtGKh0sLhMC6XS3UUajQaHbTPk1po8vv7+/vk83lWV1c5ODjA4XBQr9fZ3t6mWq2ys7Oj/u/BwQE2m41oNEokEuHcuXPous7Zs2fVeMPhMF6vF7vd3vdemTJ3QkGcOXOG6elpkskkuq6zubnJ3NwcW1tbFIvFju7pxkuuW4jLx0FaX0ZqYpDad7fgloitCxcuMDU1xcjICMlkUilpLpdLNfiQ0sLi/Jb2gAcHB8rp/TzP8kII8O6NIw8sgsXtdqtFFU3oJB0vbrebeDzO7Ows586dU07JcrmsOrS0221cLhftdltF1FSrVcrlsur83kvtTAS4xMpvb2+j6zqBQEBdLpqmqc1lzNBzOp097z34NDAKb7fbrWiNeDzO8PAwiUSCUCiE1+vF4/Hg9/vVfIvwFctHGl8/CX8vwrtarZJOp2k2m6TTaXRdp1qtsrW1RalU6mjWIGPNZrNEo1EV6nrmzBnVT9Hlcqn+rv2G0dyPRqNcvHiR8fFx/H4/mUyG1dVV7t+//4jF1z02oxA37oF+WmBGa1sEqLznoCxso9Un5zQajZJKpbh69Sqzs7MkEgmlgAm1Wy6XKZfL7O3tYbFYVE9P8YOJw7vRaDwXY/BCCHCBbCL5HMDtduPxeFTYnRzaQfNjoq24XC4ikQjT09O8/fbbBINB0uk0uVyOlZUV1tfXqdVquFwudZPH43Hcbjfb29tkMhl2d3cplUo94/KNfy99Jnd2djg4OCAYDCqNwe/3q2cQYQh0dKMXgdVt5fRLGzsu6igWizE6OspLL71ELBYjHo/jdDpV4+NarcbOzg47OztsbGwwPz9PPp/n4OCAarWqHEefNl5d1zu09mq1SrFYVAJFtPtubdUYby7UmHC3sj/FeWncz/2EJMNcuHCBq1evEo1GqdVqrK2t8cEHH7C5uUm9Xn/kErJYLOrSN17gg+zzKj0xRYBKctugrD5jNIzQI5OTk7z99tvKoe1wOFTORC6XY2Njg52dHfL5PNVqVSkXoVBI0ZbpdFpF+ZyUE/NEIbeaOOHE8y/OqkFz4CL4otEo09PTvPXWW1y4cIFsNsv6+jq3b99maWmJUqlEu91WzkQR3nt7e6yvr7O1taWcW72+hOQwCqUgWqg4AGOxGA6Hg+HhYZLJJOFwGKvVSrFYpFKpqAbHrVbrkU3XL+FtNP8jkQipVIqRkRHGxsaYmJhQFJSE621ubqpLMJvNks/nlfAW5/eTWjby+61WSykI8nfHNawWAS778syZM5w5c4ZEIgGgOPTuC7qfEMdlMpnk1VdfZWRkhEajoXjv5eVlqtWqukzE4SaKkURLiOA0ChxBv57BeFnIXmi1WooW66dF2B2LLntvenqa1157jZdeeolwOKysspWVFe7evcvCwgL5fF45/a1WK8PDw8zOziqLbmdnh1u3brGysvLcfpAXVoDLwQ4Gg3i9XnVQB+nZN8JmsxGJRLh48SKXL19mamoKXddZX1/n3r17LC0tKQ3O4XAwPj7O+fPnmZmZIR6Pk8/nVZz1k2iIzwLjpnQ4HCoaJRaL4fV6mZmZwe12K+1bIi1yuRzr6+vs7OxQqVT6np3X7TDyeDxMTEwwMjLC+Pg4w8PDhEIhrFYrhUKB7e1t9Uqn0+TzecrlsqJLjIkzT8s5Gv/mcUqBOKtcLpeK6X/77beZnZ1lfHycRCKB0+kkk8lQKBSUldhvSBje0NAQly5d4vLly/j9fhYXF3nw4IGKgJBoKNEwU6kUqVRKJXPl83lyuRyZTEZFKgEdWnk/IVEoDodDKRL9vvyM/qxAIMD4+DgXL17k3LlznD17VgVNLCwscP/+fRV+KSn+7XYbq9WK3+9XWa+NRoNSqcTCwgJ37twhl8s993O8sAIcPtHCrVarSj+v1WoD52rFVB4aGuLcuXNcuHCBcDhMLpdjbm5OefcbjYZycE1PTzM7O8vIyAiapinzS7SLfo3fmMwTCARIJBKMjY0RjUYZGxvD7XY/4muQ7EF5yff7LbwlU1WiOYaHhxkaGiIWi+F0Omk0GmSzWVZXV9UFUygUqFQqKsSvW1N+ljEfR3cYx2m32/H7/cTjcSYmJpiZmeGNN95Q0SdOp1NpX0K7GEMh+77PECwAABeFSURBVDmXHo+H4eFhZmZmGBoaUo7L9fV1crkcuq7jcrnw+/0MDw8zNjbG2NiYSuqqVCpks1m2trZwOp0sLi4OpEFz9x4T3lisokFQpKIkSpkLCbsFyOVyLCwscOvWLRYWFlhbW1PKowhvEf6vvPIKsViMVqvF1tYW9+/fZ3Nzsyd1Zl5YAW5Mp5dCVsZog0FBNFq/38/ExARnzpwhmUxisVjY2NhQtEmr1cJqteL1ehkbG+Ps2bOqhksmk2F7e7vDIdZP09DI6QWDQaV1hcNhxdHJXIoQFA5SUtX7NTb5KMJbIjeGhoZIJBIEAgEVU1sqlchkMipEMJvNqlBIsRJ6edCPE+I2mw2/308qlWJycpILFy5w4cIFZmZm8Pl8WCwWFaEidIaUMBA+vl/rbbVaCYfDjI6OMjExgcfjIZ/Ps76+TiaToV6vq3j/sbExpqamlPAOBoMq2iYSieDz+dB1XTmDB1mmQgq9CSc/qAQoOSsej0cV1JJ9l8vluHHjhhLGYjnrut6RAyIJYOFwmJ2dHdbW1nj48CGFQqEn4c4vpACXg+NyuZTQAZSGKL8ziBu6W/s2ai6Li4sqNt3pdGKz2RgeHuall17i7NmzhEIhDg4OFH0i9Vv6RU+I8BHLxRirKtqgOAKFeqjVakqQSqheoVB4ojjqpx2bkeKRyzkSiTAyMkIqlSIWi6nwwFarRTqd7tC66/X6czuFPgtGIW7kl2dnZ7l48SKXLl1ifHycWCyG3W7vKGIVDAaZnJykVqupi6Ver3dcNr2CRGgNDw8zNTVFKpWi2WyytbXF6uoqxWJRxavH43Fef/11xsfHVZKSw+Gg2WwqCsBms9FsNtnY2GB3d3dggQJWq1XVoBEnZrVa7Vjffpx1Y/SO0EvtdptSqUS1WuX+/fvcunWLdDqtEnGgs1DY2bNn+cpXvsLk5CR2u510Os3CwgKLi4sdET/PgxdOgBsXTcLKJPxNDrCg30LceEMPDw+reO9arUYul6NSqajFFL7+/PnzvPnmm6RSKZX9KBEez5tW+1ljhU8oFNFmqtUqmUwG+CRCZW9vT8Wvulwu3G43Q0ND6mfZbFbx+b2YYyMdIdqLaKrBYJBAIIDb7e6IipCD/FkZlb1GdyaeUE9jY2OkUikikYhyrMpFIx+l1rbdbicWixGLxdjf32d1dbXnmrimabjdbuUz8Hg87O3tsbGxQblcBg6TuYaGhrh48SJjY2NKy5ZkHovFoiKlxFJzuVzHhhP2A3LGZf2l2FYul+urpW20BGU/WiwWFYm0ubnJ2tpaR8VGyZdwOBxEIhFeffVV3nzzTa5evUooFGJtbY3r169z584dCoVCz8pQvHACXCDx1tFoVKXPG6Mj+g1jzHcymVRp1rLBHQ4HyWSSg4MDnE4nfr+fWCzG7OwsQ0NDtFotcrkcy8vLzM3Nkclknjg++VnGKlaLsdxAJpNhf3+fdDqN1+tV4W7Ci4ZCIUZGRggEDnt4SPZmryiUbq1bsh5dLldH1T9xVjabTXX5SMVEoXsGVZelW2jUajXS6TR2u11ZLJJYpOv6I3H1NptN8fhjY2MqtLCXzmuZz0AgQCQSwel0UqvVyGazbGxsqOzlWCzGpUuXiMfjpNNpVldXVZSMpmmcOXOG2dlZfD6fsiA1TRtoprNYCRIRI8qOkSbrJ0TJunfvHg6HQzkiJdLEeJHInJ8/f56rV69y+fJlIpEI2WyW7373u7z//vusr6/31IH9wgpw4UiBR+JUB5UgYXQGSoaVJMTs7+8TCoXQNA2v10sgECAajTI8PIzdbmd3d5ft7W11aIye9X6Zg/KS2iYS3y0HU5JLhHeWCn5S80ESKXrV4KE7w81utytqTMx2i8WiNH/h4iWNXmptd2vgg9LGhQLJ5XLqoG9sbOB2u1UEjzEefHR0VNFBQgu89dZbLC8v8/Dhw56VmZW9KdmgEmZbLpfJ5/MqLlxqxjQaDXK5nPIlFItFXC4X8XhcaduNRkMlmg2y1r7sSaGiCoUCe3t7A3lvsUh3d3dV6QtRGuQlVqiscSKR4OWXX2ZmZoZoNEqz2eTevXuqEmWvgyxeSAFuNG2M6ajys34nR3SHuQmFk81maTQaytwyat/hcJhQKKS0oXQ6zdraGhsbG32lT7rHKoeh+xBIeKPEg0vxfI/Ho4oySZZrr8xXIxUhCS/GrDVN05TgkMukm0p5nNAb1AE/ODhQMb/FYpHt7W0110JDiVWRzWap1+vqkgoEAsrBuLOz0xPnoHFOJUlLtGahF/1+v1I+9vb2VCMUKYErDvdAIIDT6VR1YCQMclAOTFEqpE6QxKJ3r3mv11oUE6HqSqXSI5FZuq6reTAWihsfH2d6elo1Z9nZ2eH69eusra11cOW9wgsnwI8LMzuudkO/YSwNKYd3dXVVlRcV55TH4yESiag0Wl3XyefzrKyssLy8rEIMu0OzeikghZ4QDVcqogntJO8lDhsjhRKLxZSmKY0JeuXAElpHLjlpKiBFi+R9JQZbGhGIRQCfJCcNuvGAjEkOpBS4kjEZP4pAlZhrSaf3+Xx4PB7GxsZUZILEWD8PhMKTtZSEEvikJodABHImk6FarWKxWAgGgyrbVbjz7e1tVlZWyOfzA5tnmTfxc8leNVrb/U4iEnrO6Lw2fm6UR16vl9nZWSYmJvB6vZRKJe7fv89HH31ENpvti+P3hRPgAplAY7ibmNPy80FsMtFmNzc3SafTSiNvt9t4PB6GhoYYGxtTFRMtFguZTEaVktze3lZOo14Koe6LTsLF7Ha7yqgzVnSU3xfufmpqiunpaYLBINvb26yvr7OwsKBKATxvMo+RggoGg8TjcRKJhNIAxSJpNBqKhnI4HKpEp8vlUnVJRDM7LsW/n5DDKELcKFzka3lW0caFcovFYqqeeCKRIBwOq73wvM8gayn1yI2ZllLzXRQGiZiS6omSzDMyMsLIyAgWi4XV1VXu3bvHvXv3ejK+p3kG8dfIGTcWI+snjJp2t4VvhLFJSyqV4q233mJkZIRarcbW1hbXrl1jfn7+kQizXuGFFOCitYlAkgMvgsjYVgv6V2in2Wyq/oGlUkn9TOidSCSiHDCSLr+0tMR7773HgwcP2N7eVhXgesl/dyeZSAEot9uNw+HoqOltFNxDQ0OMj4/zpS99idnZWYLBINVqVSUsrKysUCwWe2oGGumERCKBz+frSN+WsgMzMzMMDw8TCASwWq1Uq1VyuZzKDDQ6sfsJo1UjscnGWG9B91rKfpE5l3UR7tRY8P95xycfa7UaxWKRSCSC2+1WFg6gxiENE+Q5xHEsVtrS0hLXrl3j3r17bG9vDySDVMYvsdRSUE3O9iCrYD7ufYyBAYFAgHPnzvGrv/qryjF9/fp1fvKTn/DTn/6UYrHYN8fvk3alDwH/G/ASoAP/JXAf+DfAGWAZ+BVd1/M9H+GjY+lwrNTrdcUdDjK112jCSeYV0KHxaprG2NgY8Xgci8XC9vY2165d4/bt24pvNEYe9Jr7Fg1XyqxKLe9KpYLNZlP0hIQ6Xr16lfPnz6ta0Y1Gg42NDT766CMePnyoeo32QgOTeZOxSglesVLEdNW0wxoz09PTSnssFAqsra0pk95YYbDfB7vbqpHImUajoTqsdL+/CHyfz6fasA0NDeFyuZRjsJflE3RdVyUQ0um0UiQikUgHL25UdkSQw2HxsrW1NW7fvs3c3ByLi4vK0T6I82VUQMQPIutrLBt9EjDSJ1arlVAoxOXLl3nnnXe4fPkyLpeLubk5/vzP/5xr166RTqeVtdsPPKkG/lvA93Rd/2uapjkAD/APgR/ouv6bmqZ9C/gWh116+gpjRIWYphKHaewS3m9Hpmxi0WhkDEa+OR6Pq4Mqxaru3bunBGE/hY4cTofDQTgcVk2L/X6/6ghycHCgBGcymeTy5csMDw/j8/lUeOGNGzfUmI1cfS8cSKKVygEVbVscqLLW0lDY6XSSz+fZ3t5mcXFR1WYxtv7qt/A2zqvESEvsf7VaBehw8hrrw8/MzKhmCtKdSYqdCf/dq4ux0WiokLtisUitVlOOYim/3H1GjM2Xb968yY0bN1heXlbZl4PsAm+0dGSPGKPM+n2+PwvibD937hyvv/46r776KpFIhGKxyAcffMCtW7fY3NxUSVv9wpN0pQ8CvwD8TQBd1w+AA03T3gXeOfq13+WwU09fBbgxbtjoQBQuT2iVfqZ7C7ojOGR8criltkQkElFZgwsLC6ysrFAqlQYSiiWarcSgSzaj/v+3d36hbV1nAP9985zSRknsOk0avMbp0hJacJaZMFpo+1LY1rxkexl9WhmFvmyle9hDR1/6uA022GAMOtbRjbIy9oeWwmBbWNlDWeYqTeo2tiL/kWUr145kuYr/JLYznz3c+50cO1JiauleST4/EJKvlOj77tH97jnfv2OMnU1pz+8DBw7Q29tLZ2en7X+dyWRIp9Pk8/mqbWTrYWw0d3ppaYmlpSU7o9W8Y21ipGlwQRAwPj5uu765u7zHmf/v7meaSqWsu0J3o4ebQbhUKsX999/PyZMneeSRR2xMRF1qY2NjlMvlulTnuRkUi4uLlMtlZmdn6e7utm13VQ83MFipVJienmZmZsYWnYyPj9s+4Y3ugaO417e6StTFqJMlTXuNK85VTT5tXtff309/fz+9vb0A5PN50uk0ExMTLCwsNNxfv5UZ+INAEfitiHwJSAMvAQeNMUH0mRngYLV/LCIvAC/UQVb9/4Bwxnvt2jXrPtE74t13322XWTrAcQ20XtipVIoDBw5w+PBhdu3aRbFY5OLFi6TTaVuwE5cPTw2OG5xSX7j2cNm7d6/1Pc/NzZHL5RgaGmJwcJDh4eENfRvqKbe6wZaXl/n000+ZnZ21MyyVUWe3lUqFcrnM6Ogo2WyW6elp24oz7tbBaph3795tS9W1JYJW52mGlG6lduzYMfr7++nq6gLC2W4QBKTTabLZrDX89bip641xYWHBVnlqF7++vj56enqsT1kLocbHx7lw4QJTU1O2mMetco3r96q4WUja2mF9fd3u16rXd9xGXI13KpXioYce4vjx4xw5coTOzk6KxSJnzpxhZGSE+fn5WIKtWzHgnwcGgBeNMWdF5OeE7hKLMcaISFVJjTGvAa8B1PrMVnHvzoANtKysrNgsDo2+bw4gNRqdNWrfYO2Hsbi4yMjICENDQ/ZiijMAoyXnupRLpVL09PSQSqVshzcRsZk0H374IefOnSOTyVAoFG7pW11PuXWmqMUwHR0dlMtlm3+shTwatCwWixSLRVsFl8Tm1W5weO/evRw9epTjx4/bxlWaDaXnVw2Oxh90P0Rd3bz//vuUSiW7kqiXD1zdKLpK0RXVfffdt2FX9xs3brC0tGSLVdxsnkb3e9+KDrqRtvaiX1tbs8HjON0oand0RXvixAmefPJJ2020UCjw3nvv8e6779qtCuM4Z1sx4NPAtDHmbPT3nwgN+KyIHDLGBCJyCLjSKCEVHVTNUtCLOpVK2Ub+mtURVzDT9YtqS1EtlV5fX2dycpJMJkM+n7+lCU8j5dLztLy8bM+RLp/7+vrYt2+fTSnUjQa0QY92V2tkdaiiF6mmp5XLZVvIozcXbbK1sLBgfd5xBCxryev6ZN0cYG24BNgZrrtymZqa4tKlSxseuqltvfVxjbjeJCuVCleuhJepOwnSghU3zzopw63fqZllWhwFYXC1WCzG3jLavWnv2bOHw4cP8/jjjzMwMMC+fftsj+/BwUFKpVJs3RJhCwbcGDMjIlMicswYkwGeBi5Gj+eAH0XPbzdU0ojNhml4eNi2yHTT3OK4uN2ULfXVqn9ueXmZfD7P1NQUuVzO9h2Ja2D1IlDDVygUuHHjBouLixSLRZtXfe3aNRsY1MpQDVY22ni7mSj6PZpV5MYx1FerM7A4Apa15HVXDVqQpU2qVldXN6Rqus3B5ufnGRsbY3R0lMnJSVv56Prw662Pnl810m4+uks111gShtv9Xr2xl0olhoeHCYKAtbU127XTla/RbhTXbaKdJ7VGQleu2WyWycnJ2Ldz3GoWyovAm1EGyjjwHeBzwB9F5HlgEvhWY0S8iZ4YNeClUomRkREuX75MqVSyeza6ftG4XBVwcxNcDV4EQWADQ3EVQLgyuTc7NY6VSoUgCGzZvDZTKpfLti1rnL0uYKMB0dkObCyaUMPZ6Aq8O+Ea8Lm5OcbGxujo6GB+fp6uri67n6gWIan/PggCcrkcQRBQLpcbUrxVS173uVq8IKlzWQv3Oq9UKmSzWbsBuK7C6l21XAs3bfSee+5h//791j2q4z49PU0+n2d+fj7Waxy2aMCNMeeBk1Xeerq+4mxJFhvA1AwGbXjkVmvFabh1tqCtVq9fv05nZyeVSoW5ubkNRjFO1IhrEEiLX1zfsrsRhls2HKeM+rx5VlXrc0niLu81FbNUKtHd3W1XNalUChGxs++rV6/aFrzqY05yFdEK6LlZWloin8/bjJTNbRPiSgTQfVm1zYBuZDw7O0s+n+fy5cux5cm7tFwlphsR1wtJl1BJzMzcYIv6jdVAaoA1iUwJVz53Nn79+vWqwZ9muLCbYQm/FdQtoRk0pVIJ2OhSg+o3p2bWq9nQWfjm6tokgtaadaR9yTWbbGJiglwuR6FQiNX3rbScAVea6YJwf2irq6sb0puSmGXdiWaTp5VJ0p2zU0jy/LoTQy2O0j0wS6US+XyemZkZ5ubmYt1mTpGY72Y74pe+2Xfr8XhaF81A0ToTbUWwsrJi2zhU60tfZ9LGmFvc2C07A29mvNH2eNoHd+cnbQkMt7rGkrjuvQH3eDyeO9CsrrLk2np5PB6PZ1vEPQNfJGxDu9PYD5SSFiJmvM47A69zPPRVOxi3Ac9Uc8S3OyLywU7T2+u8M/A6J4t3oXg8Hk+L4g24x+PxtChxG/DXYv6+ZmEn6u113hl4nRMk1kIej8fj8dQP70LxeDyeFsUbcI/H42lRYjPgIvJ1EcmIyGi0i31bIiI5ERkSkfMi8kF07F4R+YeIZKPn7qTl3A4i8rqIXBGRj51jVXWUkF9E4/6RiAwkJ/lnp4bOr4pIIRrr8yJyynnvh5HOGRH5WjJSbw8ReUBE/iUiF0XkExF5KTretmN9G52bc6zdbluNegAdwBjwRWAXcAF4NI7vjvsB5ID9m479BHg5ev0y8OOk5dymjk8R7pP68Z10BE4BfwMEeAw4m7T8ddT5VeAHVT77aPQbv4twU/AxoCNpHT6DzoeAgej1HuBSpFvbjvVtdG7KsY5rBv4VYNQYM26MWQXeAk7H9N3NwGngjej1G8A3EpRl2xhj/g2UNx2upeNp4Hcm5D9AV7SHaktRQ+danAbeMsasGGMmgFHCa6ClMMYExphz0esFYBjopY3H+jY61yLRsY7LgPcCU87f09z+pLQyBvi7iKRF5IXo2EFjTBC9ngEOJiNaQ6mlY7uP/fcid8Hrjmus7XQWkSPAl4Gz7JCx3qQzNOFY+yBm/XnCGDMAPAN8V0Sect804bqrrXM3d4KOEb8CjgIngAD4abLiNAYRSQF/Br5vjLnqvteuY11F56Yc67gMeAF4wPn7C9GxtsMYU4ierwB/JVxOzepSMnq+kpyEDaOWjm079saYWWPM/4wx68Cvubl0bhudRaST0JC9aYz5S3S4rce6ms7NOtZxGfBB4GEReTDa2f5Z4J2Yvjs2RGS3iOzR18BXgY8JdX0u+thzwNvJSNhQaun4DvDtKEPhMaDiLL9bmk3+3W8SjjWEOj8rIneJyIPAw8B/45Zvu0i4c8FvgGFjzM+ct9p2rGvp3LRjHWN09xRhRHcMeCWu743zQZhlcyF6fKJ6Aj3AGSAL/BO4N2lZt6nnHwiXkWuEPr/na+lImJHwy2jch4CTSctfR51/H+n0EeGFfMj5/CuRzhngmaTl/4w6P0HoHvkIOB89TrXzWN9G56Yca19K7/F4PC2KD2J6PB5Pi+INuMfj8bQo3oB7PB5Pi+INuMfj8bQo3oB7PB5Pi+INuMfj8bQo3oB7PB5Pi/J/oQdrR2EDB3kAAAAASUVORK5CYII=\n",
             "text/plain": [
               "<Figure size 432x288 with 2 Axes>"
             ]
@@ -1460,15 +1489,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "cWdvhKDG_f3S",
-        "outputId": "c927132a-4ada-4733-cd14-d502ab82785b",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "outputId": "c927132a-4ada-4733-cd14-d502ab82785b"
       },
       "source": [
         "!ls"
       ],
-      "execution_count": 16,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1514,7 +1543,7 @@
         "plt.savefig('../figures/vae_mnist_conv_2d_rec.pdf')\n",
         "plt.show()"
       ],
-      "execution_count": 18,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1587,7 +1616,7 @@
         "plt.imshow(imgs)\n",
         "plt.savefig('../figures/vae_mnist_conv_20d_samples.pdf')"
       ],
-      "execution_count": 85,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1632,7 +1661,7 @@
         "plt.imshow(imgs)\n",
         "plt.savefig('../figures/vae_mnist_conv_2d_samples.pdf')"
       ],
-      "execution_count": 86,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1700,7 +1729,7 @@
         "plt.tight_layout()\n",
         "plt.savefig('../figures/vae_mnist_conv_20d_grid.pdf')"
       ],
-      "execution_count": 34,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1749,7 +1778,7 @@
         "plt.savefig('../figures/vae_mnist_conv_2d_grid.pdf')\n",
         "\n"
       ],
-      "execution_count": 83,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1804,7 +1833,7 @@
         "\n",
         "plot_scatter_plot(batch, encoder)"
       ],
-      "execution_count": 53,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1843,7 +1872,7 @@
         "fig.savefig('../figures/vae_mnist_conv_20d_embed.pdf')\n",
         "plt.show()"
       ],
-      "execution_count": 62,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1889,7 +1918,7 @@
         "\n",
         "plot_scatter_plot(batch, encoder)"
       ],
-      "execution_count": 63,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1920,7 +1949,7 @@
         "fig=plot_grid_plot(batch, encoder)\n",
         "fig.savefig('../figures/vae_mnist_conv_2d_embed.pdf')"
       ],
-      "execution_count": 64,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1993,7 +2022,7 @@
         "plt.imshow(arr)\n",
         "plt.savefig('../figures/vae_mnist_conv_20d_spherical.pdf')"
       ],
-      "execution_count": 81,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2047,7 +2076,7 @@
         "plt.imshow(arr)\n",
         "plt.savefig('../figures/vae_mnist_conv_2d_spherical.pdf')"
       ],
-      "execution_count": 80,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2112,7 +2141,7 @@
         "plt.tight_layout()\n",
         "plt.savefig('../figures/vae_mnist_conv_20d_linear.pdf')"
       ],
-      "execution_count": 84,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2171,7 +2200,7 @@
         "plt.tight_layout()\n",
         "plt.savefig('../figures/vae_mnist_conv_2d_linear.pdf')"
       ],
-      "execution_count": 78,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",

--- a/notebooks/vae_mnist_mlp_lightning.ipynb
+++ b/notebooks/vae_mnist_mlp_lightning.ipynb
@@ -5,8 +5,7 @@
     "colab": {
       "name": "vae_mnist_mlp.ipynb",
       "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
+      "collapsed_sections": []
     },
     "kernelspec": {
       "name": "python3",
@@ -43,19 +42,19 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "QzYqzmyMdKc_",
-        "outputId": "f1e8b0e7-4807-41cd-c1b2-1d55e067969b"
+        "outputId": "2c230901-b40e-4095-e524-cea5c8e59822"
       },
       "source": [
         "!mkdir figures\n",
         "!mkdir scripts\n",
         "%cd /content/scripts\n",
         "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/pyprobml_utils.py\n",
-        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/lvm_plots_utils.py\n",
+        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae/standalone/lvm_plots_utils.py\n",
         "!wget -q https://github.com/probml/probml-data/raw/main/checkpoints/vae-mnist-mlp.ckpt\n",
-        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae_mlp_mnist.py\n",
+        "!wget -q https://raw.githubusercontent.com/probml/pyprobml/master/scripts/vae/standalone/vae_mlp_mnist.py\n",
         "!wget -q https://github.com/probml/probml-data/raw/main/checkpoints/vae-mnist-mlp-latent-dim-2.ckpt"
       ],
-      "execution_count": 20,
+      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
@@ -75,7 +74,7 @@
         "%%capture\n",
         "! pip install --quiet torchvision pytorch-lightning torch test-tube einops umap"
       ],
-      "execution_count": 21,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -101,7 +100,7 @@
         "from pytorch_lightning.utilities.seed import seed_everything\n",
         "from vae_mlp_mnist import BasicVAEModule"
       ],
-      "execution_count": 22,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -117,7 +116,7 @@
         "seed_everything(42)\n",
         "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
       ],
-      "execution_count": 23,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -139,7 +138,7 @@
         "dm = DataLoader(mnist_full, batch_size=500)\n",
         "batch = next(iter(dm))"
       ],
-      "execution_count": 24,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -165,7 +164,7 @@
         "m.load_state_dict(torch.load(\"vae-mnist-mlp.ckpt\"))\n",
         "m.to(device)"
       ],
-      "execution_count": 27,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -210,7 +209,7 @@
         "m2.load_state_dict(torch.load(\"vae-mnist-mlp-latent-dim-2.ckpt\"))\n",
         "m2.to(device)"
       ],
-      "execution_count": 26,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -272,7 +271,7 @@
         "def reconstruct(img):\n",
         "  return m(rearrange(imgs, \"b c h w -> b ( c h w)\")).reshape(-1, 1, img_size, img_size)"
       ],
-      "execution_count": 42,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -293,7 +292,7 @@
         "axs[1].imshow(rearrange(make_grid(reconstruct(imgs)).cpu(), 'c h w -> h w c'))\n",
         "plt.show()"
       ],
-      "execution_count": 43,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -347,7 +346,7 @@
         "axs[1].imshow(rearrange(make_grid(reconstruct(imgs)).cpu(), 'c h w -> h w c'))\n",
         "plt.show()"
       ],
-      "execution_count": 44,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -426,7 +425,7 @@
         "imgs= get_random_samples(decoder, 5)\n",
         "plt.imshow(imgs)"
       ],
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -483,7 +482,7 @@
         "imgs= get_random_samples(decoder, 5)\n",
         "plt.imshow(imgs)"
       ],
-      "execution_count": 46,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -556,7 +555,7 @@
         "plt.figure(figsize=(10,10))\n",
         "plt.imshow(rearrange(make_grid(get_grid_samples(decoder, 5), 10), \" c h w -> h w c\").cpu().detach())"
       ],
-      "execution_count": 13,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -611,7 +610,7 @@
         "plt.figure(figsize=(10,10))\n",
         "plt.imshow(rearrange(make_grid(get_grid_samples(decoder, 5), 10), \" c h w -> h w c\").cpu().detach())"
       ],
-      "execution_count": 47,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -674,7 +673,7 @@
         "\n",
         "plot_scatter_plot(batch, encoder)"
       ],
-      "execution_count": 49,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -704,7 +703,7 @@
       "source": [
         "plot_grid_plot(batch, encoder)"
       ],
-      "execution_count": 15,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -746,7 +745,7 @@
         "\n",
         "plot_scatter_plot(batch, encoder)"
       ],
-      "execution_count": 52,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -776,7 +775,7 @@
       "source": [
         "plot_grid_plot(batch, encoder)"
       ],
-      "execution_count": 53,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -846,7 +845,7 @@
         "arr = get_imrange(decoder,start,end)\n",
         "plt.imshow(arr)"
       ],
-      "execution_count": 56,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -910,7 +909,7 @@
         "arr = get_imrange(decoder,start,end)\n",
         "plt.imshow(arr)"
       ],
-      "execution_count": 58,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -983,7 +982,7 @@
         "arr = get_imrange(decoder,start,end, interpolation=\"linear\")\n",
         "plt.imshow(arr)"
       ],
-      "execution_count": 59,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1047,7 +1046,7 @@
         "arr = get_imrange(decoder,start,end, interpolation=\"linear\")\n",
         "plt.imshow(arr)"
       ],
-      "execution_count": 60,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",


### PR DESCRIPTION
Update the links to point to standalone files inside the vae standalone script section of pyprobml, so that the notebooks can still be used. 