### PR TITLE
Added `resnet_jax.ipynb` for `resnet_torch.ipynb`

### DIFF
--- a/notebooks-d2l/resnet_jax.ipynb
+++ b/notebooks-d2l/resnet_jax.ipynb
@@ -1,0 +1,772 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "resnet_jax.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-resnet-jax/notebooks-d2l/resnet_jax.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "lPnXuOc7Vgw1"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install flax"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import jax\n",
+        "import jax.numpy as jnp                # JAX NumPy\n",
+        "from jax import lax\n",
+        "import matplotlib.pyplot as plt\n",
+        "import math\n",
+        "from IPython import display \n",
+        "\n",
+        "from flax import linen as nn           # The Linen API\n",
+        "from flax.training import train_state  # Useful dataclass to keep train state\n",
+        "\n",
+        "import numpy as np                     # Ordinary NumPy\n",
+        "import optax                           # Optimizers\n",
+        "\n",
+        "import torchvision\n",
+        "from torch.utils import data\n",
+        "from torchvision import transforms\n",
+        "import tensorflow_datasets as tfds     # TFDS for MNIST\n",
+        "\n",
+        "import random\n",
+        "import os\n",
+        "import time\n",
+        "from typing import Any, Callable, Sequence, Tuple\n",
+        "from functools import partial\n",
+        "\n",
+        "rng = jax.random.PRNGKey(0)\n",
+        "!mkdir figures # for saving plots\n",
+        "ModuleDef = Any"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "F9smiIg4VnEE",
+        "outputId": "7deb8665-0df8-4f7f-ddcc-29b6db7127d9"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "mkdir: cannot create directory ‘figures’: File exists\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Residual block"
+      ],
+      "metadata": {
+        "id": "qJg10m51W3h5"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class  Residual(nn.Module):\n",
+        "  \"\"\"The Residual block of ResNet.\"\"\"\n",
+        "  filters: int\n",
+        "  conv: ModuleDef\n",
+        "  norm: ModuleDef\n",
+        "  strides: Tuple[int, int] = (1, 1)\n",
+        "  use_1x1conv: bool = False\n",
+        "\n",
+        "  @nn.compact\n",
+        "  def __call__(self, x):\n",
+        "    residual = x\n",
+        "\n",
+        "    x = self.conv(self.filters, (3,3), self.strides)(x)\n",
+        "    x = self.norm()(x)\n",
+        "    x = nn.relu(x)\n",
+        "\n",
+        "    x = self.conv(self.filters, (3, 3))(x)\n",
+        "    x = self.norm(scale_init=nn.initializers.zeros)(x)\n",
+        "\n",
+        "    if self.use_1x1conv:\n",
+        "      residual = self.conv(self.filters, (1, 1), self.strides, name='conv_proj')(residual)\n",
+        "      residual = self.norm(name='norm_proj')(residual)\n",
+        "    \n",
+        "    return nn.relu(x+residual)"
+      ],
+      "metadata": {
+        "id": "4Ci7fxALW6PY"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Example where number of input and output channels is the same."
+      ],
+      "metadata": {
+        "id": "M9Z6hWjsYdRa"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train = False\n",
+        "\n",
+        "conv = partial(nn.Conv, use_bias=False, dtype=jnp.float32)\n",
+        "norm = partial(nn.BatchNorm,\n",
+        "               use_running_average=not train,\n",
+        "               momentum=0.9,\n",
+        "               epsilon=1e-5,\n",
+        "               dtype=jnp.float32)\n",
+        "\n",
+        "model = Residual(3, conv, norm)\n",
+        "batch = jnp.ones((4, 6, 6, 3))  # (N, H, W, C) format\n",
+        "variables = model.init(jax.random.PRNGKey(0), batch)\n",
+        "output = model.apply(variables, batch)\n",
+        "output.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wvSJ3ItWYd15",
+        "outputId": "2199cff0-4858-496c-d358-acf567afc26f"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(4, 6, 6, 3)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 4
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Example where we change the number of channels."
+      ],
+      "metadata": {
+        "id": "A4vAoxG_Yeal"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = Residual(6, conv, norm, use_1x1conv=True)\n",
+        "variables = model.init(jax.random.PRNGKey(0), batch)\n",
+        "output = model.apply(variables, batch)\n",
+        "output.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "etLACM6GYft7",
+        "outputId": "ea6006fd-fb1c-4b48-c86a-77c662a3288c"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(4, 6, 6, 6)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Example where we change the number of channels and the spatial size."
+      ],
+      "metadata": {
+        "id": "0D-9LsmkYtBx"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = Residual(6, conv, norm, (2, 2), True)\n",
+        "variables = model.init(jax.random.PRNGKey(0), batch)\n",
+        "output = model.apply(variables, batch)\n",
+        "output.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "SEWmLzpaYtW3",
+        "outputId": "25e9bdea-252e-4c42-e39c-3c466b07cd66"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(4, 3, 3, 6)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 6
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Resnet block\n",
+        "\n",
+        "We define a resnet block to be a sequence of residual blocks, where the first element in the sequence has a 1x1 convolution. However, the first such resnet block does not have 1x1 conv."
+      ],
+      "metadata": {
+        "id": "MWXSLpa7ZzvF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def resnet_block (num_channels, conv, norm, num_residuals, first_block=False):\n",
+        "  blk = []\n",
+        "  for i in range(num_residuals):\n",
+        "    if i == 0 and not first_block:\n",
+        "      blk.append(Residual(num_channels, conv, norm, (2,2), True))\n",
+        "    else:\n",
+        "      blk.append(Residual(num_channels, conv, norm))\n",
+        "  return blk   "
+      ],
+      "metadata": {
+        "id": "CnGQFaC4Z05q"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# The Full Resnet18 Model"
+      ],
+      "metadata": {
+        "id": "LNbnBtZ-aj1g"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class ResNet (nn.Module):\n",
+        "  @nn.compact\n",
+        "  def __call__(self, x, train: bool = True):\n",
+        "\n",
+        "    conv = partial(nn.Conv, use_bias=False, dtype=jnp.float32)\n",
+        "    norm = partial(nn.BatchNorm,\n",
+        "                   use_running_average=not train,\n",
+        "                   momentum=0.9,\n",
+        "                   epsilon=1e-5,\n",
+        "                   dtype=jnp.float32)\n",
+        "    \n",
+        "    x = nn.Conv(64, (7, 7), (2,2), padding=[(3, 3), (3, 3)], name='conv_init')(x)\n",
+        "    x = norm(name='bn_init')(x)\n",
+        "    x = nn.relu(x)\n",
+        "    x = nn.max_pool(x, (3, 3), strides=(2, 2), padding='SAME')\n",
+        "\n",
+        "    b2 = resnet_block(64, conv, norm, 2, True)\n",
+        "    b3 = resnet_block(128, conv, norm, 2)\n",
+        "    b4 = resnet_block(256, conv, norm, 2)\n",
+        "    b5 = resnet_block(512, conv, norm, 2)\n",
+        "\n",
+        "    stages = [b2, b3, b4, b5]\n",
+        "\n",
+        "    for stage in stages:\n",
+        "      for layer in stage:\n",
+        "        x = layer(x)\n",
+        "\n",
+        "    x = jnp.mean(x, axis=(1, 2)) # Works as adaptive avg pooling\n",
+        "    x = nn.Dense(10, dtype=jnp.float32)(x)\n",
+        "    x = jnp.asarray(x, np.float32)\n",
+        "\n",
+        "    return x\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "EtlWTS-wajkk"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = ResNet()\n",
+        "batch = jnp.ones((1, 224, 224, 1))  # (N, H, W, C) format\n",
+        "variables = model.init(jax.random.PRNGKey(0), batch)\n",
+        "output = model.apply(variables, batch, False)\n",
+        "output.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "G0GYXmCNcT-2",
+        "outputId": "06b6c26c-12af-4589-89ae-0f8bb1ba5e63"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(1, 10)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Train on Fashion-MNIST\n",
+        "\n",
+        "We upscale images from 28x28 to 96x96, so that the input to the global average pooling layer has size 3x3 (since the network downscales by a factor of 32)."
+      ],
+      "metadata": {
+        "id": "iWJxvxOt8nTx"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def load_data_fashion_mnist(batch_size, resize=None):\n",
+        "    \"\"\"Download the Fashion-MNIST dataset and then load it into memory.\"\"\"\n",
+        "    trans = [transforms.ToTensor()]\n",
+        "    if resize:\n",
+        "        trans.insert(0, transforms.Resize(resize))\n",
+        "    trans = transforms.Compose(trans)\n",
+        "    mnist_train = torchvision.datasets.FashionMNIST(root=\"../data\",\n",
+        "                                                    train=True,\n",
+        "                                                    transform=trans,\n",
+        "                                                    download=True)\n",
+        "    mnist_test = torchvision.datasets.FashionMNIST(root=\"../data\",\n",
+        "                                                   train=False,\n",
+        "                                                   transform=trans,\n",
+        "                                                   download=True)\n",
+        "    return (data.DataLoader(mnist_train, batch_size, shuffle=True,\n",
+        "                            num_workers=2),\n",
+        "            data.DataLoader(mnist_test, batch_size, shuffle=False,\n",
+        "                            num_workers=2))"
+      ],
+      "metadata": {
+        "id": "9N5UlozefGuw"
+      },
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        " #  Create train state"
+      ],
+      "metadata": {
+        "id": "DdIKdazp84xe"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class TrainState(train_state.TrainState):\n",
+        "  batch_stats: Any"
+      ],
+      "metadata": {
+        "id": "1WtfgkipAhdx"
+      },
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def create_train_state(rng, learning_rate, momentum):\n",
+        "  cnn = ResNet()\n",
+        "  variables = cnn.init(rng, jnp.ones([1, 96, 96, 1], jnp.float32))\n",
+        "  params, batch_stats = variables['params'], variables['batch_stats']\n",
+        "  tx = optax.sgd(learning_rate, momentum)\n",
+        "  state = TrainState.create(apply_fn=cnn.apply, params=params, tx=tx, batch_stats=batch_stats)\n",
+        "  return state"
+      ],
+      "metadata": {
+        "id": "Uqnv07T--TIE"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Metric computation"
+      ],
+      "metadata": {
+        "id": "2I-npsHrBecZ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_metrics(*, logits, labels):\n",
+        "    one_hot = jax.nn.one_hot(labels, num_classes=10)\n",
+        "    loss = jnp.mean(optax.softmax_cross_entropy(logits=logits, labels=one_hot))\n",
+        "    accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)\n",
+        "    metrics = {\n",
+        "        'loss': loss,\n",
+        "        'accuracy': accuracy,\n",
+        "    }\n",
+        "    return metrics"
+      ],
+      "metadata": {
+        "id": "SLU_yQSZ82xd"
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Training step"
+      ],
+      "metadata": {
+        "id": "0Xo2bQqeBxQD"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(state, batch):\n",
+        "  \"\"\"Train for a single step.\"\"\"\n",
+        "  def loss_fn(params):\n",
+        "    logits, new_model_state = state.apply_fn({'params': params, 'batch_stats': state.batch_stats}, batch['image'], mutable=['batch_stats'])\n",
+        "    one_hot = jax.nn.one_hot(batch['label'], num_classes=10)\n",
+        "    loss = jnp.mean(optax.softmax_cross_entropy(logits=logits, labels=one_hot))\n",
+        "\n",
+        "    return loss, (new_model_state, logits)\n",
+        "  \n",
+        "  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
+        "  aux, grads = grad_fn(state.params)\n",
+        "  # grads = lax.pmean(grads, axis_name='batch')\n",
+        "\n",
+        "  new_model_state, logits = aux[1]\n",
+        "  metrics = compute_metrics(logits=logits, labels=batch['label'])\n",
+        "\n",
+        "  new_state = state.apply_gradients(grads=grads, batch_stats=new_model_state['batch_stats'])\n",
+        "\n",
+        "  return new_state, metrics"
+      ],
+      "metadata": {
+        "id": "QtuHT1nrBxyN"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def eval_step(state, batch):\n",
+        "  variables = {'params': state.params, 'batch_stats': state.batch_stats}\n",
+        "  logits = state.apply_fn(variables, batch['image'], train=False, mutable=False)\n",
+        "  return compute_metrics(logits=logits, labels=batch['label'])"
+      ],
+      "metadata": {
+        "id": "WxbvCbD0D5gI"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def eval_model(state, test_iter):\n",
+        "\n",
+        "  batch_metrics = []\n",
+        "\n",
+        "  for i, (X, y) in enumerate(test_iter):\n",
+        "    batch = {}\n",
+        "    batch['image'] = jnp.reshape(jnp.float32(X), (-1,96,96,1))\n",
+        "    batch['label'] = jnp.float32(y)\n",
+        "    metrics = eval_step(state, batch)\n",
+        "    batch_metrics.append(metrics)\n",
+        "\n",
+        "  # compute mean of metrics across each batch in epoch.\n",
+        "  batch_metrics_np = jax.device_get(batch_metrics)\n",
+        "  epoch_metrics_np = {\n",
+        "        k: np.mean([metrics[k] for metrics in batch_metrics_np])\n",
+        "        for k in batch_metrics_np[0]}\n",
+        "  \n",
+        "  return epoch_metrics_np['accuracy']"
+      ],
+      "metadata": {
+        "id": "nCvIaXrPYQnz"
+      },
+      "execution_count": 16,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Plotting"
+      ],
+      "metadata": {
+        "id": "jyOVLntQh8Ub"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class Animator:\n",
+        "    \"\"\"For plotting data in animation.\"\"\"\n",
+        "    def __init__(self, xlabel=None, ylabel=None, legend=None, xlim=None,\n",
+        "                 ylim=None, xscale='linear', yscale='linear',\n",
+        "                 fmts=('-', 'm--', 'g-.', 'r:'), nrows=1, ncols=1,\n",
+        "                 figsize=(3.5, 2.5)):\n",
+        "        # Incrementally plot multiple lines\n",
+        "        if legend is None:\n",
+        "            legend = []\n",
+        "        display.set_matplotlib_formats('svg')\n",
+        "        self.fig, self.axes = plt.subplots(nrows, ncols, figsize=figsize)\n",
+        "        if nrows * ncols == 1:\n",
+        "            self.axes = [self.axes,]\n",
+        "        # Use a lambda function to capture arguments\n",
+        "        self.config_axes = lambda: set_axes(self.axes[\n",
+        "            0], xlabel, ylabel, xlim, ylim, xscale, yscale, legend)\n",
+        "        self.X, self.Y, self.fmts = None, None, fmts\n",
+        "\n",
+        "    def add(self, x, y):\n",
+        "        # Add multiple data points into the figure\n",
+        "        if not hasattr(y, \"__len__\"):\n",
+        "            y = [y]\n",
+        "        n = len(y)\n",
+        "        if not hasattr(x, \"__len__\"):\n",
+        "            x = [x] * n\n",
+        "        if not self.X:\n",
+        "            self.X = [[] for _ in range(n)]\n",
+        "        if not self.Y:\n",
+        "            self.Y = [[] for _ in range(n)]\n",
+        "        for i, (a, b) in enumerate(zip(x, y)):\n",
+        "            if a is not None and b is not None:\n",
+        "                self.X[i].append(a)\n",
+        "                self.Y[i].append(b)\n",
+        "        self.axes[0].cla()\n",
+        "        for x, y, fmt in zip(self.X, self.Y, self.fmts):\n",
+        "            self.axes[0].plot(x, y, fmt)\n",
+        "        self.config_axes()\n",
+        "        display.display(self.fig)\n",
+        "        display.clear_output(wait=True)"
+      ],
+      "metadata": {
+        "id": "5WJdaZMDh-LH"
+      },
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def set_axes(axes, xlabel, ylabel, xlim, ylim, xscale, yscale, legend):\n",
+        "    \"\"\"Set the axes for matplotlib.\"\"\"\n",
+        "    axes.set_xlabel(xlabel)\n",
+        "    axes.set_ylabel(ylabel)\n",
+        "    axes.set_xscale(xscale)\n",
+        "    axes.set_yscale(yscale)\n",
+        "    axes.set_xlim(xlim)\n",
+        "    axes.set_ylim(ylim)\n",
+        "    if legend:\n",
+        "        axes.legend(legend)\n",
+        "    axes.grid()"
+      ],
+      "metadata": {
+        "id": "NPf7I3rWh-FJ"
+      },
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Train function"
+      ],
+      "metadata": {
+        "id": "k6e2dKfnFFzN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train_iter, test_iter = load_data_fashion_mnist(256, resize=96)"
+      ],
+      "metadata": {
+        "id": "2W-Stn_qJVH3"
+      },
+      "execution_count": 25,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "rng, init_rng = jax.random.split(rng)"
+      ],
+      "metadata": {
+        "id": "Kb2MFc7FJWQv"
+      },
+      "execution_count": 26,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "learning_rate = 0.1\n",
+        "momentum = 0.9"
+      ],
+      "metadata": {
+        "id": "5GyeBYBGJZFL"
+      },
+      "execution_count": 27,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "state = create_train_state(init_rng, learning_rate, momentum)\n",
+        "del init_rng  # Must not be used anymore."
+      ],
+      "metadata": {
+        "id": "d2HeJRVtJa27"
+      },
+      "execution_count": 28,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_epochs = 10"
+      ],
+      "metadata": {
+        "id": "s_KMC-LdJdiO"
+      },
+      "execution_count": 29,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "animator = Animator(xlabel='epoch', xlim=[1, num_epochs], legend=['train loss', 'train acc', 'test acc'])\n",
+        "\n",
+        "for epoch in range(num_epochs):\n",
+        "\n",
+        "  batch_metrics = []\n",
+        "\n",
+        "  for i, (X, y) in enumerate(train_iter):\n",
+        "    batch = {}\n",
+        "    batch['image'] = jnp.reshape(jnp.float32(X), (-1,96,96,1))\n",
+        "    batch['label'] = jnp.float32(y)\n",
+        "    state, metrics = train_step(state, batch)\n",
+        "    batch_metrics.append(metrics)\n",
+        "\n",
+        "  # compute mean of metrics across each batch in epoch.\n",
+        "  batch_metrics_np = jax.device_get(batch_metrics)\n",
+        "  epoch_metrics_np = {\n",
+        "        k: np.mean([metrics[k] for metrics in batch_metrics_np])\n",
+        "        for k in batch_metrics_np[0]}\n",
+        "  \n",
+        "  animator.add(epoch+1, (epoch_metrics_np['loss'], epoch_metrics_np['accuracy'], None))\n",
+        "  acc = eval_model(state, test_iter)\n",
+        "  animator.add(epoch+1, (None, None, acc))\n",
+        "\n",
+        "  print('epoch: %d, loss: %.4f, train_accuracy: %.2f, test_accuracy: %.2f' % (\n",
+        "        epoch, epoch_metrics_np['loss'], epoch_metrics_np['accuracy'] * 100, acc * 100))\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 280
+        },
+        "id": "pIyNKmK3OJ-z",
+        "outputId": "3fb67666-5747-4108-a537-9c8b00e26274"
+      },
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "epoch: 9, loss: 0.0608, train_accuracy: 97.78, test_accuracy: 90.72\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 252x180 with 1 Axes>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"181.263962pt\" version=\"1.1\" viewBox=\"0 0 238.965625 181.263962\" width=\"238.965625pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 181.263962 \nL 238.965625 181.263962 \nL 238.965625 -0 \nL 0 -0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 30.103125 143.707712 \nL 225.403125 143.707712 \nL 225.403125 7.807712 \nL 30.103125 7.807712 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 51.803125 143.707712 \nL 51.803125 7.807712 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m77806972cb\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"51.803125\" xlink:href=\"#m77806972cb\" y=\"143.707712\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 2 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(48.621875 158.306149)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 95.203125 143.707712 \nL 95.203125 7.807712 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"95.203125\" xlink:href=\"#m77806972cb\" y=\"143.707712\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 4 -->\n      <defs>\n       <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n      </defs>\n      <g transform=\"translate(92.021875 158.306149)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 138.603125 143.707712 \nL 138.603125 7.807712 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"138.603125\" xlink:href=\"#m77806972cb\" y=\"143.707712\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 6 -->\n      <defs>\n       <path d=\"M 33.015625 40.375 \nQ 26.375 40.375 22.484375 35.828125 \nQ 18.609375 31.296875 18.609375 23.390625 \nQ 18.609375 15.53125 22.484375 10.953125 \nQ 26.375 6.390625 33.015625 6.390625 \nQ 39.65625 6.390625 43.53125 10.953125 \nQ 47.40625 15.53125 47.40625 23.390625 \nQ 47.40625 31.296875 43.53125 35.828125 \nQ 39.65625 40.375 33.015625 40.375 \nz\nM 52.59375 71.296875 \nL 52.59375 62.3125 \nQ 48.875 64.0625 45.09375 64.984375 \nQ 41.3125 65.921875 37.59375 65.921875 \nQ 27.828125 65.921875 22.671875 59.328125 \nQ 17.53125 52.734375 16.796875 39.40625 \nQ 19.671875 43.65625 24.015625 45.921875 \nQ 28.375 48.1875 33.59375 48.1875 \nQ 44.578125 48.1875 50.953125 41.515625 \nQ 57.328125 34.859375 57.328125 23.390625 \nQ 57.328125 12.15625 50.6875 5.359375 \nQ 44.046875 -1.421875 33.015625 -1.421875 \nQ 20.359375 -1.421875 13.671875 8.265625 \nQ 6.984375 17.96875 6.984375 36.375 \nQ 6.984375 53.65625 15.1875 63.9375 \nQ 23.390625 74.21875 37.203125 74.21875 \nQ 40.921875 74.21875 44.703125 73.484375 \nQ 48.484375 72.75 52.59375 71.296875 \nz\n\" id=\"DejaVuSans-54\"/>\n      </defs>\n      <g transform=\"translate(135.421875 158.306149)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-54\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 182.003125 143.707712 \nL 182.003125 7.807712 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"182.003125\" xlink:href=\"#m77806972cb\" y=\"143.707712\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 8 -->\n      <defs>\n       <path d=\"M 31.78125 34.625 \nQ 24.75 34.625 20.71875 30.859375 \nQ 16.703125 27.09375 16.703125 20.515625 \nQ 16.703125 13.921875 20.71875 10.15625 \nQ 24.75 6.390625 31.78125 6.390625 \nQ 38.8125 6.390625 42.859375 10.171875 \nQ 46.921875 13.96875 46.921875 20.515625 \nQ 46.921875 27.09375 42.890625 30.859375 \nQ 38.875 34.625 31.78125 34.625 \nz\nM 21.921875 38.8125 \nQ 15.578125 40.375 12.03125 44.71875 \nQ 8.5 49.078125 8.5 55.328125 \nQ 8.5 64.0625 14.71875 69.140625 \nQ 20.953125 74.21875 31.78125 74.21875 \nQ 42.671875 74.21875 48.875 69.140625 \nQ 55.078125 64.0625 55.078125 55.328125 \nQ 55.078125 49.078125 51.53125 44.71875 \nQ 48 40.375 41.703125 38.8125 \nQ 48.828125 37.15625 52.796875 32.3125 \nQ 56.78125 27.484375 56.78125 20.515625 \nQ 56.78125 9.90625 50.3125 4.234375 \nQ 43.84375 -1.421875 31.78125 -1.421875 \nQ 19.734375 -1.421875 13.25 4.234375 \nQ 6.78125 9.90625 6.78125 20.515625 \nQ 6.78125 27.484375 10.78125 32.3125 \nQ 14.796875 37.15625 21.921875 38.8125 \nz\nM 18.3125 54.390625 \nQ 18.3125 48.734375 21.84375 45.5625 \nQ 25.390625 42.390625 31.78125 42.390625 \nQ 38.140625 42.390625 41.71875 45.5625 \nQ 45.3125 48.734375 45.3125 54.390625 \nQ 45.3125 60.0625 41.71875 63.234375 \nQ 38.140625 66.40625 31.78125 66.40625 \nQ 25.390625 66.40625 21.84375 63.234375 \nQ 18.3125 60.0625 18.3125 54.390625 \nz\n\" id=\"DejaVuSans-56\"/>\n      </defs>\n      <g transform=\"translate(178.821875 158.306149)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-56\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 225.403125 143.707712 \nL 225.403125 7.807712 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"225.403125\" xlink:href=\"#m77806972cb\" y=\"143.707712\"/>\n      </g>\n     </g>\n     <g id=\"text_5\">\n      <!-- 10 -->\n      <defs>\n       <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(219.040625 158.306149)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_6\">\n     <!-- epoch -->\n     <defs>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 48.78125 52.59375 \nL 48.78125 44.1875 \nQ 44.96875 46.296875 41.140625 47.34375 \nQ 37.3125 48.390625 33.40625 48.390625 \nQ 24.65625 48.390625 19.8125 42.84375 \nQ 14.984375 37.3125 14.984375 27.296875 \nQ 14.984375 17.28125 19.8125 11.734375 \nQ 24.65625 6.203125 33.40625 6.203125 \nQ 37.3125 6.203125 41.140625 7.25 \nQ 44.96875 8.296875 48.78125 10.40625 \nL 48.78125 2.09375 \nQ 45.015625 0.34375 40.984375 -0.53125 \nQ 36.96875 -1.421875 32.421875 -1.421875 \nQ 20.0625 -1.421875 12.78125 6.34375 \nQ 5.515625 14.109375 5.515625 27.296875 \nQ 5.515625 40.671875 12.859375 48.328125 \nQ 20.21875 56 33.015625 56 \nQ 37.15625 56 41.109375 55.140625 \nQ 45.0625 54.296875 48.78125 52.59375 \nz\n\" id=\"DejaVuSans-99\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 75.984375 \nL 18.109375 75.984375 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-104\"/>\n     </defs>\n     <g transform=\"translate(112.525 171.984274)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"61.523438\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"186.181641\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"241.162109\" xlink:href=\"#DejaVuSans-104\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_11\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 118.773264 \nL 225.403125 118.773264 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"mc95af540d5\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#mc95af540d5\" y=\"118.773264\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 0.2 -->\n      <defs>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n      </defs>\n      <g transform=\"translate(7.2 122.572482)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_13\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 91.829752 \nL 225.403125 91.829752 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#mc95af540d5\" y=\"91.829752\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 0.4 -->\n      <g transform=\"translate(7.2 95.628971)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_15\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 64.886241 \nL 225.403125 64.886241 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#mc95af540d5\" y=\"64.886241\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 0.6 -->\n      <g transform=\"translate(7.2 68.68546)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-54\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_4\">\n     <g id=\"line2d_17\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 37.94273 \nL 225.403125 37.94273 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_18\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#mc95af540d5\" y=\"37.94273\"/>\n      </g>\n     </g>\n     <g id=\"text_10\">\n      <!-- 0.8 -->\n      <g transform=\"translate(7.2 41.741949)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-56\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_5\">\n     <g id=\"line2d_19\">\n      <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 10.999219 \nL 225.403125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_20\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#mc95af540d5\" y=\"10.999219\"/>\n      </g>\n     </g>\n     <g id=\"text_11\">\n      <!-- 1.0 -->\n      <g transform=\"translate(7.2 14.798437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_21\">\n    <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 71.207178 \nL 51.803125 107.390597 \nL 73.503125 115.397912 \nL 95.203125 119.963981 \nL 116.903125 124.012046 \nL 138.603125 126.84142 \nL 160.303125 130.41732 \nL 182.003125 132.767691 \nL 203.703125 135.526573 \nL 225.403125 137.530439 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"line2d_22\">\n    <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 38.286837 \nL 51.803125 25.100224 \nL 73.503125 22.092063 \nL 95.203125 20.311802 \nL 116.903125 18.97493 \nL 138.603125 17.912757 \nL 160.303125 16.55125 \nL 182.003125 15.768971 \nL 203.703125 14.662747 \nL 225.403125 13.984985 \n\" style=\"fill:none;stroke:#bf00bf;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"line2d_23\">\n    <path clip-path=\"url(#pac492784b9)\" d=\"M 30.103125 29.457101 \nL 51.803125 30.733236 \nL 73.503125 24.852497 \nL 95.203125 22.366016 \nL 116.903125 31.443664 \nL 138.603125 22.576509 \nL 160.303125 20.892541 \nL 182.003125 24.61569 \nL 203.703125 21.695054 \nL 225.403125 23.49743 \n\" style=\"fill:none;stroke:#008000;stroke-dasharray:9.6,2.4,1.5,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 30.103125 143.707712 \nL 30.103125 7.807712 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 225.403125 143.707712 \nL 225.403125 7.807712 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 30.103125 143.707712 \nL 225.403125 143.707712 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 30.103125 7.807712 \nL 225.403125 7.807712 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"legend_1\">\n    <g id=\"patch_7\">\n     <path d=\"M 140.634375 99.274899 \nL 218.403125 99.274899 \nQ 220.403125 99.274899 220.403125 97.274899 \nL 220.403125 54.240524 \nQ 220.403125 52.240524 218.403125 52.240524 \nL 140.634375 52.240524 \nQ 138.634375 52.240524 138.634375 54.240524 \nL 138.634375 97.274899 \nQ 138.634375 99.274899 140.634375 99.274899 \nz\n\" style=\"fill:#ffffff;opacity:0.8;stroke:#cccccc;stroke-linejoin:miter;\"/>\n    </g>\n    <g id=\"line2d_24\">\n     <path d=\"M 142.634375 60.338962 \nL 162.634375 60.338962 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_25\"/>\n    <g id=\"text_12\">\n     <!-- train loss -->\n     <defs>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n      <path id=\"DejaVuSans-32\"/>\n      <path d=\"M 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 0 \nL 9.421875 0 \nz\n\" id=\"DejaVuSans-108\"/>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n     </defs>\n     <g transform=\"translate(170.634375 63.838962)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"80.322266\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"141.601562\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"169.384766\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"232.763672\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"264.550781\" xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"292.333984\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"353.515625\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"405.615234\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n    <g id=\"line2d_26\">\n     <path d=\"M 142.634375 75.017087 \nL 162.634375 75.017087 \n\" style=\"fill:none;stroke:#bf00bf;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_27\"/>\n    <g id=\"text_13\">\n     <!-- train acc -->\n     <g transform=\"translate(170.634375 78.517087)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"80.322266\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"141.601562\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"169.384766\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"232.763672\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"264.550781\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"325.830078\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"380.810547\" xlink:href=\"#DejaVuSans-99\"/>\n     </g>\n    </g>\n    <g id=\"line2d_28\">\n     <path d=\"M 142.634375 89.695212 \nL 162.634375 89.695212 \n\" style=\"fill:none;stroke:#008000;stroke-dasharray:9.6,2.4,1.5,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_29\"/>\n    <g id=\"text_14\">\n     <!-- test acc -->\n     <g transform=\"translate(170.634375 93.195212)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"100.732422\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"152.832031\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"192.041016\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"223.828125\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"285.107422\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"340.087891\" xlink:href=\"#DejaVuSans-99\"/>\n     </g>\n    </g>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"pac492784b9\">\n   <rect height=\"135.9\" width=\"195.3\" x=\"30.103125\" y=\"7.807712\"/>\n  </clipPath>\n </defs>\n</svg>\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        ""
+      ],
+      "metadata": {
+        "id": "4Ah0uYVdOtvs"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Converted `resnet_torch.ipynb` notebook to `resnet_jax.ipynb`.

## Checklist:
 * [x]  Converted `torch` code to `jax`.
 * [x]  Verified that it runs on colab.
 
 ## Potential problems/Important remarks
 The best accuracy on the test set is same as the pytorch code. 

The notebook is available at https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-resnet-jax/notebooks-d2l/resnet_jax.ipynb