### PR TITLE
Added `rnn_jax.ipynb` for `rnn_torch.ipynb`

### DIFF
--- a/notebooks-d2l/rnn_jax.ipynb
+++ b/notebooks-d2l/rnn_jax.ipynb
@@ -1,0 +1,1241 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/probml/probml-notebooks/blob/main/notebooks-d2l/rnn_jax.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OCwSuMn6YVmk"
+      },
+      "source": [
+        "# Recurrent neural networks\n",
+        "\n",
+        "We show how to implement RNNs from scratch.\n",
+        "Based on sec 8.5 of http://d2l.ai/chapter_recurrent-neural-networks/rnn-scratch.html.\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q flax"
+      ],
+      "metadata": {
+        "id": "HyCT8e35ACRG",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "471c105b-11b9-4582-8a74-cc9969435a79"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[?25l\r\u001b[K     |█▉                              | 10 kB 22.2 MB/s eta 0:00:01\r\u001b[K     |███▋                            | 20 kB 15.0 MB/s eta 0:00:01\r\u001b[K     |█████▍                          | 30 kB 7.7 MB/s eta 0:00:01\r\u001b[K     |███████▏                        | 40 kB 3.5 MB/s eta 0:00:01\r\u001b[K     |█████████                       | 51 kB 3.5 MB/s eta 0:00:01\r\u001b[K     |██████████▊                     | 61 kB 4.1 MB/s eta 0:00:01\r\u001b[K     |████████████▌                   | 71 kB 4.3 MB/s eta 0:00:01\r\u001b[K     |██████████████▎                 | 81 kB 4.8 MB/s eta 0:00:01\r\u001b[K     |████████████████                | 92 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████▉              | 102 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |███████████████████▋            | 112 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▍          | 122 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |███████████████████████▏        | 133 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████       | 143 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▊     | 153 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▌   | 163 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▎ | 174 kB 4.2 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 184 kB 4.2 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 136 kB 47.1 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 72 kB 777 kB/s \n",
+            "\u001b[?25h"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "o6VNlv_FYTbS"
+      },
+      "outputs": [],
+      "source": [
+        "import jax.numpy as jnp\n",
+        "import matplotlib.pyplot as plt\n",
+        "import math\n",
+        "from IPython import display \n",
+        "\n",
+        "import jax\n",
+        "import flax.linen as nn\n",
+        "from flax import jax_utils\n",
+        "import optax\n",
+        "\n",
+        "import collections\n",
+        "import re\n",
+        "import random\n",
+        "import os\n",
+        "import requests\n",
+        "import hashlib\n",
+        "import time\n",
+        "import functools\n",
+        "\n",
+        "random.seed(0)\n",
+        "rng = jax.random.PRNGKey(0)\n",
+        "\n",
+        "!mkdir figures # for saving plots"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wiYH4kGgak5S"
+      },
+      "source": [
+        "# Data\n",
+        "\n",
+        " As data, we use the book \"The Time Machine\" by H G Wells,\n",
+        "preprocessed using the code in [this colab](https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/text_preproc_torch.ipynb)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "tLIKRJomvBV5"
+      },
+      "outputs": [],
+      "source": [
+        "class SeqDataLoader:\n",
+        "    \"\"\"An iterator to load sequence data.\"\"\"\n",
+        "    def __init__(self, batch_size, num_steps, use_random_iter, max_tokens):\n",
+        "        if use_random_iter:\n",
+        "            self.data_iter_fn = seq_data_iter_random\n",
+        "        else:\n",
+        "            self.data_iter_fn = seq_data_iter_sequential\n",
+        "        self.corpus, self.vocab = load_corpus_time_machine(max_tokens)\n",
+        "        self.batch_size, self.num_steps = batch_size, num_steps\n",
+        "\n",
+        "    def __iter__(self):\n",
+        "        return self.data_iter_fn(self.corpus, self.batch_size, self.num_steps)\n",
+        "\n",
+        "class Vocab:\n",
+        "    \"\"\"Vocabulary for text.\"\"\"\n",
+        "    def __init__(self, tokens=None, min_freq=0, reserved_tokens=None):\n",
+        "        if tokens is None:\n",
+        "            tokens = []\n",
+        "        if reserved_tokens is None:\n",
+        "            reserved_tokens = []\n",
+        "        # Sort according to frequencies\n",
+        "        counter = count_corpus(tokens)\n",
+        "        self.token_freqs = sorted(counter.items(), key=lambda x: x[1],\n",
+        "                                  reverse=True)\n",
+        "        # The index for the unknown token is 0\n",
+        "        self.unk, uniq_tokens = 0, ['<unk>'] + reserved_tokens\n",
+        "        uniq_tokens += [\n",
+        "            token for token, freq in self.token_freqs\n",
+        "            if freq >= min_freq and token not in uniq_tokens]\n",
+        "        self.idx_to_token, self.token_to_idx = [], dict()\n",
+        "        for token in uniq_tokens:\n",
+        "            self.idx_to_token.append(token)\n",
+        "            self.token_to_idx[token] = len(self.idx_to_token) - 1\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.idx_to_token)\n",
+        "\n",
+        "    def __getitem__(self, tokens):\n",
+        "        if not isinstance(tokens, (list, tuple)):\n",
+        "            return self.token_to_idx.get(tokens, self.unk)\n",
+        "        return [self.__getitem__(token) for token in tokens]\n",
+        "\n",
+        "    def to_tokens(self, indices):\n",
+        "        if not isinstance(indices, (list, tuple)):\n",
+        "            return self.idx_to_token[indices]\n",
+        "        return [self.idx_to_token[index] for index in indices]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "-TvZsL4gtHQ2"
+      },
+      "outputs": [],
+      "source": [
+        "def tokenize(lines, token='word'):\n",
+        "    \"\"\"Split text lines into word or character tokens.\"\"\"\n",
+        "    if token == 'word':\n",
+        "        return [line.split() for line in lines]\n",
+        "    elif token == 'char':\n",
+        "        return [list(line) for line in lines]\n",
+        "    else:\n",
+        "        print('ERROR: unknown token type: ' + token)\n",
+        "\n",
+        "def count_corpus(tokens):\n",
+        "    \"\"\"Count token frequencies.\"\"\"\n",
+        "    # Here `tokens` is a 1D list or 2D list\n",
+        "    if len(tokens) == 0 or isinstance(tokens[0], list):\n",
+        "        # Flatten a list of token lists into a list of tokens\n",
+        "        tokens = [token for line in tokens for token in line]\n",
+        "    return collections.Counter(tokens)\n",
+        "\n",
+        "def seq_data_iter_random(corpus, batch_size, num_steps):\n",
+        "    \"\"\"Generate a minibatch of subsequences using random sampling.\"\"\"\n",
+        "    # Start with a random offset (inclusive of `num_steps - 1`) to partition a\n",
+        "    # sequence\n",
+        "    corpus = corpus[random.randint(0, num_steps - 1):]\n",
+        "    # Subtract 1 since we need to account for labels\n",
+        "    num_subseqs = (len(corpus) - 1) // num_steps\n",
+        "    # The starting indices for subsequences of length `num_steps`\n",
+        "    initial_indices = list(range(0, num_subseqs * num_steps, num_steps))\n",
+        "    # In random sampling, the subsequences from two adjacent random\n",
+        "    # minibatches during iteration are not necessarily adjacent on the\n",
+        "    # original sequence\n",
+        "    random.shuffle(initial_indices)\n",
+        "\n",
+        "    def data(pos):\n",
+        "        # Return a sequence of length `num_steps` starting from `pos`\n",
+        "        return corpus[pos:pos + num_steps]\n",
+        "\n",
+        "    num_batches = num_subseqs // batch_size\n",
+        "    for i in range(0, batch_size * num_batches, batch_size):\n",
+        "        # Here, `initial_indices` contains randomized starting indices for\n",
+        "        # subsequences\n",
+        "        initial_indices_per_batch = initial_indices[i:i + batch_size]\n",
+        "        X = [data(j) for j in initial_indices_per_batch]\n",
+        "        Y = [data(j + 1) for j in initial_indices_per_batch]\n",
+        "        yield jnp.array(X), jnp.array(Y)\n",
+        "\n",
+        "def seq_data_iter_sequential(corpus, batch_size, num_steps):\n",
+        "    \"\"\"Generate a minibatch of subsequences using sequential partitioning.\"\"\"\n",
+        "    # Start with a random offset to partition a sequence\n",
+        "    offset = random.randint(0, num_steps)\n",
+        "    num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size\n",
+        "    Xs = jnp.array(corpus[offset:offset + num_tokens])\n",
+        "    Ys = jnp.array(corpus[offset + 1:offset + 1 + num_tokens])\n",
+        "    Xs, Ys = Xs.reshape(batch_size, -1), Ys.reshape(batch_size, -1)\n",
+        "    num_batches = Xs.shape[1] // num_steps\n",
+        "    for i in range(0, num_steps * num_batches, num_steps):\n",
+        "        X = Xs[:, i:i + num_steps]\n",
+        "        Y = Ys[:, i:i + num_steps]\n",
+        "        yield X, Y"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "yRp-MH0Nv7rN"
+      },
+      "outputs": [],
+      "source": [
+        "def download(name, cache_dir=os.path.join('..', 'data')):\n",
+        "    \"\"\"Download a file inserted into DATA_HUB, return the local filename.\"\"\"\n",
+        "    assert name in DATA_HUB, f\"{name} does not exist in {DATA_HUB}.\"\n",
+        "    url, sha1_hash = DATA_HUB[name]\n",
+        "    os.makedirs(cache_dir, exist_ok=True)\n",
+        "    fname = os.path.join(cache_dir, url.split('/')[-1])\n",
+        "    if os.path.exists(fname):\n",
+        "        sha1 = hashlib.sha1()\n",
+        "        with open(fname, 'rb') as f:\n",
+        "            while True:\n",
+        "                data = f.read(1048576)\n",
+        "                if not data:\n",
+        "                    break\n",
+        "                sha1.update(data)\n",
+        "        if sha1.hexdigest() == sha1_hash:\n",
+        "            return fname  # Hit cache\n",
+        "    print(f'Downloading {fname} from {url}...')\n",
+        "    r = requests.get(url, stream=True, verify=True)\n",
+        "    with open(fname, 'wb') as f:\n",
+        "        f.write(r.content)\n",
+        "    return fname\n",
+        "\n",
+        "def read_time_machine():\n",
+        "    \"\"\"Load the time machine dataset into a list of text lines.\"\"\"\n",
+        "    with open(download('time_machine'), 'r') as f:\n",
+        "        lines = f.readlines()\n",
+        "    return [re.sub('[^A-Za-z]+', ' ', line).strip().lower() for line in lines]\n",
+        "\n",
+        "def load_corpus_time_machine(max_tokens=-1):\n",
+        "    \"\"\"Return token indices and the vocabulary of the time machine dataset.\"\"\"\n",
+        "    lines = read_time_machine()\n",
+        "    tokens = tokenize(lines, 'char')\n",
+        "    vocab = Vocab(tokens)\n",
+        "    # Since each text line in the time machine dataset is not necessarily a\n",
+        "    # sentence or a paragraph, flatten all the text lines into a single list\n",
+        "    corpus = [vocab[token] for line in tokens for token in line]\n",
+        "    if max_tokens > 0:\n",
+        "        corpus = corpus[:max_tokens]\n",
+        "    return corpus, vocab\n",
+        "\n",
+        "def load_data_time_machine(batch_size, num_steps, use_random_iter=False,\n",
+        "                           max_tokens=10000):\n",
+        "    \"\"\"Return the iterator and the vocabulary of the time machine dataset.\"\"\"\n",
+        "    data_iter = SeqDataLoader(batch_size, num_steps, use_random_iter,\n",
+        "                              max_tokens)\n",
+        "    return data_iter, data_iter.vocab"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "nG2T4maNYdsG",
+        "outputId": "c581b6d0-5934-4ffd-d560-ebf9d927befe"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading ../data/timemachine.txt from http://d2l-data.s3-accelerate.amazonaws.com/timemachine.txt...\n"
+          ]
+        }
+      ],
+      "source": [
+        "DATA_HUB = dict()\n",
+        "DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'\n",
+        "DATA_HUB['time_machine'] = (DATA_URL + 'timemachine.txt',\n",
+        "                                '090b5e7e70c295757f55df93cb0a180b9691891a')\n",
+        "\n",
+        "batch_size, num_steps = 32, 35\n",
+        "train_iter, vocab = load_data_time_machine(batch_size, num_steps)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GGQryRwZauLq"
+      },
+      "source": [
+        "# Model\n",
+        "\n",
+        "We fit an unconditional RNN, for language modeling (ie. not vec2seq or seq2seq. Following the D2L notation, the model has the form\n",
+        "$$\\begin{align}\n",
+        "H_t &= \\phi(X_t W_{xh} + H_{t-1}  W_{hh} + b_h) \\\\\n",
+        "O_t &= H_t W_{hq} + b_q\n",
+        "\\end{align}\n",
+        "$$\n",
+        "where $X_t$ is the $(n,d)$ matrix of (one-hot) inputs \n",
+        "(for batch size $n$ and vocabulary size $d$),\n",
+        "$H_t$ is the $(n,h)$ matrix of hidden states \n",
+        "(for $h$ hidden states),\n",
+        "and $O_t$ is the $(n,q)$ matrix of output logits\n",
+        "(for $q$ output labels, often $q=d$).\n",
+        " \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "3TC24W0EanF7"
+      },
+      "outputs": [],
+      "source": [
+        "# Create the initial parameters\n",
+        "def get_params(vocab_size, num_hiddens, init_rng):\n",
+        "    num_inputs = num_outputs = vocab_size\n",
+        "\n",
+        "    def normal(shape, rng):\n",
+        "        return jax.random.normal(rng, shape=shape) * 0.01\n",
+        "\n",
+        "    hidden_rng, out_rng = jax.random.split(init_rng)\n",
+        "    # Hidden layer parameters\n",
+        "    W_xh = normal((num_inputs, num_hiddens), hidden_rng)\n",
+        "    W_hh = normal((num_hiddens, num_hiddens), hidden_rng)\n",
+        "    b_h = jnp.zeros(num_hiddens)\n",
+        "    # Output layer parameters\n",
+        "    W_hq = normal((num_hiddens, num_outputs), out_rng)\n",
+        "    b_q = jnp.zeros(num_outputs)\n",
+        "    params = [W_xh, W_hh, b_h, W_hq, b_q]\n",
+        "    return params"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "dEf08b5ccaPx"
+      },
+      "outputs": [],
+      "source": [
+        "# Create the initial state\n",
+        "# We assume this is a tuple of one element (later we will use longer tuples)\n",
+        "def init_rnn_state(batch_size, num_hiddens):\n",
+        "    return (jnp.zeros((batch_size, num_hiddens)),)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "NkvId2WmcqFz"
+      },
+      "outputs": [],
+      "source": [
+        "# Forward function. \n",
+        "# Input sequence is (T,B,V), where T is length of the sequence, B is batch size, V is vocab size.\n",
+        "# We iterate over each time step, and process the batch (for that timestep in parallel).\n",
+        "# Output sequence is (T*B, V), since we concatenate all the time steps.\n",
+        "# We also return the final state, so we can process the next subsequence.\n",
+        "@jax.jit\n",
+        "def rnn(params, state, inputs):\n",
+        "    # Here `inputs` shape: (`num_steps`, `batch_size`, `vocab_size`)\n",
+        "    W_xh, W_hh, b_h, W_hq, b_q = params\n",
+        "    H, = state\n",
+        "    outputs = []\n",
+        "    # Shape of `X`: (`batch_size`, `vocab_size`)\n",
+        "    for X in inputs:\n",
+        "        H = jnp.tanh((X @ W_xh) + (H @ W_hh) + b_h)\n",
+        "        Y = H @ W_hq + b_q\n",
+        "        outputs.append(Y)\n",
+        "    return jnp.concatenate(outputs, axis=0), (H,)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "Qw3vhoRKdVxt"
+      },
+      "outputs": [],
+      "source": [
+        "# Make the model class \n",
+        "# Input X to apply is (B,T) matrix of integers (from vocab encoding).\n",
+        "# We transpose this to (T,B) then one-hot encode to (T,B,V), where V is vocab.\n",
+        "# The result is passed to the forward function.\n",
+        "# (We define the forward function as an argument, so we can change it later.)\n",
+        "\n",
+        "class RNNModelScratch: \n",
+        "    \"\"\"A RNN Model implemented from scratch.\"\"\"\n",
+        "    def __init__(self, vocab_size, num_hiddens, get_params, init_state,\n",
+        "                 forward_fn):\n",
+        "        self.vocab_size, self.num_hiddens = vocab_size, num_hiddens\n",
+        "        self.init_state, self.get_params = init_state, get_params\n",
+        "        self.forward_fn = forward_fn\n",
+        "\n",
+        "    def apply(self, params, state, X):\n",
+        "        X = jax.nn.one_hot(X.T, num_classes=self.vocab_size)\n",
+        "        return self.forward_fn(params, state, X)\n",
+        "\n",
+        "    def begin_state(self, batch_size):\n",
+        "        return self.init_state(batch_size, self.num_hiddens)\n",
+        "\n",
+        "    def init_params(self, rng):\n",
+        "        return self.get_params(self.vocab_size, self.num_hiddens, rng)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "zJ2brHhpdbh5"
+      },
+      "outputs": [],
+      "source": [
+        "num_hiddens = 512\n",
+        "net = RNNModelScratch(len(vocab), num_hiddens, get_params, init_rnn_state, rnn)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ibw5knTqdxrv",
+        "outputId": "a03f3d52-85b2-4188-8932-ff1221d889ca"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "1\n",
+            "(2, 512)\n",
+            "28\n",
+            "(10, 28)\n"
+          ]
+        }
+      ],
+      "source": [
+        "X = jnp.arange(10).reshape((2, 5)) # batch 2, sequence length is 5\n",
+        "params = net.init_params(rng)\n",
+        "state = net.begin_state(X.shape[0])\n",
+        "print(len(state)) # length 1\n",
+        "print(state[0].shape) # (2,512)\n",
+        "\n",
+        "Y, new_state = net.apply(params, state, X)\n",
+        "print(len(vocab)) # 28\n",
+        "print(Y.shape) # (2x5, 28)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tLtX5YfSfiBn"
+      },
+      "source": [
+        "# Prediction (generation)\n",
+        "\n",
+        "We pass in an initial prefix string, that is not generated. This is used to \"warm-up\" the hidden state. Specifically, we update the hidden state given the observed prefix, but don't generate anything. After that, for each of the T steps, we compute the (1,V) output tensor, pick the argmax index, and append it to the output. Finally, we convert the to indices to readable token sequence of size (1,T). (Note that this is a greedy, deterministic procedure.)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "MvGhZUIGd3F3"
+      },
+      "outputs": [],
+      "source": [
+        "def predict(prefix, num_preds, net, params, vocab):  \n",
+        "    \"\"\"Generate new characters following the `prefix`.\"\"\"\n",
+        "    state = net.begin_state(batch_size=1)\n",
+        "    outputs = [vocab[prefix[0]]]\n",
+        "    get_input = lambda: jnp.array([outputs[-1]]).reshape((1, 1))\n",
+        "    for y in prefix[1:]:  # Warm-up period\n",
+        "        _, state = net.apply(params, state, get_input())\n",
+        "        outputs.append(vocab[y])\n",
+        "    for _ in range(num_preds):  # Predict `num_preds` steps\n",
+        "        y, state = net.apply(params, state, get_input())\n",
+        "        y = y.reshape(-1, y.shape[-1])\n",
+        "        outputs.append(int(y.argmax(axis=1).reshape(1)))\n",
+        "    return ''.join([vocab.idx_to_token[i] for i in outputs])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 39
+        },
+        "id": "678bHt1ogoh8",
+        "outputId": "bff4ba09-3c01-476a-a1d6-ed6d194b2b5a"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'time traveller cncncncncn'"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
+      ],
+      "source": [
+        "# sample 10 characters after the prefix.\n",
+        "# since the model is untrained, the results will be garbage.\n",
+        "predict('time traveller ', 10, net, params, vocab)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2WTrDGSIhQxN"
+      },
+      "source": [
+        "# Training\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rPuo8za_hUWL"
+      },
+      "source": [
+        "To ensure the gradient doesn't blow up when doing backpropagation through many layers, we use gradient clipping, which corresponds to the update\n",
+        "$$\n",
+        "g := \\min(1, \\theta /||g||) g\n",
+        "$$\n",
+        "where $\\theta$ is the scaling parameter, and $g$ is the gradient vector.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "LDuvumDhgpvh"
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def grad_clipping(grads, theta):\n",
+        "    \"\"\"Clip the gradient.\"\"\"\n",
+        "    def grad_update(grads):\n",
+        "      return jax.tree_map(lambda g: g * theta / norm, grads)\n",
+        "\n",
+        "    norm = jnp.sqrt(sum(jax.tree_util.tree_leaves(jax.tree_map(\n",
+        "        lambda x: jnp.sum(x ** 2), grads))))\n",
+        "    # Update gradient if norm > theta\n",
+        "    # This is jax.jit compatible\n",
+        "    grads = jax.lax.cond(norm > theta, grad_update, lambda g: g, grads)\n",
+        "    return grads"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "D0Exq_Lihxld"
+      },
+      "source": [
+        "The training step is fairly standard, except for the use of gradient clipping, and the issue of the hidden state.\n",
+        "If the data iterator uses random ordering of the sequences, we need to initialize the hidden state for each minibatch. However, if the data iterator uses sequential ordering, we only initialize the hidden state at the very beginning of the process. In the latter case, the hidden state will depend on the value at the previous minibatch.\n",
+        "\n",
+        "The state vector may be a tensor or a tuple, depending on what kind of RNN we are using. In addition, the parameter updater can be an optax optimizer, or a simpler custom sgd optimizer.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "tA_QeZH5rp1o"
+      },
+      "outputs": [],
+      "source": [
+        "class Animator:\n",
+        "    \"\"\"For plotting data in animation.\"\"\"\n",
+        "    def __init__(self, xlabel=None, ylabel=None, legend=None, xlim=None,\n",
+        "                 ylim=None, xscale='linear', yscale='linear',\n",
+        "                 fmts=('-', 'm--', 'g-.', 'r:'), nrows=1, ncols=1,\n",
+        "                 figsize=(3.5, 2.5)):\n",
+        "        # Incrementally plot multiple lines\n",
+        "        if legend is None:\n",
+        "            legend = []\n",
+        "        display.set_matplotlib_formats('svg')\n",
+        "        self.fig, self.axes = plt.subplots(nrows, ncols, figsize=figsize)\n",
+        "        if nrows * ncols == 1:\n",
+        "            self.axes = [self.axes,]\n",
+        "        # Use a lambda function to capture arguments\n",
+        "        self.config_axes = lambda: set_axes(self.axes[\n",
+        "            0], xlabel, ylabel, xlim, ylim, xscale, yscale, legend)\n",
+        "        self.X, self.Y, self.fmts = None, None, fmts\n",
+        "\n",
+        "    def add(self, x, y):\n",
+        "        # Add multiple data points into the figure\n",
+        "        if not hasattr(y, \"__len__\"):\n",
+        "            y = [y]\n",
+        "        n = len(y)\n",
+        "        if not hasattr(x, \"__len__\"):\n",
+        "            x = [x] * n\n",
+        "        if not self.X:\n",
+        "            self.X = [[] for _ in range(n)]\n",
+        "        if not self.Y:\n",
+        "            self.Y = [[] for _ in range(n)]\n",
+        "        for i, (a, b) in enumerate(zip(x, y)):\n",
+        "            if a is not None and b is not None:\n",
+        "                self.X[i].append(a)\n",
+        "                self.Y[i].append(b)\n",
+        "        self.axes[0].cla()\n",
+        "        for x, y, fmt in zip(self.X, self.Y, self.fmts):\n",
+        "            self.axes[0].plot(x, y, fmt)\n",
+        "        self.config_axes()\n",
+        "        display.display(self.fig)\n",
+        "        display.clear_output(wait=True)\n",
+        "\n",
+        "class Timer:\n",
+        "    \"\"\"Record multiple running times.\"\"\"\n",
+        "    def __init__(self):\n",
+        "        self.times = []\n",
+        "        self.start()\n",
+        "\n",
+        "    def start(self):\n",
+        "        \"\"\"Start the timer.\"\"\"\n",
+        "        self.tik = time.time()\n",
+        "\n",
+        "    def stop(self):\n",
+        "        \"\"\"Stop the timer and record the time in a list.\"\"\"\n",
+        "        self.times.append(time.time() - self.tik)\n",
+        "        return self.times[-1]\n",
+        "\n",
+        "    def avg(self):\n",
+        "        \"\"\"Return the average time.\"\"\"\n",
+        "        return sum(self.times) / len(self.times)\n",
+        "\n",
+        "    def sum(self):\n",
+        "        \"\"\"Return the sum of time.\"\"\"\n",
+        "        return sum(self.times)\n",
+        "\n",
+        "    def cumsum(self):\n",
+        "        \"\"\"Return the accumulated time.\"\"\"\n",
+        "        return jnp.array(self.times).cumsum().tolist()\n",
+        "\n",
+        "class Accumulator:\n",
+        "    \"\"\"For accumulating sums over `n` variables.\"\"\"\n",
+        "    def __init__(self, n):\n",
+        "        self.data = [0.0] * n\n",
+        "\n",
+        "    def add(self, *args):\n",
+        "        self.data = [a + float(b) for a, b in zip(self.data, args)]\n",
+        "\n",
+        "    def reset(self):\n",
+        "        self.data = [0.0] * len(self.data)\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        return self.data[idx]\n",
+        "\n",
+        "def set_axes(axes, xlabel, ylabel, xlim, ylim, xscale, yscale, legend):\n",
+        "    \"\"\"Set the axes for matplotlib.\"\"\"\n",
+        "    axes.set_xlabel(xlabel)\n",
+        "    axes.set_ylabel(ylabel)\n",
+        "    axes.set_xscale(xscale)\n",
+        "    axes.set_yscale(yscale)\n",
+        "    axes.set_xlim(xlim)\n",
+        "    axes.set_ylim(ylim)\n",
+        "    if legend:\n",
+        "        axes.legend(legend)\n",
+        "    axes.grid()\n",
+        "\n",
+        "@jax.jit\n",
+        "def sgd(params, grads, lr, batch_size):\n",
+        "    \"\"\"Minibatch stochastic gradient descent.\"\"\"\n",
+        "    params = jax.tree_multimap(lambda p, g: p - lr * g / batch_size, params,\n",
+        "                               grads)\n",
+        "    return params"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(apply_fn, loss_fn, params, state, X, Y):\n",
+        "      def loss(params, state, X, Y):\n",
+        "        y = Y.T.reshape(-1) #(B,T) -> (T,B)\n",
+        "        y_hat, state = apply_fn(params, state, X)\n",
+        "        y_hat = y_hat.reshape(-1, y_hat.shape[-1])\n",
+        "        y_one_hot = jax.nn.one_hot(y, num_classes=y_hat.shape[-1])\n",
+        "        return loss_fn(y_hat, y_one_hot).mean(), state\n",
+        "\n",
+        "      grad_fn = jax.value_and_grad(loss, has_aux=True)\n",
+        "      (l, state), grads = grad_fn(params, state, X, Y)\n",
+        "      grads = grad_clipping(grads, 1)\n",
+        "      return l, state, grads"
+      ],
+      "metadata": {
+        "id": "Tx-RsQNtEihe"
+      },
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "Eq_QMLUKhw3k"
+      },
+      "outputs": [],
+      "source": [
+        "def train_epoch(net, params, train_iter, loss, updater, use_random_iter):\n",
+        "    state, timer = None, Timer()\n",
+        "    metric = Accumulator(2)  # Sum of training loss, no. of tokens\n",
+        "    if isinstance(updater, optax.GradientTransformation):\n",
+        "      updater_state = updater.init(params)\n",
+        "    # Convert to jax Partial functions for jax.jit compatibility \n",
+        "    apply_fn = jax.tree_util.Partial(net.apply)\n",
+        "    loss_fn = jax.tree_util.Partial(loss)\n",
+        "    for X, Y in train_iter:\n",
+        "        if state is None or use_random_iter:\n",
+        "            # Initialize `state` when either it is the first iteration or\n",
+        "            # using random sampling\n",
+        "            state = net.begin_state(batch_size=X.shape[0])\n",
+        "        l, state, grads = train_step(apply_fn, loss_fn, params, state, X, Y)\n",
+        "        if isinstance(updater, optax.GradientTransformation):\n",
+        "            updates, updater_state = updater.update(grads, updater_state)\n",
+        "            params = optax.apply_updates(params, updates)\n",
+        "        else:\n",
+        "            # batch_size=1 since the `mean` function has been invoked\n",
+        "            params = updater(params, grads, batch_size=1)\n",
+        "        metric.add(l * Y.size, Y.size)\n",
+        "    return params, math.exp(metric[0] / metric[1]), metric[1] / timer.stop()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "T64jNH0Ciq4o"
+      },
+      "source": [
+        "The main training function is fairly standard.\n",
+        "The loss function is per-symbol cross-entropy, $-\\log q(x_t)$, where $q$ is the model prediction from the RNN. Since we compute the average loss across time steps within a batch, we are computing $-\\frac{1}{T} \\sum_{t=1}^T \\log p(x_t|x_{1:t-1})$. The exponential of this is the perplexity (ppl). We plot this metric during training, since it is independent of document length. In addition, we print the MAP sequence prediction following the suffix 'time traveller', to get a sense of what the model is doing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "id": "0tPGxQDWiqfl"
+      },
+      "outputs": [],
+      "source": [
+        "def train(net, params, train_iter, vocab, lr, num_epochs,\n",
+        "          use_random_iter=False):\n",
+        "    loss = optax.softmax_cross_entropy\n",
+        "    animator = Animator(xlabel='epoch', ylabel='perplexity',\n",
+        "                            legend=['train'], xlim=[10, num_epochs])\n",
+        "    # Initialize\n",
+        "    if isinstance(net, nn.Module):\n",
+        "        updater = optax.sgd(lr)\n",
+        "    else:\n",
+        "        updater = lambda params, grads, batch_size: sgd(params, grads, lr,\n",
+        "                                                        batch_size)\n",
+        "    num_preds = 50\n",
+        "    predict_ = lambda prefix: predict(prefix, num_preds, net, params, vocab)\n",
+        "    # Train and predict\n",
+        "    for epoch in range(num_epochs):\n",
+        "        params, ppl, speed = train_epoch(net, params, train_iter, loss, updater,\n",
+        "                                     use_random_iter)\n",
+        "        if (epoch + 1) % 10 == 0:\n",
+        "            # Prediction takes time on the flax model\n",
+        "            # print(predict_('time traveller'))\n",
+        "            animator.add(epoch + 1, [ppl])\n",
+        "    device = jax.default_backend()\n",
+        "    print(f'perplexity {ppl:.1f}, {speed:.1f} tokens/sec on {device}')\n",
+        "    print(predict_('time traveller'))\n",
+        "    print(predict_('traveller'))\n",
+        "    return params"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 314
+        },
+        "id": "OfD7J9-YjSCi",
+        "outputId": "c6a52b42-2b73-4ec9-cf4d-ac19f57df051"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "perplexity 1.0, 34154.9 tokens/sec on gpu\n",
+            "time travelleryou can show black is white by argument said filby\n",
+            "travelleryou can show black is white by argument said filby\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 252x180 with 1 Axes>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"180.65625pt\" version=\"1.1\" viewBox=\"0 0 262.1875 180.65625\" width=\"262.1875pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 180.65625 \nL 262.1875 180.65625 \nL 262.1875 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 50.14375 143.1 \nL 245.44375 143.1 \nL 245.44375 7.2 \nL 50.14375 7.2 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 86.015179 143.1 \nL 86.015179 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m5220999b6b\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"86.015179\" xlink:href=\"#m5220999b6b\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 100 -->\n      <defs>\n       <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(76.471429 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 125.872321 143.1 \nL 125.872321 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"125.872321\" xlink:href=\"#m5220999b6b\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 200 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(116.328571 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 165.729464 143.1 \nL 165.729464 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"165.729464\" xlink:href=\"#m5220999b6b\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 300 -->\n      <defs>\n       <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n      </defs>\n      <g transform=\"translate(156.185714 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-51\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 205.586607 143.1 \nL 205.586607 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"205.586607\" xlink:href=\"#m5220999b6b\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 400 -->\n      <defs>\n       <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n      </defs>\n      <g transform=\"translate(196.042857 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 245.44375 143.1 \nL 245.44375 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"245.44375\" xlink:href=\"#m5220999b6b\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_5\">\n      <!-- 500 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(235.9 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_6\">\n     <!-- epoch -->\n     <defs>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 48.78125 52.59375 \nL 48.78125 44.1875 \nQ 44.96875 46.296875 41.140625 47.34375 \nQ 37.3125 48.390625 33.40625 48.390625 \nQ 24.65625 48.390625 19.8125 42.84375 \nQ 14.984375 37.3125 14.984375 27.296875 \nQ 14.984375 17.28125 19.8125 11.734375 \nQ 24.65625 6.203125 33.40625 6.203125 \nQ 37.3125 6.203125 41.140625 7.25 \nQ 44.96875 8.296875 48.78125 10.40625 \nL 48.78125 2.09375 \nQ 45.015625 0.34375 40.984375 -0.53125 \nQ 36.96875 -1.421875 32.421875 -1.421875 \nQ 20.0625 -1.421875 12.78125 6.34375 \nQ 5.515625 14.109375 5.515625 27.296875 \nQ 5.515625 40.671875 12.859375 48.328125 \nQ 20.21875 56 33.015625 56 \nQ 37.15625 56 41.109375 55.140625 \nQ 45.0625 54.296875 48.78125 52.59375 \nz\n\" id=\"DejaVuSans-99\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 75.984375 \nL 18.109375 75.984375 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-104\"/>\n     </defs>\n     <g transform=\"translate(132.565625 171.376563)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"61.523438\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"186.181641\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"241.162109\" xlink:href=\"#DejaVuSans-104\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_11\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 50.14375 122.362153 \nL 245.44375 122.362153 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"m1a3704db5b\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"50.14375\" xlink:href=\"#m1a3704db5b\" y=\"122.362153\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 2.5 -->\n      <defs>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n      </defs>\n      <g transform=\"translate(27.240625 126.161372)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_13\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 50.14375 97.596424 \nL 245.44375 97.596424 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"50.14375\" xlink:href=\"#m1a3704db5b\" y=\"97.596424\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 5.0 -->\n      <g transform=\"translate(27.240625 101.395642)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_15\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 50.14375 72.830694 \nL 245.44375 72.830694 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"50.14375\" xlink:href=\"#m1a3704db5b\" y=\"72.830694\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 7.5 -->\n      <defs>\n       <path d=\"M 8.203125 72.90625 \nL 55.078125 72.90625 \nL 55.078125 68.703125 \nL 28.609375 0 \nL 18.3125 0 \nL 43.21875 64.59375 \nL 8.203125 64.59375 \nz\n\" id=\"DejaVuSans-55\"/>\n      </defs>\n      <g transform=\"translate(27.240625 76.629913)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-55\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_4\">\n     <g id=\"line2d_17\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 50.14375 48.064965 \nL 245.44375 48.064965 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_18\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"50.14375\" xlink:href=\"#m1a3704db5b\" y=\"48.064965\"/>\n      </g>\n     </g>\n     <g id=\"text_10\">\n      <!-- 10.0 -->\n      <g transform=\"translate(20.878125 51.864183)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"159.033203\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_5\">\n     <g id=\"line2d_19\">\n      <path clip-path=\"url(#pa62f418e0b)\" d=\"M 50.14375 23.299235 \nL 245.44375 23.299235 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_20\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"50.14375\" xlink:href=\"#m1a3704db5b\" y=\"23.299235\"/>\n      </g>\n     </g>\n     <g id=\"text_11\">\n      <!-- 12.5 -->\n      <g transform=\"translate(20.878125 27.098454)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"159.033203\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_12\">\n     <!-- perplexity -->\n     <defs>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 0 \nL 9.421875 0 \nz\n\" id=\"DejaVuSans-108\"/>\n      <path d=\"M 54.890625 54.6875 \nL 35.109375 28.078125 \nL 55.90625 0 \nL 45.3125 0 \nL 29.390625 21.484375 \nL 13.484375 0 \nL 2.875 0 \nL 24.125 28.609375 \nL 4.6875 54.6875 \nL 15.28125 54.6875 \nL 29.78125 35.203125 \nL 44.28125 54.6875 \nz\n\" id=\"DejaVuSans-120\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 32.171875 -5.078125 \nQ 28.375 -14.84375 24.75 -17.8125 \nQ 21.140625 -20.796875 15.09375 -20.796875 \nL 7.90625 -20.796875 \nL 7.90625 -13.28125 \nL 13.1875 -13.28125 \nQ 16.890625 -13.28125 18.9375 -11.515625 \nQ 21 -9.765625 23.484375 -3.21875 \nL 25.09375 0.875 \nL 2.984375 54.6875 \nL 12.5 54.6875 \nL 29.59375 11.921875 \nL 46.6875 54.6875 \nL 56.203125 54.6875 \nz\n\" id=\"DejaVuSans-121\"/>\n     </defs>\n     <g transform=\"translate(14.798437 100.276562)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"63.476562\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"166.113281\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"229.589844\" xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"257.373047\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"317.146484\" xlink:href=\"#DejaVuSans-120\"/>\n      <use x=\"376.326172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"404.109375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"443.318359\" xlink:href=\"#DejaVuSans-121\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_21\">\n    <path clip-path=\"url(#pa62f418e0b)\" d=\"M 50.14375 13.377273 \nL 54.129464 41.223737 \nL 58.115179 53.373242 \nL 62.100893 58.137739 \nL 66.086607 61.857548 \nL 70.072321 66.266892 \nL 74.058036 67.72701 \nL 78.04375 71.119995 \nL 82.029464 72.040534 \nL 86.015179 73.317344 \nL 90.000893 77.004691 \nL 93.986607 79.506915 \nL 97.972321 81.204224 \nL 101.958036 83.245942 \nL 105.94375 87.709917 \nL 109.929464 92.359703 \nL 113.915179 97.67781 \nL 117.900893 103.881504 \nL 121.886607 111.353198 \nL 125.872321 116.821771 \nL 129.858036 120.418824 \nL 133.84375 122.704231 \nL 137.829464 127.13747 \nL 141.815179 129.216311 \nL 145.800893 131.496605 \nL 149.786607 132.760729 \nL 153.772321 133.213043 \nL 157.758036 133.56915 \nL 161.74375 134.268636 \nL 165.729464 134.494054 \nL 169.715179 135.178908 \nL 173.700893 135.488996 \nL 177.686607 135.311046 \nL 181.672321 136.331281 \nL 185.658036 136.340958 \nL 189.64375 136.381917 \nL 193.629464 136.54361 \nL 197.615179 136.761772 \nL 201.600893 136.63754 \nL 205.586607 136.771633 \nL 209.572321 136.922727 \nL 213.558036 136.788917 \nL 217.54375 136.706249 \nL 221.529464 136.712741 \nL 225.515179 136.767505 \nL 229.500893 135.86106 \nL 233.486607 135.744492 \nL 237.472321 135.724213 \nL 241.458036 136.770255 \nL 245.44375 136.863702 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 50.14375 143.1 \nL 50.14375 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 245.44375 143.1 \nL 245.44375 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 50.14375 143.1 \nL 245.44375 143.1 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 50.14375 7.2 \nL 245.44375 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"legend_1\">\n    <g id=\"patch_7\">\n     <path d=\"M 183.16875 29.878125 \nL 238.44375 29.878125 \nQ 240.44375 29.878125 240.44375 27.878125 \nL 240.44375 14.2 \nQ 240.44375 12.2 238.44375 12.2 \nL 183.16875 12.2 \nQ 181.16875 12.2 181.16875 14.2 \nL 181.16875 27.878125 \nQ 181.16875 29.878125 183.16875 29.878125 \nz\n\" style=\"fill:#ffffff;opacity:0.8;stroke:#cccccc;stroke-linejoin:miter;\"/>\n    </g>\n    <g id=\"line2d_22\">\n     <path d=\"M 185.16875 20.298437 \nL 205.16875 20.298437 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_23\"/>\n    <g id=\"text_13\">\n     <!-- train -->\n     <defs>\n      <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n     </defs>\n     <g transform=\"translate(213.16875 23.798437)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"80.322266\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"141.601562\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"169.384766\" xlink:href=\"#DejaVuSans-110\"/>\n     </g>\n    </g>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"pa62f418e0b\">\n   <rect height=\"135.9\" width=\"195.3\" x=\"50.14375\" y=\"7.2\"/>\n  </clipPath>\n </defs>\n</svg>\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "random.seed(0)\n",
+        "num_epochs, lr = 500, 1\n",
+        "num_hiddens = 512\n",
+        "net = RNNModelScratch(len(vocab), num_hiddens, get_params, init_rnn_state, rnn)\n",
+        "params = net.init_params(rng)\n",
+        "params = train(net, params, train_iter, vocab, lr, num_epochs)  "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CJ3nTS2flVtH",
+        "outputId": "6fdf5ff8-e026-460a-8ccd-ecc500fe6778"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "time travelleryou can show black is white by argument said filby but you willnever convince mepossibly not said th\n",
+            "the got hege tare ve you in a moment weincline to overlook this fact there are really four dimensionsth\n"
+          ]
+        }
+      ],
+      "source": [
+        "num_preds = 100\n",
+        "predict_ = lambda prefix: predict(prefix, num_preds, net, params, vocab)\n",
+        "\n",
+        "print(predict_('time traveller'))\n",
+        "print(predict_('the'))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "b0TXLX21mJ_I",
+        "outputId": "2f509a01-024c-457f-fc62-c975b7b18516"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "the got hege tare ve you in a moment weincline to overlook this fact there are really four dimensionsthree which we call the three planes of space and a fourth timethere is however a tendency to draw an unreal distinction betweenthe former three dimensions and the latter bectursat dithe thicg to expect us to begin uponsaid filby an argumentative person with red hairi do not mean to ask you to accept anything without reasonableground for it you will soon admit as much as i need from you youknow of c\n"
+          ]
+        }
+      ],
+      "source": [
+        "num_preds = 500\n",
+        "predict_= lambda prefix: predict(prefix, num_preds, net, params, vocab)\n",
+        "\n",
+        "print(predict_('the'))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "URvl3gPSvy2P"
+      },
+      "source": [
+        "# Creating a Flax module\n",
+        "\n",
+        "We now show how to use create an RNN as a module, which is faster than our pure Python implementation.\n",
+        "\n",
+        "While Flax has cells for more advanced recurrent models, it does not have a basic RNNCell. Therefore, we create an RNNCell similar to those defined in `flax.linen.recurrent` [here](https://flax.readthedocs.io/en/latest/_modules/flax/linen/recurrent.html)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from typing import Any, Callable, Tuple\n",
+        "\n",
+        "PRNGKey = Any\n",
+        "Shape = Tuple[int]\n",
+        "Dtype = Any\n",
+        "Array = Any\n",
+        "\n",
+        "class RNNCell(nn.recurrent.RNNCellBase):\n",
+        "    \"\"\"RNN Cell.\"\"\"\n",
+        "    activation_fn: Callable[..., Any] = nn.activation.tanh\n",
+        "    kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = (\n",
+        "        nn.linear.default_kernel_init)\n",
+        "    recurrent_kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = (\n",
+        "        nn.initializers.orthogonal())\n",
+        "    bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = nn.initializers.zeros\n",
+        "    \n",
+        "    @nn.compact\n",
+        "    def __call__(self, carry, inputs):\n",
+        "        \"\"\"RNN Cell.\n",
+        "\n",
+        "        Args:\n",
+        "            carry: the hidden state of the RNN cell,\n",
+        "                initialized using `RNNCell.initialize_carry`.\n",
+        "            inputs: an ndarray with the input for the current time step.\n",
+        "                All dimensions except the final are considered batch dimensions.\n",
+        "\n",
+        "        Returns:\n",
+        "            A tuple with the new carry and the output.\n",
+        "        \"\"\"\n",
+        "        h = carry\n",
+        "        hidden_features = h.shape[-1]\n",
+        "        # Dense layer applied to the previous state\n",
+        "        dense_h = functools.partial(nn.Dense,\n",
+        "                          features=hidden_features,\n",
+        "                          use_bias=False,\n",
+        "                          kernel_init=self.recurrent_kernel_init,\n",
+        "                          bias_init=self.bias_init)\n",
+        "        # Dense layer applied to the input, i\n",
+        "        dense_i = functools.partial(nn.Dense,\n",
+        "                          features=hidden_features,\n",
+        "                          use_bias=True,\n",
+        "                          kernel_init=self.kernel_init,\n",
+        "                          bias_init=self.bias_init)\n",
+        "        new_h = self.activation_fn(dense_i()(inputs) + dense_h()(h))\n",
+        "        return new_h, new_h\n",
+        "    \n",
+        "    @staticmethod\n",
+        "    def initialize_carry(rng, batch_dims, size,\n",
+        "                         init_fn=nn.initializers.zeros):\n",
+        "        \"\"\"Initialize the RNN cell carry.\n",
+        "        Args:\n",
+        "            rng: random number generator passed to the init_fn.\n",
+        "            batch_dims: a tuple providing the shape of the batch dimensions.\n",
+        "            size: the size or number of features of the memory.\n",
+        "            init_fn: initializer function for the carry.\n",
+        "        Returns:\n",
+        "            An initialized carry for the given RNN cell.\n",
+        "        \"\"\"\n",
+        "        mem_shape = batch_dims + (size,)\n",
+        "        return init_fn(rng, mem_shape)"
+      ],
+      "metadata": {
+        "id": "v42JrpEzIm-y"
+      },
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, we create an RNN module to call the RNNCell for each step."
+      ],
+      "metadata": {
+        "id": "rqn-ThsOLEnC"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class RNN(nn.Module):\n",
+        "    @functools.partial(\n",
+        "        nn.transforms.scan,\n",
+        "        variable_broadcast='params',\n",
+        "        in_axes=0, out_axes=0,\n",
+        "        split_rngs={'params': False})\n",
+        "    @nn.compact\n",
+        "    def __call__(self, state, x):\n",
+        "        return RNNCell()(state, x)\n",
+        "\n",
+        "    @staticmethod\n",
+        "    def initialize_carry(rng, batch_dims, size):\n",
+        "        return RNNCell.initialize_carry(rng, batch_dims, size)"
+      ],
+      "metadata": {
+        "id": "SzIM0zW2OT7Q"
+      },
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "6cbe7sYAsAjr",
+        "outputId": "0b1f122f-16c6-4ab4-f667-367098af28ee"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(32, 256)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 25
+        }
+      ],
+      "source": [
+        "num_hiddens = 256\n",
+        "rnn_layer = RNN()\n",
+        "\n",
+        "batch_size, num_steps = 32, 35\n",
+        "state = rnn_layer.initialize_carry(rng, (batch_size,), num_hiddens)\n",
+        "state.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "F1hVhsSgwLLU"
+      },
+      "source": [
+        "Now we update the state with a random one-hot array of inputs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7pAV6m9rwN1d",
+        "outputId": "780baac3-739a-46a4-a182-82db2396d254"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "((35, 32, 256), (32, 256))"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 26
+        }
+      ],
+      "source": [
+        "X = jax.random.normal(rng, shape=(num_steps, batch_size, len(vocab)))\n",
+        "params = rnn_layer.init(rng, state, X)\n",
+        "state_new, Y = rnn_layer.apply(params, state, X)\n",
+        "Y.shape, state_new.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6J9R2aHzwhK_"
+      },
+      "source": [
+        "Now we define our model. It consists of an RNN Layer followed by a dense layer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "id": "89IqhaoSwiRT"
+      },
+      "outputs": [],
+      "source": [
+        "class RNNModel(nn.Module):\n",
+        "    \"\"\"The RNN model.\"\"\"\n",
+        "    rnn: nn.Module\n",
+        "    vocab_size: int\n",
+        "    num_hiddens: int\n",
+        "    bidirectional: bool = False\n",
+        "\n",
+        "    def setup(self):\n",
+        "        # If the RNN is bidirectional (to be introduced later),\n",
+        "        # `num_directions` should be 2, else it should be 1.\n",
+        "        if not self.bidirectional:\n",
+        "            self.num_directions = 1\n",
+        "        else:\n",
+        "            self.num_directions = 2\n",
+        "\n",
+        "    @nn.compact\n",
+        "    def __call__(self, state, inputs):\n",
+        "        X = jax.nn.one_hot(inputs.T, num_classes=self.vocab_size)\n",
+        "        state, Y = self.rnn(state, X)\n",
+        "        output = nn.Dense(self.vocab_size)(Y)\n",
+        "        return output, state\n",
+        "\n",
+        "    def begin_state(self, batch_size=1):\n",
+        "        # Use fixed random key since default state init fn is just `zeros`.\n",
+        "        return self.rnn.initialize_carry(jax.random.PRNGKey(0), (batch_size,),\n",
+        "                                         num_hiddens)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HVO0IVrGxBD1"
+      },
+      "source": [
+        "Test the untrained model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 39
+        },
+        "id": "J19s-kDjwi3F",
+        "outputId": "64ff740a-b4a8-4504-8900-d8ae93cf54d8"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'time travellerfvytfjwjsyijjtjtmfjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj'"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 28
+        }
+      ],
+      "source": [
+        "net = RNNModel(rnn=rnn_layer, vocab_size=len(vocab), num_hiddens=num_hiddens)\n",
+        "params = net.init(rng, state, jnp.ones([batch_size, num_steps]))\n",
+        "predict('time traveller', 50, net, params, vocab)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "V6RGAFRrxIMl"
+      },
+      "source": [
+        "Train it. The results are similar to the 'from scratch' implementation, but much faster."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 314
+        },
+        "id": "O_mu4sc2xEQH",
+        "outputId": "f7b3579d-0b30-42e9-f139-a644c44d54ae"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "perplexity 1.3, 42947.2 tokens/sec on gpu\n",
+            "time traveller fricif ffor d inou with rave yor some malk has i \n",
+            "traveller after the payser whis the fopmer d on anlithith m\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 252x180 with 1 Axes>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"180.65625pt\" version=\"1.1\" viewBox=\"0 0 246.284375 180.65625\" width=\"246.284375pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 180.65625 \nL 246.284375 180.65625 \nL 246.284375 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 34.240625 143.1 \nL 229.540625 143.1 \nL 229.540625 7.2 \nL 34.240625 7.2 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 70.112054 143.1 \nL 70.112054 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m5576eae702\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"70.112054\" xlink:href=\"#m5576eae702\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 100 -->\n      <defs>\n       <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(60.568304 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 109.969196 143.1 \nL 109.969196 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"109.969196\" xlink:href=\"#m5576eae702\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 200 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(100.425446 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 149.826339 143.1 \nL 149.826339 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"149.826339\" xlink:href=\"#m5576eae702\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 300 -->\n      <defs>\n       <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n      </defs>\n      <g transform=\"translate(140.282589 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-51\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 189.683482 143.1 \nL 189.683482 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"189.683482\" xlink:href=\"#m5576eae702\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 400 -->\n      <defs>\n       <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n      </defs>\n      <g transform=\"translate(180.139732 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 229.540625 143.1 \nL 229.540625 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"229.540625\" xlink:href=\"#m5576eae702\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_5\">\n      <!-- 500 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(219.996875 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_6\">\n     <!-- epoch -->\n     <defs>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 48.78125 52.59375 \nL 48.78125 44.1875 \nQ 44.96875 46.296875 41.140625 47.34375 \nQ 37.3125 48.390625 33.40625 48.390625 \nQ 24.65625 48.390625 19.8125 42.84375 \nQ 14.984375 37.3125 14.984375 27.296875 \nQ 14.984375 17.28125 19.8125 11.734375 \nQ 24.65625 6.203125 33.40625 6.203125 \nQ 37.3125 6.203125 41.140625 7.25 \nQ 44.96875 8.296875 48.78125 10.40625 \nL 48.78125 2.09375 \nQ 45.015625 0.34375 40.984375 -0.53125 \nQ 36.96875 -1.421875 32.421875 -1.421875 \nQ 20.0625 -1.421875 12.78125 6.34375 \nQ 5.515625 14.109375 5.515625 27.296875 \nQ 5.515625 40.671875 12.859375 48.328125 \nQ 20.21875 56 33.015625 56 \nQ 37.15625 56 41.109375 55.140625 \nQ 45.0625 54.296875 48.78125 52.59375 \nz\n\" id=\"DejaVuSans-99\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 75.984375 \nL 18.109375 75.984375 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-104\"/>\n     </defs>\n     <g transform=\"translate(116.6625 171.376563)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"61.523438\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"186.181641\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"241.162109\" xlink:href=\"#DejaVuSans-104\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_11\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 34.240625 122.905817 \nL 229.540625 122.905817 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"m466ea92f36\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m466ea92f36\" y=\"122.905817\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 2 -->\n      <g transform=\"translate(20.878125 126.705036)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_13\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 34.240625 84.320914 \nL 229.540625 84.320914 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m466ea92f36\" y=\"84.320914\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 4 -->\n      <g transform=\"translate(20.878125 88.120132)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_15\">\n      <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 34.240625 45.73601 \nL 229.540625 45.73601 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m466ea92f36\" y=\"45.73601\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 6 -->\n      <defs>\n       <path d=\"M 33.015625 40.375 \nQ 26.375 40.375 22.484375 35.828125 \nQ 18.609375 31.296875 18.609375 23.390625 \nQ 18.609375 15.53125 22.484375 10.953125 \nQ 26.375 6.390625 33.015625 6.390625 \nQ 39.65625 6.390625 43.53125 10.953125 \nQ 47.40625 15.53125 47.40625 23.390625 \nQ 47.40625 31.296875 43.53125 35.828125 \nQ 39.65625 40.375 33.015625 40.375 \nz\nM 52.59375 71.296875 \nL 52.59375 62.3125 \nQ 48.875 64.0625 45.09375 64.984375 \nQ 41.3125 65.921875 37.59375 65.921875 \nQ 27.828125 65.921875 22.671875 59.328125 \nQ 17.53125 52.734375 16.796875 39.40625 \nQ 19.671875 43.65625 24.015625 45.921875 \nQ 28.375 48.1875 33.59375 48.1875 \nQ 44.578125 48.1875 50.953125 41.515625 \nQ 57.328125 34.859375 57.328125 23.390625 \nQ 57.328125 12.15625 50.6875 5.359375 \nQ 44.046875 -1.421875 33.015625 -1.421875 \nQ 20.359375 -1.421875 13.671875 8.265625 \nQ 6.984375 17.96875 6.984375 36.375 \nQ 6.984375 53.65625 15.1875 63.9375 \nQ 23.390625 74.21875 37.203125 74.21875 \nQ 40.921875 74.21875 44.703125 73.484375 \nQ 48.484375 72.75 52.59375 71.296875 \nz\n\" id=\"DejaVuSans-54\"/>\n      </defs>\n      <g transform=\"translate(20.878125 49.535229)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-54\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_10\">\n     <!-- perplexity -->\n     <defs>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 0 \nL 9.421875 0 \nz\n\" id=\"DejaVuSans-108\"/>\n      <path d=\"M 54.890625 54.6875 \nL 35.109375 28.078125 \nL 55.90625 0 \nL 45.3125 0 \nL 29.390625 21.484375 \nL 13.484375 0 \nL 2.875 0 \nL 24.125 28.609375 \nL 4.6875 54.6875 \nL 15.28125 54.6875 \nL 29.78125 35.203125 \nL 44.28125 54.6875 \nz\n\" id=\"DejaVuSans-120\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 32.171875 -5.078125 \nQ 28.375 -14.84375 24.75 -17.8125 \nQ 21.140625 -20.796875 15.09375 -20.796875 \nL 7.90625 -20.796875 \nL 7.90625 -13.28125 \nL 13.1875 -13.28125 \nQ 16.890625 -13.28125 18.9375 -11.515625 \nQ 21 -9.765625 23.484375 -3.21875 \nL 25.09375 0.875 \nL 2.984375 54.6875 \nL 12.5 54.6875 \nL 29.59375 11.921875 \nL 46.6875 54.6875 \nL 56.203125 54.6875 \nz\n\" id=\"DejaVuSans-121\"/>\n     </defs>\n     <g transform=\"translate(14.798438 100.276562)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"63.476562\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"166.113281\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"229.589844\" xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"257.373047\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"317.146484\" xlink:href=\"#DejaVuSans-120\"/>\n      <use x=\"376.326172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"404.109375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"443.318359\" xlink:href=\"#DejaVuSans-121\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_17\">\n    <path clip-path=\"url(#pfe0a0e11b1)\" d=\"M 34.240625 13.377273 \nL 38.226339 46.323056 \nL 42.212054 73.699907 \nL 46.197768 88.725939 \nL 50.183482 97.075397 \nL 54.169196 106.575051 \nL 58.154911 111.915854 \nL 62.140625 114.742243 \nL 66.126339 118.654837 \nL 70.112054 122.6965 \nL 74.097768 122.969937 \nL 78.083482 125.436188 \nL 82.069196 124.235639 \nL 86.054911 127.853582 \nL 90.040625 129.25391 \nL 94.026339 130.07521 \nL 98.012054 130.340715 \nL 101.997768 131.021437 \nL 105.983482 130.833997 \nL 109.969196 131.523663 \nL 113.954911 132.825244 \nL 117.940625 133.193117 \nL 121.926339 134.071857 \nL 125.912054 132.249875 \nL 129.897768 133.405561 \nL 133.883482 134.31575 \nL 137.869196 134.02696 \nL 141.854911 133.701678 \nL 145.840625 134.530915 \nL 149.826339 134.54046 \nL 153.812054 133.951847 \nL 157.797768 135.218503 \nL 161.783482 135.552076 \nL 165.769196 135.12201 \nL 169.754911 136.135093 \nL 173.740625 134.624778 \nL 177.726339 135.821215 \nL 181.712054 135.898515 \nL 185.697768 135.865935 \nL 189.683482 134.905811 \nL 193.669196 135.910036 \nL 197.654911 135.676065 \nL 201.640625 135.096077 \nL 205.626339 134.409326 \nL 209.612054 135.896276 \nL 213.597768 136.922727 \nL 217.583482 135.877486 \nL 221.569196 136.272419 \nL 225.554911 136.022037 \nL 229.540625 136.040169 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 34.240625 143.1 \nL 34.240625 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 229.540625 143.1 \nL 229.540625 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 34.240625 143.1 \nL 229.540625 143.1 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 34.240625 7.2 \nL 229.540625 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"legend_1\">\n    <g id=\"patch_7\">\n     <path d=\"M 167.265625 29.878125 \nL 222.540625 29.878125 \nQ 224.540625 29.878125 224.540625 27.878125 \nL 224.540625 14.2 \nQ 224.540625 12.2 222.540625 12.2 \nL 167.265625 12.2 \nQ 165.265625 12.2 165.265625 14.2 \nL 165.265625 27.878125 \nQ 165.265625 29.878125 167.265625 29.878125 \nz\n\" style=\"fill:#ffffff;opacity:0.8;stroke:#cccccc;stroke-linejoin:miter;\"/>\n    </g>\n    <g id=\"line2d_18\">\n     <path d=\"M 169.265625 20.298437 \nL 189.265625 20.298437 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_19\"/>\n    <g id=\"text_11\">\n     <!-- train -->\n     <defs>\n      <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n     </defs>\n     <g transform=\"translate(197.265625 23.798437)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"80.322266\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"141.601562\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"169.384766\" xlink:href=\"#DejaVuSans-110\"/>\n     </g>\n    </g>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"pfe0a0e11b1\">\n   <rect height=\"135.9\" width=\"195.3\" x=\"34.240625\" y=\"7.2\"/>\n  </clipPath>\n </defs>\n</svg>\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "num_epochs, lr = 500, 1\n",
+        "params = train(net, params, train_iter, vocab, lr, num_epochs)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "rnn_jax.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
## Description
 
Converted `rnn_torch.ipynb` to `rnn_jax.ipynb`.

### Colab Link

https://colab.research.google.com/github/UmarJ/probml-notebooks/blob/rnn-jax/notebooks-d2l/rnn_jax.ipynb

### Issue

https://github.com/probml/pyprobml/issues/686

## Checklist

- [x] Converted `torch` code to `jax`.
- [x]  Verified that it runs on Colab.

## Comments

Solved the issues discussed in https://github.com/probml/probml-notebooks/pull/63#issuecomment-1086912628. These were caused by `nn.transforms.scan` not being applied to the `Cell`. Results are now identical to the vanilla JAX and PyTorch implementations.