### PR TITLE
Added `multi_head_attention_jax.ipynb` for `multi_head_attention.ipynb`

### DIFF
--- a/notebooks-d2l/multi_head_attention_jax.ipynb
+++ b/notebooks-d2l/multi_head_attention_jax.ipynb
@@ -1,0 +1,296 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "multi_head_attention_jax.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyO8gxPUHQxxEah8esp88bOf",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-multi_head_attention_jax/notebooks-d2l/multi_head_attention_jax.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Multi-head attention.\n",
+        "\n",
+        "We show how to multi-head attention.\n",
+        "Based on sec 10.5 of http://d2l.ai/chapter_attention-mechanisms/multihead-attention.html."
+      ],
+      "metadata": {
+        "id": "wLi0wAUA0u5Y"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install flax"
+      ],
+      "metadata": {
+        "id": "dusEMnO30wCC"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import jax\n",
+        "import jax.numpy as jnp                # JAX NumPy\n",
+        "from jax import lax\n",
+        "import math\n",
+        "from IPython import display \n",
+        "\n",
+        "from flax import linen as nn           # The Linen API\n",
+        "from flax.training import train_state  # Useful dataclass to keep train state\n",
+        "\n",
+        "import numpy as np                     # Ordinary NumPy\n",
+        "import optax                           # Optimizers\n",
+        "\n",
+        "rng = jax.random.PRNGKey(0)"
+      ],
+      "metadata": {
+        "id": "IQ6mjh6m0yEY"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Implementation"
+      ],
+      "metadata": {
+        "id": "yMmf_Xs11A6N"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Utility functions."
+      ],
+      "metadata": {
+        "id": "hVcs3_ji1DJc"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def transpose_qkv(X, num_heads):\n",
+        "    # Shape of input `X`:\n",
+        "    # (`batch_size`, no. of queries or key-value pairs, `num_hiddens`).\n",
+        "    # Shape of output `X`:\n",
+        "    # (`batch_size`, no. of queries or key-value pairs, `num_heads`,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    X = X.reshape((X.shape[0], X.shape[1], num_heads, -1))\n",
+        "\n",
+        "    # Shape of output `X`:\n",
+        "    # (`batch_size`, `num_heads`, no. of queries or key-value pairs,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    X = jnp.transpose(X, (0, 2, 1, 3))\n",
+        "    \n",
+        "    # Shape of `output`:\n",
+        "    # (`batch_size` * `num_heads`, no. of queries or key-value pairs,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    return X.reshape((-1, X.shape[2], X.shape[3]))\n",
+        "\n",
+        "\n",
+        "def transpose_output(X, num_heads):\n",
+        "    \"\"\"Reverse the operation of `transpose_qkv`\"\"\"\n",
+        "    X = X.reshape((-1, num_heads, X.shape[1], X.shape[2]))\n",
+        "    X = jnp.transpose(X, (0, 2, 1, 3))\n",
+        "    return X.reshape((X.shape[0], X.shape[1], -1))"
+      ],
+      "metadata": {
+        "id": "FyrU7PKw02Sz"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Main function.\n"
+      ],
+      "metadata": {
+        "id": "Lz5ac5-I1Inf"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def sequence_mask(X, valid_len, value=0):\n",
+        "    \"\"\"Mask irrelevant entries in sequences.\"\"\"\n",
+        "    maxlen = X.shape[1]\n",
+        "    mask = jnp.arange((maxlen), dtype=jnp.float32)[None, :] < valid_len[:, None]\n",
+        "    X = X.at[~mask].set(value)\n",
+        "    return X\n",
+        "\n",
+        "def masked_softmax(X, valid_lens):\n",
+        "    \"\"\"Perform softmax operation by masking elements on the last axis.\"\"\"\n",
+        "    # `X`: 3D tensor, `valid_lens`: 1D or 2D tensor\n",
+        "    if valid_lens is None:\n",
+        "        return nn.softmax(X, dim=-1)\n",
+        "    else:\n",
+        "        shape = X.shape\n",
+        "        if valid_lens.ndim == 1:\n",
+        "            valid_lens = jnp.repeat(valid_lens, shape[1])\n",
+        "        else:\n",
+        "            valid_lens = valid_lens.reshape(-1)\n",
+        "        # On the last axis, replace masked elements with a very large negative\n",
+        "        # value, whose exponentiation outputs 0\n",
+        "        X = sequence_mask(X.reshape(-1, shape[-1]), valid_lens,\n",
+        "                              value=-1e6)\n",
+        "        return nn.softmax(X.reshape(shape), axis=-1)"
+      ],
+      "metadata": {
+        "id": "vSx2qStP1HMr"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class DotProductAttention(nn.Module):\n",
+        "    \"\"\"Scaled dot product attention.\"\"\"\n",
+        "    dropout: float\n",
+        "    \n",
+        "    # Shape of `queries`: (`batch_size`, no. of queries, `d`)\n",
+        "    # Shape of `keys`: (`batch_size`, no. of key-value pairs, `d`)\n",
+        "    # Shape of `values`: (`batch_size`, no. of key-value pairs, value\n",
+        "    # dimension)\n",
+        "    # Shape of `valid_lens`: (`batch_size`,) or (`batch_size`, no. of queries)\n",
+        "    @nn.compact\n",
+        "    def __call__(self, queries, keys, values, valid_lens=None, deterministic=True):\n",
+        "        d = queries.shape[-1]\n",
+        "        scores = queries@(keys.swapaxes(1, 2)) / math.sqrt(d)\n",
+        "        attention_weights = masked_softmax(scores, valid_lens)\n",
+        "        dropout_layer = nn.Dropout(self.dropout, deterministic=deterministic)\n",
+        "        return dropout_layer(attention_weights)@values"
+      ],
+      "metadata": {
+        "id": "RZQBxFP01LGj"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class MultiHeadAttention(nn.Module):\n",
+        "    num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    dropout: float\n",
+        "    bias: bool = False\n",
+        "        \n",
+        "    @nn.compact\n",
+        "    def __call__(self, queries, keys, values, valid_lens):\n",
+        "        # Shape of `queries`, `keys`, or `values`:\n",
+        "        # (`batch_size`, no. of queries or key-value pairs, `num_hiddens`)\n",
+        "        # Shape of `valid_lens`:\n",
+        "        # (`batch_size`,) or (`batch_size`, no. of queries)\n",
+        "        # After transposing, shape of output `queries`, `keys`, or `values`:\n",
+        "        # (`batch_size` * `num_heads`, no. of queries or key-value pairs,\n",
+        "        # `num_hiddens` / `num_heads`)\n",
+        "        queries = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias)(queries), self.num_heads)\n",
+        "        keys = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias)(keys), self.num_heads)\n",
+        "        values = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias)(values), self.num_heads)\n",
+        "        \n",
+        "        if valid_lens is not None:\n",
+        "            # On axis 0, copy the first item (scalar or vector) for\n",
+        "            # `num_heads` times, then copy the next item, and so on\n",
+        "            valid_lens = jnp.repeat(valid_lens, self.num_heads, axis=0)\n",
+        "            \n",
+        "        # Shape of `output`: (`batch_size` * `num_heads`, no. of queries,\n",
+        "        # `num_hiddens` / `num_heads`)\n",
+        "        output = DotProductAttention(self.dropout)(queries, keys, values, valid_lens)\n",
+        "        \n",
+        "        # Shape of `output_concat`:\n",
+        "        # (`batch_size`, no. of queries, `num_hiddens`)\n",
+        "        output_concat = transpose_output(output, self.num_heads)\n",
+        "        return nn.Dense(self.num_hiddens, use_bias=self.bias)(output_concat)"
+      ],
+      "metadata": {
+        "id": "9J5YKN0z1Nby"
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Example\n",
+        "\n",
+        "The shape of the multi-head attention output is (batch_size, num_queries, num_hiddens)."
+      ],
+      "metadata": {
+        "id": "q7yauRxS1RoA"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_hiddens, num_heads = 100, 5\n",
+        "attention = MultiHeadAttention(num_hiddens, num_heads, 0.5)\n",
+        "batch_size, num_queries, num_kvpairs, valid_lens = 2, 4, 6, jnp.array([3, 2])\n",
+        "X = jnp.ones((batch_size, num_queries, num_hiddens))\n",
+        "Y = jnp.ones((batch_size, num_kvpairs, num_hiddens))\n",
+        "variables = attention.init(jax.random.PRNGKey(0), X, Y, Y, valid_lens)\n",
+        "output = attention.apply(variables, X, Y, Y, valid_lens)\n",
+        "output.shape"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gqSglANA1PCJ",
+        "outputId": "52f16213-474d-48de-968d-0ead7c56a633"
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(2, 4, 100)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 7
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        ""
+      ],
+      "metadata": {
+        "id": "vs2BTQ_O1Tqo"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Convert `multi_head_attention.ipynb` to `multi_head_attention_jax.ipynb`

### Colab link

https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-multi_head_attention_jax/notebooks-d2l/multi_head_attention_jax.ipynb

### Issue 

[convert pytorch d2l.ai demos to JAX](https://github.com/probml/pyprobml/issues/686) 

### Steps

- [x] Convert the pytorch code to jax/flax.

### Figures

## Checklist:

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

## Potential problems/Important remarks
