### PR TITLE
Boolean indices is not jit compatible

### DIFF
--- a/notebooks-d2l/multi_head_attention_jax.ipynb
+++ b/notebooks-d2l/multi_head_attention_jax.ipynb
@@ -129,7 +129,7 @@
         "    \"\"\"Mask irrelevant entries in sequences.\"\"\"\n",
         "    maxlen = X.shape[1]\n",
         "    mask = jnp.arange((maxlen), dtype=jnp.float32)[None, :] < valid_len[:, None]\n",
-        "    X = X.at[~mask].set(value)\n",
+        "    X = jnp.where(~mask, value, X)\n",
         "    return X\n",
         "\n",
         "def masked_softmax(X, valid_lens):\n",


### PR DESCRIPTION
## Description

Boolean indices (e.g., `x.at[x < 0].set(0)`) does not work under JIT compilation.

[Refer here](https://jax.readthedocs.io/en/latest/errors.html#jax.errors.NonConcreteBooleanIndexError)
