### PR TITLE
Add `transformer_jax.ipynb` for `transformer_torch.ipynb`

### DIFF
--- a/notebooks-d2l/transformers_jax.ipynb
+++ b/notebooks-d2l/transformers_jax.ipynb
@@ -1,0 +1,2028 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "m6vJh-hiqW_w"
+      },
+      "source": [
+        "# Transformers\n",
+        "\n",
+        "We show how to implement transformers.\n",
+        "Based on sec 10.7 of http://d2l.ai/chapter_attention-mechanisms/transformer.html\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:42.982225Z",
+          "iopub.status.busy": "2022-04-07T04:20:42.981962Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.556823Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.555890Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:42.982194Z"
+        },
+        "id": "0etSJOpsOPuu",
+        "outputId": "84095501-6e63-48d8-9b70-8e98e5a3ce30",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Collecting flax\n",
+            "  Downloading flax-0.4.1-py3-none-any.whl (184 kB)\n",
+            "\u001b[K     |████████████████████████████████| 184 kB 5.1 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from flax) (3.2.2)\n",
+            "Requirement already satisfied: jax>=0.3 in /usr/local/lib/python3.7/dist-packages (from flax) (0.3.4)\n",
+            "Requirement already satisfied: msgpack in /usr/local/lib/python3.7/dist-packages (from flax) (1.0.3)\n",
+            "Requirement already satisfied: numpy>=1.12 in /usr/local/lib/python3.7/dist-packages (from flax) (1.21.5)\n",
+            "Collecting optax\n",
+            "  Downloading optax-0.1.1-py3-none-any.whl (136 kB)\n",
+            "\u001b[K     |████████████████████████████████| 136 kB 46.5 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from jax>=0.3->flax) (3.10.0.2)\n",
+            "Requirement already satisfied: scipy>=1.2.1 in /usr/local/lib/python3.7/dist-packages (from jax>=0.3->flax) (1.4.1)\n",
+            "Requirement already satisfied: absl-py in /usr/local/lib/python3.7/dist-packages (from jax>=0.3->flax) (1.0.0)\n",
+            "Requirement already satisfied: opt-einsum in /usr/local/lib/python3.7/dist-packages (from jax>=0.3->flax) (3.3.0)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from absl-py->jax>=0.3->flax) (1.15.0)\n",
+            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->flax) (3.0.7)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib->flax) (0.11.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->flax) (2.8.2)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->flax) (1.4.0)\n",
+            "Collecting chex>=0.0.4\n",
+            "  Downloading chex-0.1.2-py3-none-any.whl (72 kB)\n",
+            "\u001b[K     |████████████████████████████████| 72 kB 429 kB/s \n",
+            "\u001b[?25hRequirement already satisfied: jaxlib>=0.1.37 in /usr/local/lib/python3.7/dist-packages (from optax->flax) (0.3.2+cuda11.cudnn805)\n",
+            "Requirement already satisfied: dm-tree>=0.1.5 in /usr/local/lib/python3.7/dist-packages (from chex>=0.0.4->optax->flax) (0.1.6)\n",
+            "Requirement already satisfied: toolz>=0.9.0 in /usr/local/lib/python3.7/dist-packages (from chex>=0.0.4->optax->flax) (0.11.2)\n",
+            "Requirement already satisfied: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from jaxlib>=0.1.37->optax->flax) (2.0)\n",
+            "Installing collected packages: chex, optax, flax\n",
+            "Successfully installed chex-0.1.2 flax-0.4.1 optax-0.1.1\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install flax"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.559798Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.559495Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.572291Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.571603Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.559762Z"
+        },
+        "id": "Y5XhMfBtqSW4",
+        "outputId": "ce91b189-9af2-4411-dee5-51e6a4bb7638",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+          ]
+        }
+      ],
+      "source": [
+        "# import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import pandas as pd\n",
+        "import math\n",
+        "from IPython import display \n",
+        "\n",
+        "import functools\n",
+        "\n",
+        "import collections\n",
+        "import random\n",
+        "import os\n",
+        "import requests\n",
+        "import zipfile\n",
+        "import hashlib\n",
+        "import time\n",
+        "\n",
+        "from jax.config import config\n",
+        "config.update(\"jax_enable_x64\", True)\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import numpy as np\n",
+        "from jax import random\n",
+        "from flax import linen as nn\n",
+        "from flax.training import train_state\n",
+        "import optax\n",
+        "\n",
+        "key = random.PRNGKey(314)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dnCwBw05qn6f"
+      },
+      "source": [
+        "# Layers"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6rE6nWWV2M5_"
+      },
+      "source": [
+        "## Positionwise Feed-Forward Networks"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.575121Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.574569Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.582735Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.581817Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.575082Z"
+        },
+        "id": "8ubc9FVzqovL",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class PositionWiseFFN(nn.Module):\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    ffn_num_outputs: int\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.dense1 = nn.Dense(self.ffn_num_hiddens)\n",
+        "        self.relu = nn.relu\n",
+        "        self.dense2 = nn.Dense(self.ffn_num_outputs)\n",
+        "\n",
+        "    def __call__(self, inputs):\n",
+        "        return self.dense2(self.relu(self.dense1(inputs)))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.587014Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.586794Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.652817Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.651925Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.586980Z"
+        },
+        "id": "TLehwIIwqpRU",
+        "outputId": "414fdfa3-9729-4edf-a274-654110b0e08e",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(2, 3, 8)\n"
+          ]
+        }
+      ],
+      "source": [
+        "ffn = PositionWiseFFN(ffn_num_input=4, ffn_num_hiddens=4, ffn_num_outputs=8) \n",
+        "\n",
+        "x = jnp.ones((2, 3, 4))\n",
+        "key, mykey = random.split(key, 2)\n",
+        "params = ffn.init(mykey, x)\n",
+        "Y = ffn.apply(params, x)\n",
+        "\n",
+        "print(Y.shape)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2n93Mon62Td3"
+      },
+      "source": [
+        "## Residual Connection and Layer Normalization"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.654437Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.654125Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.660906Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.659945Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.654399Z"
+        },
+        "id": "D2A0wMZSq2qt",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class AddNorm(nn.Module):\n",
+        "    dropout_rate: int\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.dropout = nn.Dropout(self.dropout_rate)\n",
+        "        self.ln = nn.LayerNorm()\n",
+        "\n",
+        "    def __call__(self, X, Y, train):\n",
+        "        return self.ln(self.dropout(Y, deterministic = not train) + X)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.662779Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.662292Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.687432Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.686594Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.662743Z"
+        },
+        "id": "VFitw8AFrEC3",
+        "outputId": "67771673-dd3c-4da5-e22f-59713936de34",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(2, 3, 4)"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "add_norm = AddNorm(0.5)  # Normalized_shape is input.size()[1:]\n",
+        "key, mykey = random.split(key, 2)\n",
+        "x = jnp.ones((2, 3, 4))\n",
+        "y = jnp.ones((2, 3, 4))\n",
+        "params = add_norm.init(mykey, x, y, False)\n",
+        "add_norm.apply(params, x, y, False).shape\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_iRpZ75OrIaa"
+      },
+      "source": [
+        "# Encoder"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.689233Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.688966Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.696074Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.695083Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.689198Z"
+        },
+        "id": "nXEUO1gqvQF9",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class DotProductAttention(nn.Module):\n",
+        "    \"\"\"Scaled dot product attention.\"\"\"\n",
+        "    dropout_rate: float\n",
+        "    \n",
+        "    # Shape of `queries`: (`batch_size`, no. of queries, `d`)\n",
+        "    # Shape of `keys`: (`batch_size`, no. of key-value pairs, `d`)\n",
+        "    # Shape of `values`: (`batch_size`, no. of key-value pairs, value\n",
+        "    # dimension)\n",
+        "    # Shape of `valid_lens`: (`batch_size`,) or (`batch_size`, no. of queries)\n",
+        "    @nn.compact\n",
+        "    def __call__(self, queries, keys, values, train, valid_lens=None):\n",
+        "        d = queries.shape[-1]\n",
+        "        scores = queries@(keys.swapaxes(1, 2)) / math.sqrt(d)\n",
+        "        attention_weights = masked_softmax(scores, valid_lens)\n",
+        "        dropout_layer = nn.Dropout(self.dropout_rate, deterministic=not train)\n",
+        "        return dropout_layer(attention_weights)@values, attention_weights"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.697926Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.697680Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.710111Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.709381Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.697893Z"
+        },
+        "id": "PGRyY5fEwBcN",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class MultiHeadAttention(nn.Module):\n",
+        "    num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    dropout: float\n",
+        "    bias: bool = False\n",
+        "        \n",
+        "    @nn.compact\n",
+        "    def __call__(self, queries, keys, values, valid_lens, train):\n",
+        "        # Shape of `queries`, `keys`, or `values`:\n",
+        "        # (`batch_size`, no. of queries or key-value pairs, `num_hiddens`)\n",
+        "        # Shape of `valid_lens`:\n",
+        "        # (`batch_size`,) or (`batch_size`, no. of queries)\n",
+        "        # After transposing, shape of output `queries`, `keys`, or `values`:\n",
+        "        # (`batch_size` * `num_heads`, no. of queries or key-value pairs,\n",
+        "        # `num_hiddens` / `num_heads`)\n",
+        "        queries = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias)(queries), self.num_heads)\n",
+        "        keys = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias)(keys), self.num_heads)\n",
+        "        values = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias)(values), self.num_heads)\n",
+        "        \n",
+        "        if valid_lens is not None:\n",
+        "            # On axis 0, copy the first item (scalar or vector) for\n",
+        "            # `num_heads` times, then copy the next item, and so on\n",
+        "            valid_lens = jnp.repeat(valid_lens, self.num_heads, axis=0)\n",
+        "            \n",
+        "        # Shape of `output`: (`batch_size` * `num_heads`, no. of queries,\n",
+        "        # `num_hiddens` / `num_heads`)\n",
+        "        output, attention_weights = DotProductAttention(self.dropout)(queries, keys, values, train, valid_lens)\n",
+        "        \n",
+        "        # Shape of `output_concat`:\n",
+        "        # (`batch_size`, no. of queries, `num_hiddens`)\n",
+        "        output_concat = transpose_output(output, self.num_heads)\n",
+        "        return nn.Dense(self.num_hiddens, use_bias=self.bias)(output_concat), attention_weights"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.711738Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.711412Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.727317Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.726246Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.711705Z"
+        },
+        "id": "bAhv_p0cNk3Z",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def sequence_mask(X, valid_len, value=0):\n",
+        "    \"\"\"Mask irrelevant entries in sequences.\"\"\"\n",
+        "    maxlen = X.shape[1]\n",
+        "    mask = jnp.arange((maxlen), dtype=jnp.float32)[None, :] < valid_len[:, None]\n",
+        "\n",
+        "    X = jnp.where(~mask, value, X)\n",
+        "    \n",
+        "    return X\n",
+        "\n",
+        "def masked_softmax(X, valid_lens):\n",
+        "    \"\"\"Perform softmax operation by masking elements on the last axis.\"\"\"\n",
+        "    # `X`: 3D tensor, `valid_lens`: 1D or 2D tensor\n",
+        "    if valid_lens is None:\n",
+        "        return nn.softmax(X, axis=-1)\n",
+        "    else:\n",
+        "        shape = X.shape\n",
+        "        if valid_lens.ndim == 1:\n",
+        "            valid_lens = jnp.repeat(valid_lens, shape[1])\n",
+        "        else:\n",
+        "            valid_lens = valid_lens.reshape(-1)\n",
+        "        # On the last axis, replace masked elements with a very large negative\n",
+        "        # value, whose exponentiation outputs 0\n",
+        "        X = sequence_mask(X.reshape(-1, shape[-1]), valid_lens, value=-1e6)\n",
+        "        return nn.softmax(X.reshape(shape), axis=-1)\n",
+        "\n",
+        "def transpose_qkv(X, num_heads):\n",
+        "    # Shape of input `X`:\n",
+        "    # (`batch_size`, no. of queries or key-value pairs, `num_hiddens`).\n",
+        "    # Shape of output `X`:\n",
+        "    # (`batch_size`, no. of queries or key-value pairs, `num_heads`,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    X = X.reshape((X.shape[0], X.shape[1], num_heads, -1))\n",
+        "\n",
+        "    # Shape of output `X`:\n",
+        "    # (`batch_size`, `num_heads`, no. of queries or key-value pairs,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    X = jnp.transpose(X, (0, 2, 1, 3))\n",
+        "    \n",
+        "    # Shape of `output`:\n",
+        "    # (`batch_size` * `num_heads`, no. of queries or key-value pairs,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    return X.reshape((-1, X.shape[2], X.shape[3]))\n",
+        "\n",
+        "\n",
+        "def transpose_output(X, num_heads):\n",
+        "    \"\"\"Reverse the operation of `transpose_qkv`\"\"\"\n",
+        "    X = X.reshape((-1, num_heads, X.shape[1], X.shape[2]))\n",
+        "    X = jnp.transpose(X, (0, 2, 1, 3))\n",
+        "    return X.reshape((X.shape[0], X.shape[1], -1))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.732287Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.731592Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.741812Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.741045Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.732249Z"
+        },
+        "id": "hYl6Y2EAwnE7",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class PositionalEncoding(nn.Module):\n",
+        "    num_hiddens:int\n",
+        "    dropout:float\n",
+        "    max_len = 1000\n",
+        "\n",
+        "    @nn.compact\n",
+        "    def __call__(self, X, train):\n",
+        "        dropout = nn.Dropout(self.dropout)\n",
+        "        P = jax.numpy.zeros((1, self.max_len, self.num_hiddens))\n",
+        "        x = jax.numpy.arange(self.max_len, dtype=jax.numpy.float32).reshape(\n",
+        "            -1, 1) / jax.numpy.power(\n",
+        "                10000,\n",
+        "                jax.numpy.arange(0, self.num_hiddens, 2, dtype=jax.numpy.float32) /\n",
+        "                self.num_hiddens)\n",
+        "        P = P.at[:, :, 0::2].set(jax.numpy.sin(x))\n",
+        "        P = P.at[:, :, 1::2].set(jax.numpy.cos(x))\n",
+        "        \n",
+        "        X = X + P[:, :X.shape[1], :]\n",
+        "        return dropout(X, deterministic= not train), P"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.743788Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.743275Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.754803Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.753927Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.743705Z"
+        },
+        "id": "Zhnkr_RarJCh",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class EncoderBlock(nn.Module):\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    dropout_rate: float\n",
+        "    use_bias: bool = False\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.attention = MultiHeadAttention(self.num_hiddens, self.num_heads, self.dropout_rate, self.use_bias)\n",
+        "        self.addnorm1 = AddNorm(self.dropout_rate)\n",
+        "        self.ffn = PositionWiseFFN(self.ffn_num_input, self.ffn_num_hiddens, self.num_hiddens)\n",
+        "        self.addnorm2 = AddNorm(self.dropout_rate)\n",
+        "\n",
+        "    def __call__(self, X, valid_lens, train):\n",
+        "        output, attention_weights = self.attention(X, X, X, valid_lens, train)\n",
+        "        Y = self.addnorm1(X, output, train)\n",
+        "        return self.addnorm2(Y, self.ffn(Y), train), attention_weights"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.757845Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.757359Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.966220Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.965440Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.757808Z"
+        },
+        "id": "cgfrrCKJrJVp",
+        "outputId": "30e46d90-6975-453e-a8ca-f86e8d604ee7",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(2, 100, 24)"
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "X = jnp.ones((2, 100, 24))\n",
+        "valid_lens = jnp.array([3, 2])\n",
+        "encoder_blk = EncoderBlock(24, 24, 48, 8, 0.5)\n",
+        "key, mykey = random.split(key, 2)\n",
+        "params = encoder_blk.init(mykey, X, valid_lens, False)\n",
+        "encoder_blk_output = encoder_blk.apply(params, X, valid_lens, False)[0]\n",
+        "encoder_blk_output.shape"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.967909Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.967407Z",
+          "iopub.status.idle": "2022-04-07T04:20:50.977486Z",
+          "shell.execute_reply": "2022-04-07T04:20:50.976695Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.967865Z"
+        },
+        "id": "9BHcHiBIrMZ_",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class TransformerEncoder(nn.Module):\n",
+        "    vocab_size: int\n",
+        "    num_hiddens:int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    num_layers: int\n",
+        "    dropout_rate: float\n",
+        "    use_bias: bool=False\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.embedding = nn.Embed(self.vocab_size, self.num_hiddens)\n",
+        "        self.pos_encoding = PositionalEncoding(self.num_hiddens, self.dropout_rate)\n",
+        "        self.blks = [EncoderBlock(self.num_hiddens, self.ffn_num_input, self.ffn_num_hiddens,\n",
+        "                             self.num_heads, self.dropout_rate, self.use_bias) for _ in range(self.num_layers)]\n",
+        "\n",
+        "    def __call__(self, X, valid_lens, train):\n",
+        "        # Since positional encoding values are between -1 and 1, the embedding\n",
+        "        # values are multiplied by the square root of the embedding dimension\n",
+        "        # to rescale before they are summed up\n",
+        "        X, _ = self.pos_encoding(self.embedding(X) * jnp.sqrt(self.num_hiddens), train)\n",
+        "\n",
+        "        attention_weights = [None] * len(self.blks)\n",
+        "        for i, blk in enumerate(self.blks):\n",
+        "            X, attention_weight = blk(X, valid_lens, train)\n",
+        "            attention_weights[i] = attention_weight\n",
+        "        return X, attention_weights"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vn1g8puTrUdw"
+      },
+      "source": [
+        "The shape of the transformer encoder output is (batch size, number of time steps, num_hiddens)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:50.979210Z",
+          "iopub.status.busy": "2022-04-07T04:20:50.978697Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.401045Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.400357Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:50.979172Z"
+        },
+        "id": "O-u7PLrTrPsT",
+        "outputId": "07101f26-0f45-4fde-b0b8-8a535fa5d2fe",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(2, 100, 24)"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "encoder_test = TransformerEncoder(200, 24, 24, 48, 8, 2, 0.5)\n",
+        "key, mykey = random.split(key, 2)\n",
+        "x = jnp.ones((2, 100), jnp.int64)\n",
+        "valid_lens = jnp.array([3, 2])\n",
+        "params = encoder_test.init(mykey, x, valid_lens, False)\n",
+        "encoder_test.apply(params, x, valid_lens, False)[0].shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "l5JEeGFirWUZ"
+      },
+      "source": [
+        "# Decoder"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.403193Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.402640Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.416087Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.415201Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.403157Z"
+        },
+        "id": "x1GX2mrhrWvJ",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class DecoderBlock(nn.Module):\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    dropout_rate: float\n",
+        "    i: int\n",
+        "\n",
+        "    # The `i`-th block in the decoder\n",
+        "    def setup(self):\n",
+        "        self.attention1 = MultiHeadAttention(self.num_hiddens, self.num_heads, self.dropout_rate)\n",
+        "        self.addnorm1 = AddNorm(self.dropout_rate)\n",
+        "        self.attention2 = MultiHeadAttention(self.num_hiddens, self.num_heads, self.dropout_rate)\n",
+        "        self.addnorm2 = AddNorm(self.dropout_rate)\n",
+        "        self.ffn = PositionWiseFFN(self.ffn_num_input, self.ffn_num_hiddens, self.num_hiddens)\n",
+        "        self.addnorm3 = AddNorm(self.dropout_rate)\n",
+        "\n",
+        "    def __call__(self, X, state, train):\n",
+        "        enc_outputs, enc_valid_lens = state[0], state[1]\n",
+        "        # During training, all the tokens of any output sequence are processed\n",
+        "        # at the same time, so `state[2][self.i]` is `None` as initialized.\n",
+        "        # When decoding any output sequence token by token during prediction,\n",
+        "        # `state[2][self.i]` contains representations of the decoded output at\n",
+        "        # the `i`-th block up to the current time step\n",
+        "        if state[2][self.i] is None:\n",
+        "            key_values = X\n",
+        "        else:\n",
+        "            key_values = jnp.concatenate((state[2][self.i], X), axis=1)\n",
+        "        state[2][self.i] = key_values\n",
+        "\n",
+        "        if train:\n",
+        "            batch_size, num_steps, _ = X.shape\n",
+        "            # Shape of `dec_valid_lens`: (`batch_size`, `num_steps`), where\n",
+        "            # every row is [1, 2, ..., `num_steps`]\n",
+        "            dec_valid_lens = jnp.tile(jnp.arange(1, num_steps + 1), (batch_size, 1))\n",
+        "        else:\n",
+        "            dec_valid_lens = None\n",
+        "\n",
+        "        # Self-attention\n",
+        "        X2, attention_weight1 = self.attention1(X, key_values, key_values, dec_valid_lens, train)\n",
+        "        Y = self.addnorm1(X, X2, train)\n",
+        "        # Encoder-decoder attention. Shape of `enc_outputs`:\n",
+        "        # (`batch_size`, `num_steps`, `num_hiddens`)\n",
+        "        Y2, attention_weight2 = self.attention2(Y, enc_outputs, enc_outputs, enc_valid_lens, train)\n",
+        "        Z = self.addnorm2(Y, Y2, train)\n",
+        "        return self.addnorm3(Z, self.ffn(Z), train), state, attention_weight1, attention_weight2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.417554Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.417235Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.730238Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.729581Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.417502Z"
+        },
+        "id": "3LQ9ei-ardtA",
+        "outputId": "7fb732e9-354c-4288-95ed-ca2837ac1030",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(2, 100, 24)"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "decoder_blk = DecoderBlock(24, 24, 48, 8, 0.5, 0)\n",
+        "key, mykey = random.split(key, 2)\n",
+        "X = jnp.ones((2, 100, 24))\n",
+        "state = [encoder_blk_output, valid_lens, [None]]\n",
+        "train = False\n",
+        "params = decoder_blk.init(mykey, X, state, train)\n",
+        "decoder_blk.apply(params, X, state, train)[0].shape"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.733033Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.732617Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.743862Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.743056Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.732993Z"
+        },
+        "id": "0eV-Q0NGrfwV",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class TransformerDecoder(nn.Module):\n",
+        "    vocab_size: int\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    num_layers: int\n",
+        "    dropout_rate: float\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.embedding = nn.Embed(self.vocab_size, self.num_hiddens)\n",
+        "        self.pos_encoding = PositionalEncoding(self.num_hiddens, self.dropout_rate)\n",
+        "        self.blks = [DecoderBlock(self.num_hiddens, self.ffn_num_input, self.ffn_num_hiddens, self.num_heads, self.dropout_rate, i) for i in range(self.num_layers)]\n",
+        "        self.dense = nn.Dense(self.vocab_size)\n",
+        "\n",
+        "    def init_state(self, enc_outputs, enc_valid_lens):\n",
+        "        return [enc_outputs, enc_valid_lens, [None] * self.num_layers]\n",
+        "\n",
+        "    def __call__(self, X, state, train):\n",
+        "        X, _ = self.pos_encoding(self.embedding(X) * jnp.sqrt(self.num_hiddens), train)\n",
+        "        attention_weights = [[None] * len(self.blks) for _ in range(2)]\n",
+        "        for i, blk in enumerate(self.blks):\n",
+        "            X, state, attention_weight1, attention_weight2 = blk(X, state, train)\n",
+        "            # Decoder self-attention weights\n",
+        "            attention_weights[0][i] = attention_weight1\n",
+        "            # Encoder-decoder attention weights\n",
+        "            attention_weights[1][i] = attention_weight2\n",
+        "        return self.dense(X), state, attention_weights"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CQFOi9zqCuvG"
+      },
+      "source": [
+        "# Transformer"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.745714Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.745259Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.756492Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.755764Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.745667Z"
+        },
+        "id": "FxSdJDZY8Hfg",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class EncoderDecoder(nn.Module):\n",
+        "    encoder: nn.Module\n",
+        "    decoder: nn.Module\n",
+        "\n",
+        "    def __call__(self, enc_X, valid_lens, dec_X, train):\n",
+        "        enc_outputs, attention_weights = self.encoder(enc_X, valid_lens, train)\n",
+        "        dec_state = self.decoder.init_state(enc_outputs, valid_lens)\n",
+        "        return (*self.decoder(dec_X, dec_state, train), attention_weights)\n",
+        "    \n",
+        "    def encode(self, enc_X, valid_lens, train):\n",
+        "      return self.encoder(enc_X, valid_lens, train)\n",
+        "\n",
+        "\n",
+        "    def decode(self, dec_X, dec_state, train):\n",
+        "      return self.decoder(dec_X, dec_state, train)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "j4fhuNfGrrAF"
+      },
+      "source": [
+        "# Full model\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.758512Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.758182Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.772368Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.771492Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.758407Z"
+        },
+        "id": "o_C6Ke82BM7V",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "# Required functions for downloading data\n",
+        "from torch.utils import data\n",
+        "import torch\n",
+        "\n",
+        "def download(name, cache_dir=os.path.join('..', 'data')):\n",
+        "    \"\"\"Download a file inserted into DATA_HUB, return the local filename.\"\"\"\n",
+        "    assert name in DATA_HUB, f\"{name} does not exist in {DATA_HUB}.\"\n",
+        "    url, sha1_hash = DATA_HUB[name]\n",
+        "    os.makedirs(cache_dir, exist_ok=True)\n",
+        "    fname = os.path.join(cache_dir, url.split('/')[-1])\n",
+        "    if os.path.exists(fname):\n",
+        "        sha1 = hashlib.sha1()\n",
+        "        with open(fname, 'rb') as f:\n",
+        "            while True:\n",
+        "                data = f.read(1048576)\n",
+        "                if not data:\n",
+        "                    break\n",
+        "                sha1.update(data)\n",
+        "        if sha1.hexdigest() == sha1_hash:\n",
+        "            return fname  # Hit cache\n",
+        "    print(f'Downloading {fname} from {url}...')\n",
+        "    r = requests.get(url, stream=True, verify=True)\n",
+        "    with open(fname, 'wb') as f:\n",
+        "        f.write(r.content)\n",
+        "    return fname\n",
+        "\n",
+        "def download_extract(name, folder=None):\n",
+        "    \"\"\"Download and extract a zip/tar file.\"\"\"\n",
+        "    fname = download(name)\n",
+        "    base_dir = os.path.dirname(fname)\n",
+        "    data_dir, ext = os.path.splitext(fname)\n",
+        "    if ext == '.zip':\n",
+        "        fp = zipfile.ZipFile(fname, 'r')\n",
+        "    elif ext in ('.tar', '.gz'):\n",
+        "        fp = tarfile.open(fname, 'r')\n",
+        "    else:\n",
+        "        assert False, 'Only zip/tar files can be extracted.'\n",
+        "    fp.extractall(base_dir)\n",
+        "    return os.path.join(base_dir, folder) if folder else data_dir"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.774602Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.774131Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.786334Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.785490Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.774363Z"
+        },
+        "id": "-c0dzTV5AXXn",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def read_data_nmt():\n",
+        "    \"\"\"Load the English-French dataset.\"\"\"\n",
+        "    data_dir = download_extract('fra-eng')\n",
+        "    with open(os.path.join(data_dir, 'fra.txt'), 'r') as f:\n",
+        "        return f.read()\n",
+        "\n",
+        "def preprocess_nmt(text):\n",
+        "    \"\"\"Preprocess the English-French dataset.\"\"\"\n",
+        "    def no_space(char, prev_char):\n",
+        "        return char in set(',.!?') and prev_char != ' '\n",
+        "\n",
+        "    # Replace non-breaking space with space, and convert uppercase letters to\n",
+        "    # lowercase ones\n",
+        "    text = text.replace('\\u202f', ' ').replace('\\xa0', ' ').lower()\n",
+        "    # Insert space between words and punctuation marks\n",
+        "    out = [\n",
+        "        ' ' + char if i > 0 and no_space(char, text[i - 1]) else char\n",
+        "        for i, char in enumerate(text)]\n",
+        "    return ''.join(out)\n",
+        "\n",
+        "def tokenize_nmt(text, num_examples=None):\n",
+        "    \"\"\"Tokenize the English-French dataset.\"\"\"\n",
+        "    source, target = [], []\n",
+        "    for i, line in enumerate(text.split('\\n')):\n",
+        "        if num_examples and i > num_examples:\n",
+        "            break\n",
+        "        parts = line.split('\\t')\n",
+        "        if len(parts) == 2:\n",
+        "            source.append(parts[0].split(' '))\n",
+        "            target.append(parts[1].split(' '))\n",
+        "    return source, target\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.789572Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.788692Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.802094Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.801367Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.789511Z"
+        },
+        "id": "GE_0EjLhH1pR",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class Vocab:  \n",
+        "    \"\"\"Vocabulary for text.\"\"\"\n",
+        "    def __init__(self, tokens=None, min_freq=0, reserved_tokens=None):\n",
+        "        if tokens is None:\n",
+        "            tokens = []\n",
+        "        if reserved_tokens is None:\n",
+        "            reserved_tokens = []\n",
+        "        # Sort according to frequencies\n",
+        "        counter = count_corpus(tokens)\n",
+        "        self.token_freqs = sorted(counter.items(), key=lambda x: x[1],\n",
+        "                                  reverse=True)\n",
+        "        # The index for the unknown token is 0\n",
+        "        self.unk, uniq_tokens = 0, ['<unk>'] + reserved_tokens\n",
+        "        uniq_tokens += [\n",
+        "            token for token, freq in self.token_freqs\n",
+        "            if freq >= min_freq and token not in uniq_tokens]\n",
+        "        self.idx_to_token, self.token_to_idx = [], dict()\n",
+        "        for token in uniq_tokens:\n",
+        "            self.idx_to_token.append(token)\n",
+        "            self.token_to_idx[token] = len(self.idx_to_token) - 1\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.idx_to_token)\n",
+        "\n",
+        "    def __getitem__(self, tokens):\n",
+        "        if not isinstance(tokens, (list, tuple)):\n",
+        "            return self.token_to_idx.get(tokens, self.unk)\n",
+        "        return [self.__getitem__(token) for token in tokens]\n",
+        "\n",
+        "    def to_tokens(self, indices):\n",
+        "        if not isinstance(indices, (list, tuple)):\n",
+        "            return self.idx_to_token[indices]\n",
+        "        return [self.idx_to_token[index] for index in indices]\n",
+        "\n",
+        "def count_corpus(tokens):  \n",
+        "    \"\"\"Count token frequencies.\"\"\"\n",
+        "    # Here `tokens` is a 1D list or 2D list\n",
+        "    if len(tokens) == 0 or isinstance(tokens[0], list):\n",
+        "        # Flatten a list of token lists into a list of tokens\n",
+        "        tokens = [token for line in tokens for token in line]\n",
+        "    return collections.Counter(tokens)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.804674Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.804453Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.814415Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.813672Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.804650Z"
+        },
+        "id": "Gbs426U9IQU0",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "reduce_sum = lambda x, *args, **kwargs: x.sum(*args, **kwargs)\n",
+        "astype = lambda x, *args, **kwargs: x.type(*args, **kwargs)\n",
+        "\n",
+        "def build_array_nmt(lines, vocab, num_steps):\n",
+        "    \"\"\"Transform text sequences of machine translation into minibatches.\"\"\"\n",
+        "    lines = [vocab[l] for l in lines]\n",
+        "    lines = [l + [vocab['<eos>']] for l in lines]\n",
+        "    array = torch.tensor([truncate_pad(\n",
+        "        l, num_steps, vocab['<pad>']) for l in lines])\n",
+        "    valid_len = reduce_sum(astype(array != vocab['<pad>'], torch.int32), 1)\n",
+        "    return array, valid_len"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.816357Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.815856Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.827501Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.826754Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.816318Z"
+        },
+        "id": "3yYUa_itADJm",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def load_array(data_arrays, batch_size, is_train=True):\n",
+        "    \"\"\"Construct a PyTorch data iterator.\"\"\"\n",
+        "    dataset = data.TensorDataset(*data_arrays)\n",
+        "    return data.DataLoader(dataset, batch_size, shuffle=is_train)\n",
+        "\n",
+        "def truncate_pad(line, num_steps, padding_token):\n",
+        "    \"\"\"Truncate or pad sequences.\"\"\"\n",
+        "    if len(line) > num_steps:\n",
+        "        return line[:num_steps]  # Truncate\n",
+        "    return line + [padding_token] * (num_steps - len(line))\n",
+        "    \n",
+        "def load_data_nmt(batch_size, num_steps, num_examples=600):\n",
+        "    \"\"\"Return the iterator and the vocabularies of the translation dataset.\"\"\"\n",
+        "    text = preprocess_nmt(read_data_nmt())\n",
+        "    source, target = tokenize_nmt(text, num_examples)\n",
+        "    src_vocab = Vocab(source, min_freq=2,\n",
+        "                          reserved_tokens=['<pad>', '<bos>', '<eos>'])\n",
+        "    tgt_vocab = Vocab(target, min_freq=2,\n",
+        "                          reserved_tokens=['<pad>', '<bos>', '<eos>'])\n",
+        "    src_array, src_valid_len = build_array_nmt(source, src_vocab, num_steps)\n",
+        "    tgt_array, tgt_valid_len = build_array_nmt(target, tgt_vocab, num_steps)\n",
+        "    data_arrays = (src_array, src_valid_len, tgt_array, tgt_valid_len)\n",
+        "    data_iter = load_array(data_arrays, batch_size)\n",
+        "    return data_iter, src_vocab, tgt_vocab"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f1dieC4GqW68"
+      },
+      "source": [
+        "# Data\n",
+        "\n",
+        "We use a english-french dataset. See [this colab](https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/text_preproc_torch.ipynb#scrollTo=yDmK1xQ9T4IY) for details."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.829202Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.828878Z",
+          "iopub.status.idle": "2022-04-07T04:20:51.836206Z",
+          "shell.execute_reply": "2022-04-07T04:20:51.835384Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.829167Z"
+        },
+        "id": "QzTch77XdfxK",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "DATA_HUB = dict()\n",
+        "DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'\n",
+        "\n",
+        "DATA_HUB['fra-eng'] = (DATA_URL + 'fra-eng.zip',\n",
+        "                           '94646ad1522d915e7b0f9296181140edcf86a4f5')\n",
+        "\n",
+        "batch_size, num_steps = 64, 10"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:51.838255Z",
+          "iopub.status.busy": "2022-04-07T04:20:51.837860Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.248209Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.247416Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:51.838178Z"
+        },
+        "id": "r-4oeZhRqZ2y",
+        "outputId": "c2b2086a-c6e8-4a1a-d3e0-dc75e2e4e9da",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Downloading ../data/fra-eng.zip from http://d2l-data.s3-accelerate.amazonaws.com/fra-eng.zip...\n"
+          ]
+        }
+      ],
+      "source": [
+        "train_iter, src_vocab, tgt_vocab = load_data_nmt(batch_size, num_steps)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.249949Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.249716Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.256291Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.255366Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.249916Z"
+        },
+        "id": "AbqbhodcrsGG",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "num_hiddens, num_layers, dropout = 32, 2, 0.1\n",
+        "ffn_num_input, ffn_num_hiddens, num_heads = 32, 64, 4\n",
+        "\n",
+        "encoder = TransformerEncoder(len(src_vocab), num_hiddens, ffn_num_input,\n",
+        "                             ffn_num_hiddens, num_heads, num_layers, dropout)\n",
+        "decoder = TransformerDecoder(len(tgt_vocab),\n",
+        "                             num_hiddens, ffn_num_input,\n",
+        "                             ffn_num_hiddens, num_heads, num_layers, dropout)\n",
+        "Transformer = functools.partial(EncoderDecoder, encoder, decoder)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "THw6lR1bsHD-"
+      },
+      "source": [
+        "# Training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.258342Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.257858Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.278437Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.277753Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.258307Z"
+        },
+        "id": "0OJenK-mMh1m",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "class Animator:\n",
+        "    \"\"\"For plotting data in animation.\"\"\"\n",
+        "    def __init__(self, xlabel=None, ylabel=None, legend=None, xlim=None,\n",
+        "                 ylim=None, xscale='linear', yscale='linear',\n",
+        "                 fmts=('-', 'm--', 'g-.', 'r:'), nrows=1, ncols=1,\n",
+        "                 figsize=(3.5, 2.5)):\n",
+        "        # Incrementally plot multiple lines\n",
+        "        if legend is None:\n",
+        "            legend = []\n",
+        "        display.set_matplotlib_formats('svg')\n",
+        "        self.fig, self.axes = plt.subplots(nrows, ncols, figsize=figsize)\n",
+        "        if nrows * ncols == 1:\n",
+        "            self.axes = [self.axes,]\n",
+        "        # Use a lambda function to capture arguments\n",
+        "        self.config_axes = lambda: set_axes(self.axes[\n",
+        "            0], xlabel, ylabel, xlim, ylim, xscale, yscale, legend)\n",
+        "        self.X, self.Y, self.fmts = None, None, fmts\n",
+        "\n",
+        "    def add(self, x, y):\n",
+        "        # Add multiple data points into the figure\n",
+        "        if not hasattr(y, \"__len__\"):\n",
+        "            y = [y]\n",
+        "        n = len(y)\n",
+        "        if not hasattr(x, \"__len__\"):\n",
+        "            x = [x] * n\n",
+        "        if not self.X:\n",
+        "            self.X = [[] for _ in range(n)]\n",
+        "        if not self.Y:\n",
+        "            self.Y = [[] for _ in range(n)]\n",
+        "        for i, (a, b) in enumerate(zip(x, y)):\n",
+        "            if a is not None and b is not None:\n",
+        "                self.X[i].append(a)\n",
+        "                self.Y[i].append(b)\n",
+        "        self.axes[0].cla()\n",
+        "        for x, y, fmt in zip(self.X, self.Y, self.fmts):\n",
+        "            self.axes[0].plot(x, y, fmt)\n",
+        "        self.config_axes()\n",
+        "        display.display(self.fig)\n",
+        "        display.clear_output(wait=True)\n",
+        "\n",
+        "class Timer:\n",
+        "    \"\"\"Record multiple running times.\"\"\"\n",
+        "    def __init__(self):\n",
+        "        self.times = []\n",
+        "        self.start()\n",
+        "\n",
+        "    def start(self):\n",
+        "        \"\"\"Start the timer.\"\"\"\n",
+        "        self.tik = time.time()\n",
+        "\n",
+        "    def stop(self):\n",
+        "        \"\"\"Stop the timer and record the time in a list.\"\"\"\n",
+        "        self.times.append(time.time() - self.tik)\n",
+        "        return self.times[-1]\n",
+        "\n",
+        "    def avg(self):\n",
+        "        \"\"\"Return the average time.\"\"\"\n",
+        "        return sum(self.times) / len(self.times)\n",
+        "\n",
+        "    def sum(self):\n",
+        "        \"\"\"Return the sum of time.\"\"\"\n",
+        "        return sum(self.times)\n",
+        "\n",
+        "    def cumsum(self):\n",
+        "        \"\"\"Return the accumulated time.\"\"\"\n",
+        "        return np.array(self.times).cumsum().tolist()\n",
+        "\n",
+        "class Accumulator:\n",
+        "    \"\"\"For accumulating sums over `n` variables.\"\"\"\n",
+        "    def __init__(self, n):\n",
+        "        self.data = [0.0] * n\n",
+        "\n",
+        "    def add(self, *args):\n",
+        "        self.data = [a + float(b) for a, b in zip(self.data, args)]\n",
+        "\n",
+        "    def reset(self):\n",
+        "        self.data = [0.0] * len(self.data)\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        return self.data[idx]\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.283948Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.283342Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.292988Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.292342Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.283910Z"
+        },
+        "id": "p2fqQdzkZvdF",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def set_axes(axes, xlabel, ylabel, xlim, ylim, xscale, yscale, legend):\n",
+        "    \"\"\"Set the axes for matplotlib.\"\"\"\n",
+        "    axes.set_xlabel(xlabel)\n",
+        "    axes.set_ylabel(ylabel)\n",
+        "    axes.set_xscale(xscale)\n",
+        "    axes.set_yscale(yscale)\n",
+        "    axes.set_xlim(xlim)\n",
+        "    axes.set_ylim(ylim)\n",
+        "    if legend:\n",
+        "        axes.legend(legend)\n",
+        "    axes.grid()\n",
+        "\n",
+        "def grad_clipping(net, theta):\n",
+        "    \"\"\"Clip the gradient.\"\"\"\n",
+        "    if isinstance(net, nn.Module):\n",
+        "        params = [p for p in net.parameters() if p.requires_grad]\n",
+        "    else:\n",
+        "        params = net.params\n",
+        "    norm = torch.sqrt(sum(torch.sum((p.grad**2)) for p in params))\n",
+        "    if norm > theta:\n",
+        "        for param in params:\n",
+        "            param.grad[:] *= theta / norm\n",
+        "\n",
+        "def try_gpu(i=0):\n",
+        "    \"\"\"Return gpu(i) if exists, otherwise return cpu().\"\"\"\n",
+        "    if torch.cuda.device_count() >= i + 1:\n",
+        "      return torch.device(f'cuda:{i}')\n",
+        "    return torch.device('cpu')\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.295946Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.295331Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.301928Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.301109Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.295908Z"
+        },
+        "id": "fim0FaVM9qYe",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def cross_entropy_loss(logits, labels, lengths) -> float:\n",
+        "  \"\"\"The softmax cross-entropy loss with masks.\"\"\"\n",
+        "\n",
+        "  # `pred` shape: (`batch_size`, `num_steps`, `vocab_size`)\n",
+        "  # `label` shape: (`batch_size`, `num_steps`)\n",
+        "  # `valid_len` shape: (`batch_size`,)\n",
+        "  one_hot_labels = jax.nn.one_hot(labels, num_classes=logits.shape[2])\n",
+        "  xe = jnp.sum(nn.log_softmax(logits) * one_hot_labels, axis=-1)\n",
+        "  masked_xe = jnp.mean(sequence_mask(xe, lengths))\n",
+        "  return -masked_xe"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.303913Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.303588Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.320811Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.320023Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.303878Z"
+        },
+        "id": "3hP-eQkc9poF",
+        "outputId": "aa9190be-8792-43e3-8673-0d0abf7923da",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(1.04591068, dtype=float64)"
+            ]
+          },
+          "execution_count": 30,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "p = jnp.array([[[0.10, 0.40, 0.50]]])\n",
+        "label = jnp.array([[1]])\n",
+        "valid_len = jnp.array([1])\n",
+        "cross_entropy_loss(p, label, valid_len)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.322495Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.322014Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.331609Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.330986Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.322461Z"
+        },
+        "id": "OlHTsKhxg_RM",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def get_initial_params(model, rng):\n",
+        "  \"\"\"Returns the initial parameters of a seq2seq model.\"\"\"\n",
+        "  valid_lens = jnp.ones((64), jnp.int64)\n",
+        "  init_rngs = {'params': random.PRNGKey(0), 'dropout': random.PRNGKey(1)}\n",
+        "  variables = model.init(\n",
+        "      init_rngs,\n",
+        "      jnp.ones((64, 10), jnp.int64),\n",
+        "      valid_lens,\n",
+        "      jnp.ones((64, 10), jnp.int64),\n",
+        "      train=False\n",
+        "  )\n",
+        "  return variables['params']\n",
+        "\n",
+        "def get_train_state(rng, lr) -> train_state.TrainState:\n",
+        "  \"\"\"Returns a train state.\"\"\"\n",
+        "  model = Transformer()\n",
+        "  params = get_initial_params(model, rng)\n",
+        "  tx = optax.adam(lr)\n",
+        "  return train_state.TrainState.create(\n",
+        "      apply_fn=model.apply, params=params, tx=tx)\n",
+        "\n",
+        "\n",
+        "def compute_metrics(logits, labels, Y_valid_len):\n",
+        "  \"\"\"Computes metrics and returns them.\"\"\"\n",
+        "  loss = cross_entropy_loss(logits, labels, Y_valid_len)\n",
+        "  token_accuracy = jnp.argmax(logits, -1) == labels\n",
+        "  sequence_accuracy = (\n",
+        "      jnp.sum(sequence_mask(token_accuracy, Y_valid_len), axis=-1) == Y_valid_len\n",
+        "  )\n",
+        "  accuracy = jnp.mean(sequence_accuracy)\n",
+        "  metrics = {\n",
+        "      'loss': loss,\n",
+        "      'accuracy': accuracy,\n",
+        "  }\n",
+        "  return metrics\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.333358Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.333105Z",
+          "iopub.status.idle": "2022-04-07T04:20:58.346100Z",
+          "shell.execute_reply": "2022-04-07T04:20:58.345406Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.333326Z"
+        },
+        "id": "N5Bn5tM9JNYR",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def train_step(state: train_state.TrainState, key, X, X_valid_len, Y, Y_valid_len, bos, dec_input):\n",
+        "  \"\"\"Trains one step.\"\"\"\n",
+        "  \n",
+        "  def loss_fn(params):\n",
+        "    logits, _, _, _ = state.apply_fn({'params': params}, X, X_valid_len, dec_input, train=True, rngs={'dropout': key})\n",
+        "    loss = cross_entropy_loss(logits, Y, Y_valid_len)\n",
+        "    return loss, logits\n",
+        "\n",
+        "  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
+        "  (_, logits), grads = grad_fn(state.params)\n",
+        "  state = state.apply_gradients(grads=grads)\n",
+        "  metrics = compute_metrics(logits, Y, Y_valid_len)\n",
+        "\n",
+        "  return state, metrics\n",
+        "\n",
+        "def train_seq2seq(data_iter, lr, num_epochs, tgt_vocab):\n",
+        "    \"\"\"Train a model for sequence to sequence.\"\"\"\n",
+        "\n",
+        "    key = random.PRNGKey(314)\n",
+        "    state = get_train_state(key, lr)\n",
+        "\n",
+        "    animator = Animator(xlabel='epoch', ylabel='loss',xlim=[10, num_epochs])\n",
+        "    for epoch in range(num_epochs):\n",
+        "        timer = Timer()\n",
+        "        metric = Accumulator(2)  # Sum of training loss, no. of tokens\n",
+        "        for batch in data_iter:\n",
+        "            X, X_valid_len, Y, Y_valid_len = [jnp.array(x) for x in batch]\n",
+        "\n",
+        "            bos = jnp.array([tgt_vocab['<bos>']] * Y.shape[0]).reshape(-1, 1)\n",
+        "            dec_input = jnp.concatenate([bos, Y[:, :-1]], 1)  # Teacher forcing\n",
+        "\n",
+        "            state, metrics = train_step(state, key, X, X_valid_len, Y, Y_valid_len, bos, dec_input)\n",
+        "\n",
+        "            num_tokens = Y_valid_len.sum()\n",
+        "\n",
+        "            metric.add(metrics[\"loss\"] * num_tokens, num_tokens)\n",
+        "        # if (epoch + 1) % 10 == 0:\n",
+        "        animator.add(epoch + 1, (metric[0] / metric[1],))\n",
+        "    print(f'loss {metric[0] / metric[1]:.3f}, {metric[1] / timer.stop():.1f} '\n",
+        "          f'tokens/sec on {str(device)}')\n",
+        "    \n",
+        "    return state\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 44,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 279
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:20:58.348042Z",
+          "iopub.status.busy": "2022-04-07T04:20:58.347583Z",
+          "iopub.status.idle": "2022-04-07T04:22:27.855939Z",
+          "shell.execute_reply": "2022-04-07T04:22:27.854928Z",
+          "shell.execute_reply.started": "2022-04-07T04:20:58.348006Z"
+        },
+        "id": "4-qC6IFAJQgA",
+        "outputId": "21c8889c-68fe-446b-ffae-b306a83c4857",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "loss 0.115, 3828.9 tokens/sec on cpu\n"
+          ]
+        },
+        {
+          "data": {
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"180.65625pt\" version=\"1.1\" viewBox=\"0 0 255.825 180.65625\" width=\"255.825pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 180.65625 \nL 255.825 180.65625 \nL 255.825 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 43.78125 143.1 \nL 239.08125 143.1 \nL 239.08125 7.2 \nL 43.78125 7.2 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 84.897039 143.1 \nL 84.897039 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m46d09138df\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"84.897039\" xlink:href=\"#m46d09138df\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 50 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(78.534539 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 136.291776 143.1 \nL 136.291776 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"136.291776\" xlink:href=\"#m46d09138df\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 100 -->\n      <defs>\n       <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n      </defs>\n      <g transform=\"translate(126.748026 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 187.686513 143.1 \nL 187.686513 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"187.686513\" xlink:href=\"#m46d09138df\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 150 -->\n      <g transform=\"translate(178.142763 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-53\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 239.08125 143.1 \nL 239.08125 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"239.08125\" xlink:href=\"#m46d09138df\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 200 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(229.5375 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"127.246094\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_5\">\n     <!-- epoch -->\n     <defs>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 48.78125 52.59375 \nL 48.78125 44.1875 \nQ 44.96875 46.296875 41.140625 47.34375 \nQ 37.3125 48.390625 33.40625 48.390625 \nQ 24.65625 48.390625 19.8125 42.84375 \nQ 14.984375 37.3125 14.984375 27.296875 \nQ 14.984375 17.28125 19.8125 11.734375 \nQ 24.65625 6.203125 33.40625 6.203125 \nQ 37.3125 6.203125 41.140625 7.25 \nQ 44.96875 8.296875 48.78125 10.40625 \nL 48.78125 2.09375 \nQ 45.015625 0.34375 40.984375 -0.53125 \nQ 36.96875 -1.421875 32.421875 -1.421875 \nQ 20.0625 -1.421875 12.78125 6.34375 \nQ 5.515625 14.109375 5.515625 27.296875 \nQ 5.515625 40.671875 12.859375 48.328125 \nQ 20.21875 56 33.015625 56 \nQ 37.15625 56 41.109375 55.140625 \nQ 45.0625 54.296875 48.78125 52.59375 \nz\n\" id=\"DejaVuSans-99\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 75.984375 \nL 18.109375 75.984375 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-104\"/>\n     </defs>\n     <g transform=\"translate(126.203125 171.376563)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"61.523438\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"186.181641\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"241.162109\" xlink:href=\"#DejaVuSans-104\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_9\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 43.78125 107.641538 \nL 239.08125 107.641538 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"m681b5c67ee\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"43.78125\" xlink:href=\"#m681b5c67ee\" y=\"107.641538\"/>\n      </g>\n     </g>\n     <g id=\"text_6\">\n      <!-- 0.5 -->\n      <defs>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n      </defs>\n      <g transform=\"translate(20.878125 111.440757)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_11\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 43.78125 70.158965 \nL 239.08125 70.158965 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"43.78125\" xlink:href=\"#m681b5c67ee\" y=\"70.158965\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 1.0 -->\n      <g transform=\"translate(20.878125 73.958184)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_13\">\n      <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 43.78125 32.676393 \nL 239.08125 32.676393 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"43.78125\" xlink:href=\"#m681b5c67ee\" y=\"32.676393\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 1.5 -->\n      <g transform=\"translate(20.878125 36.475612)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_9\">\n     <!-- loss -->\n     <defs>\n      <path d=\"M 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 0 \nL 9.421875 0 \nz\n\" id=\"DejaVuSans-108\"/>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n     </defs>\n     <g transform=\"translate(14.798437 84.807812)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"27.783203\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"88.964844\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"141.064453\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_15\">\n    <path clip-path=\"url(#p9bdd0d0e5c)\" d=\"M 34.530197 13.377273 \nL 35.558092 41.660496 \nL 36.585987 59.138288 \nL 37.613882 70.313322 \nL 38.641776 76.769289 \nL 39.669671 81.802482 \nL 40.697566 85.520324 \nL 41.725461 88.609935 \nL 42.753355 92.837553 \nL 43.78125 95.843969 \nL 44.809145 99.455073 \nL 45.837039 100.522499 \nL 46.864934 103.583466 \nL 47.892829 105.913096 \nL 48.920724 107.302856 \nL 49.948618 109.942961 \nL 50.976513 110.942404 \nL 52.004408 112.675471 \nL 53.032303 113.330628 \nL 54.060197 114.431799 \nL 55.088092 115.918355 \nL 56.115987 115.711336 \nL 57.143882 117.488675 \nL 58.171776 118.936284 \nL 59.199671 120.880765 \nL 60.227566 121.563351 \nL 62.283355 122.071274 \nL 63.31125 123.313225 \nL 64.339145 124.328066 \nL 65.367039 124.304144 \nL 66.394934 125.414057 \nL 67.422829 125.116474 \nL 68.450724 125.845516 \nL 69.478618 125.674644 \nL 70.506513 125.933777 \nL 71.534408 126.374791 \nL 72.562303 127.528438 \nL 73.590197 127.158152 \nL 74.618092 127.7877 \nL 75.645987 128.711824 \nL 76.673882 128.517351 \nL 77.701776 128.56164 \nL 78.729671 129.336811 \nL 79.757566 129.14116 \nL 80.785461 129.558527 \nL 81.813355 130.156465 \nL 83.869145 130.282468 \nL 84.897039 130.606918 \nL 85.924934 129.831122 \nL 86.952829 130.545869 \nL 89.008618 131.310825 \nL 90.036513 131.571203 \nL 91.064408 131.156316 \nL 92.092303 131.351036 \nL 93.120197 131.762037 \nL 94.148092 131.591469 \nL 95.175987 131.826145 \nL 96.203882 132.421651 \nL 97.231776 132.392331 \nL 98.259671 132.199951 \nL 99.287566 132.329065 \nL 100.315461 132.1056 \nL 101.343355 132.125863 \nL 102.37125 132.714527 \nL 103.399145 132.442752 \nL 104.427039 133.283776 \nL 105.454934 133.522509 \nL 106.482829 132.795318 \nL 107.510724 133.179467 \nL 108.538618 132.725983 \nL 109.566513 133.402111 \nL 110.594408 133.444552 \nL 111.622303 133.298208 \nL 112.650197 133.808475 \nL 113.678092 133.662233 \nL 114.705987 133.967467 \nL 115.733882 133.277348 \nL 116.761776 133.806536 \nL 117.789671 133.236286 \nL 118.817566 133.958607 \nL 119.845461 134.387088 \nL 120.873355 133.964012 \nL 121.90125 134.234782 \nL 122.929145 134.136878 \nL 123.957039 134.40793 \nL 124.984934 134.355586 \nL 126.012829 134.922469 \nL 127.040724 134.775258 \nL 128.068618 134.187323 \nL 129.096513 134.969449 \nL 130.124408 135.068331 \nL 131.152303 134.722226 \nL 132.180197 134.57334 \nL 133.208092 134.30274 \nL 134.235987 134.326375 \nL 135.263882 134.620357 \nL 137.319671 134.108963 \nL 138.347566 134.625362 \nL 139.375461 134.29633 \nL 140.403355 134.62203 \nL 144.514934 134.951598 \nL 145.542829 135.615424 \nL 146.570724 135.344148 \nL 148.626513 134.963745 \nL 150.682303 135.136856 \nL 151.710197 134.96191 \nL 152.738092 135.404366 \nL 153.765987 134.93394 \nL 154.793882 135.340116 \nL 155.821776 135.069726 \nL 156.849671 135.534275 \nL 157.877566 135.592895 \nL 158.905461 135.372376 \nL 161.989145 135.411413 \nL 163.017039 135.73111 \nL 164.044934 134.859214 \nL 165.072829 135.780952 \nL 166.100724 135.509296 \nL 167.128618 135.439075 \nL 169.184408 135.469055 \nL 170.212303 136.004747 \nL 171.240197 135.131393 \nL 172.268092 135.443733 \nL 173.295987 135.469073 \nL 174.323882 135.31653 \nL 175.351776 135.339571 \nL 177.407566 135.014163 \nL 178.435461 135.654866 \nL 179.463355 135.661619 \nL 180.49125 136.001983 \nL 181.519145 135.749353 \nL 182.547039 135.687873 \nL 183.574934 136.259527 \nL 184.602829 135.586715 \nL 185.630724 136.105565 \nL 186.658618 135.981028 \nL 187.686513 136.247732 \nL 189.742303 135.570676 \nL 190.770197 135.711957 \nL 192.825987 136.430747 \nL 193.853882 136.339278 \nL 194.881776 135.888915 \nL 195.909671 135.972232 \nL 197.965461 135.549924 \nL 198.993355 135.633493 \nL 200.02125 136.206088 \nL 202.077039 136.53214 \nL 203.104934 136.335345 \nL 204.132829 136.422628 \nL 205.160724 135.948781 \nL 206.188618 135.839842 \nL 207.216513 135.926216 \nL 208.244408 136.350083 \nL 210.300197 135.865576 \nL 211.328092 136.16086 \nL 212.355987 136.24584 \nL 213.383882 136.078488 \nL 214.411776 136.323905 \nL 215.439671 136.195918 \nL 216.467566 135.813526 \nL 217.495461 136.116335 \nL 218.523355 136.285203 \nL 219.55125 135.719337 \nL 220.579145 136.100064 \nL 221.607039 136.246667 \nL 222.634934 135.649188 \nL 224.690724 135.834308 \nL 225.718618 136.13355 \nL 226.746513 135.927186 \nL 227.774408 136.20386 \nL 228.802303 136.612155 \nL 229.830197 136.011249 \nL 230.858092 136.087602 \nL 231.885987 135.967948 \nL 232.913882 136.461358 \nL 233.941776 136.160719 \nL 235.997566 136.895563 \nL 237.025461 136.922727 \nL 238.053355 136.632192 \nL 239.08125 136.53497 \nL 239.08125 136.53497 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 43.78125 143.1 \nL 43.78125 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 239.08125 143.1 \nL 239.08125 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 43.78125 143.1 \nL 239.08125 143.1 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 43.78125 7.2 \nL 239.08125 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p9bdd0d0e5c\">\n   <rect height=\"135.9\" width=\"195.3\" x=\"43.78125\" y=\"7.2\"/>\n  </clipPath>\n </defs>\n</svg>\n",
+            "text/plain": [
+              "<Figure size 252x180 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "lr, num_epochs, device = 0.005, 200, try_gpu()\n",
+        "transformer_train_state = train_seq2seq(train_iter, lr, num_epochs, tgt_vocab)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XItVF3uzsdCM"
+      },
+      "source": [
+        "# Evaluation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 45,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:27.857948Z",
+          "iopub.status.busy": "2022-04-07T04:22:27.857642Z",
+          "iopub.status.idle": "2022-04-07T04:22:27.871062Z",
+          "shell.execute_reply": "2022-04-07T04:22:27.870064Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:27.857908Z"
+        },
+        "id": "M2VB7oXlqPJD",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def eval_encoder(state, enc_X, enc_valid_len):\n",
+        "    return Transformer().apply({'params': state.params}, enc_X, enc_valid_len, train=False, method=EncoderDecoder.encode)\n",
+        "@jax.jit\n",
+        "def eval_decoder(state, dec_X, dec_state):\n",
+        "    return Transformer().apply({'params': state.params}, dec_X, dec_state, train=False, method=EncoderDecoder.decode)\n",
+        "\n",
+        "def predict_seq2seq(state, src_sentence, src_vocab, tgt_vocab, num_steps, save_attention_weights=False):\n",
+        "    \"\"\"Predict for sequence to sequence.\"\"\"\n",
+        "    \n",
+        "    src_tokens = src_vocab[src_sentence.lower().split(' ')] + [src_vocab['<eos>']]\n",
+        "    enc_valid_len = jnp.array([len(src_tokens)])\n",
+        "    src_tokens = truncate_pad(src_tokens, num_steps, src_vocab['<pad>'])\n",
+        "\n",
+        "    # Add the batch axis\n",
+        "    enc_X = jnp.expand_dims(jnp.array(src_tokens, dtype=jnp.int64), axis=0)\n",
+        "    enc_outputs, encoder_attention_weights = eval_encoder(state, enc_X, enc_valid_len)\n",
+        "    dec_state = Transformer().decoder.init_state(enc_outputs, enc_valid_len)\n",
+        "\n",
+        "    # Add the batch axis\n",
+        "    dec_X = jnp.expand_dims(jnp.array([tgt_vocab['<bos>']], dtype=jnp.int64), axis=0)\n",
+        "\n",
+        "    output_seq, attention_weight_seq = [], []\n",
+        "    for _ in range(num_steps):\n",
+        "        Y, dec_state, decoder_attention_weights = eval_decoder(state, dec_X, dec_state)\n",
+        "\n",
+        "        # We use the token with the highest prediction likelihood as the input\n",
+        "        # of the decoder at the next time step\n",
+        "        dec_X = Y.argmax(axis=2)\n",
+        "\n",
+        "        pred = dec_X.squeeze(axis=0)\n",
+        "\n",
+        "        # Save attention weights (to be covered later)\n",
+        "        if save_attention_weights:\n",
+        "            attention_weight_seq.append(decoder_attention_weights)\n",
+        "        # Once the end-of-sequence token is predicted, the generation of the\n",
+        "        # output sequence is complete\n",
+        "        if pred == tgt_vocab['<eos>']:\n",
+        "            break\n",
+        "        output_seq.append(int(pred))\n",
+        "      \n",
+        "    return ' '.join(tgt_vocab.to_tokens(output_seq)), attention_weight_seq, encoder_attention_weights"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 46,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:27.873118Z",
+          "iopub.status.busy": "2022-04-07T04:22:27.872676Z",
+          "iopub.status.idle": "2022-04-07T04:22:27.885548Z",
+          "shell.execute_reply": "2022-04-07T04:22:27.884740Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:27.873067Z"
+        },
+        "id": "qwybiVMkwPp8",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def bleu(pred_seq, label_seq, k):  \n",
+        "    \"\"\"Compute the BLEU.\"\"\"\n",
+        "    pred_tokens, label_tokens = pred_seq.split(' '), label_seq.split(' ')\n",
+        "    len_pred, len_label = len(pred_tokens), len(label_tokens)\n",
+        "    score = math.exp(min(0, 1 - len_label / len_pred))\n",
+        "    for n in range(1, k + 1):\n",
+        "        num_matches, label_subs = 0, collections.defaultdict(int)\n",
+        "        for i in range(len_label - n + 1):\n",
+        "            label_subs[''.join(label_tokens[i:i + n])] += 1\n",
+        "        for i in range(len_pred - n + 1):\n",
+        "            if label_subs[''.join(pred_tokens[i:i + n])] > 0:\n",
+        "                num_matches += 1\n",
+        "                label_subs[''.join(pred_tokens[i:i + n])] -= 1\n",
+        "        score *= math.pow(num_matches / (len_pred - n + 1), math.pow(0.5, n))\n",
+        "    return score"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 47,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:24:58.089281Z",
+          "iopub.status.busy": "2022-04-07T04:24:58.088703Z",
+          "iopub.status.idle": "2022-04-07T04:24:58.135014Z",
+          "shell.execute_reply": "2022-04-07T04:24:58.134202Z",
+          "shell.execute_reply.started": "2022-04-07T04:24:58.089240Z"
+        },
+        "id": "JRbDnsZLsPdy",
+        "outputId": "e9e47ffb-4ae7-4919-8785-7f247ba0bd4c",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "go . => va !,  bleu 1.000\n",
+            "i lost . => j'ai perdu .,  bleu 1.000\n",
+            "he's calm . => il est <unk> .,  bleu 0.658\n",
+            "i'm home . => je suis chez moi .,  bleu 1.000\n"
+          ]
+        }
+      ],
+      "source": [
+        "engs = ['go .', \"i lost .\", 'he\\'s calm .', 'i\\'m home .']\n",
+        "fras = ['va !', 'j\\'ai perdu .', 'il est calme .', 'je suis chez moi .']\n",
+        "\n",
+        "for eng, fra in zip(engs, fras):\n",
+        "    translation, dec_attention_weight_seq, encoder_attention_weights = predict_seq2seq(transformer_train_state, eng, src_vocab, tgt_vocab, num_steps, True)\n",
+        "    print(f'{eng} => {translation}, ', f'bleu {bleu(translation, fra, k=2):.3f}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_rxnfmBtsgnn"
+      },
+      "source": [
+        "# Visualization of attention heatmaps\n",
+        "\n",
+        "We visualize the attention heatmaps for the last (english, french) pair, where the input has length 3 and the output has length 5.\n",
+        "\n",
+        "The shape of the encoder self-attention weights is (number of encoder layers, number of attention heads, num_steps or number of queries, num_steps or number of key-value pairs).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 48,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:45.402329Z",
+          "iopub.status.busy": "2022-04-07T04:22:45.401902Z",
+          "iopub.status.idle": "2022-04-07T04:22:45.410932Z",
+          "shell.execute_reply": "2022-04-07T04:22:45.409954Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:45.402282Z"
+        },
+        "id": "OoNT_10Zs540",
+        "outputId": "1a0186d4-6719-41d3-d8c9-9419f61ad853",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(2, 4, 10, 10)"
+            ]
+          },
+          "execution_count": 48,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "enc_attention_weights = jnp.concatenate(encoder_attention_weights, 0).reshape(\n",
+        "    (num_layers, num_heads, -1, num_steps))\n",
+        "enc_attention_weights.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gS_fjqcItJBS"
+      },
+      "source": [
+        "Encoder self-attention for each of the 2 encoder blocks.\n",
+        "The input has length 4, so all keys are 0 after that."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 49,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:45.413371Z",
+          "iopub.status.busy": "2022-04-07T04:22:45.412759Z",
+          "iopub.status.idle": "2022-04-07T04:22:45.426385Z",
+          "shell.execute_reply": "2022-04-07T04:22:45.425338Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:45.413327Z"
+        },
+        "id": "kHyQ3ugTTX9q",
+        "trusted": true
+      },
+      "outputs": [],
+      "source": [
+        "def show_heatmaps(matrices, xlabel, ylabel, titles=None, figsize=(2.5, 2.5),\n",
+        "                  cmap='Reds'):\n",
+        "    display.set_matplotlib_formats('svg')\n",
+        "    num_rows, num_cols = matrices.shape[0], matrices.shape[1]\n",
+        "    fig, axes = plt.subplots(num_rows, num_cols, figsize=figsize,\n",
+        "                                 sharex=True, sharey=True, squeeze=False)\n",
+        "    for i, (row_axes, row_matrices) in enumerate(zip(axes, matrices)):\n",
+        "        for j, (ax, matrix) in enumerate(zip(row_axes, row_matrices)):\n",
+        "            pcm = ax.imshow(matrix, cmap=cmap)\n",
+        "            if i == num_rows - 1:\n",
+        "                ax.set_xlabel(xlabel)\n",
+        "            if j == 0:\n",
+        "                ax.set_ylabel(ylabel)\n",
+        "            if titles:\n",
+        "                ax.set_title(titles[j])\n",
+        "    fig.colorbar(pcm, ax=axes, shrink=0.6)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 50,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 330
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:45.428458Z",
+          "iopub.status.busy": "2022-04-07T04:22:45.428081Z",
+          "iopub.status.idle": "2022-04-07T04:22:46.333378Z",
+          "shell.execute_reply": "2022-04-07T04:22:46.331448Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:45.428419Z"
+        },
+        "id": "smscWfpntKFt",
+        "outputId": "4d3d3d1f-30b2-4b54-c2d0-58f5d6253ab4",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"231.582992pt\" version=\"1.1\" viewBox=\"0 0 402.06155 231.582992\" width=\"402.06155pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 231.582992 \nL 402.06155 231.582992 \nL 402.06155 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 34.240625 90.24856 \nL 102.17106 90.24856 \nL 102.17106 22.318125 \nL 34.240625 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p933459a7d9)\">\n    <image height=\"68\" id=\"image73737f7367\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"34.240625\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAP5JREFUeJzt3D0KwjAcQPGkZKsI6uBQL+Gp6pG8meAoHsDB4madfTQOBe2H7zc2hIbHfyptYx0Wbcg4Ntfc0mwVQx9gbAwCBgGDgEHAIJBiiEOfYVScEDAIGAQMAgYBg4BBwCBgEDAIGAQMAqkN2Ueqf8kJAYOAQcAgYBAwCBgEDAIGAYOAQcAgYBAwCBgEDAIGAYOAQcAgkOpq3Wvj83LqvB7LZXZP3FS97vVLTggYBAwCBgGDgEEgne+P7OL+w8a42nYvFNNuPO3Tf4FBwCBgEDAIxLa5ZV8hOpS77Ma5frHphIBBwCBgEDAIGASiP0N454SAQcAgYBAwCBgEXuh0F+7k4Z7WAAAAAElFTkSuQmCC\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"mc310a732f1\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"37.637147\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_2\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"71.602364\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_3\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"mdc56b2b14e\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mdc56b2b14e\" y=\"25.714647\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 0 -->\n      <defs>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(20.878125 29.513865)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mdc56b2b14e\" y=\"59.679864\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 5 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(20.878125 63.479083)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_3\">\n     <!-- Query positions -->\n     <defs>\n      <path d=\"M 39.40625 66.21875 \nQ 28.65625 66.21875 22.328125 58.203125 \nQ 16.015625 50.203125 16.015625 36.375 \nQ 16.015625 22.609375 22.328125 14.59375 \nQ 28.65625 6.59375 39.40625 6.59375 \nQ 50.140625 6.59375 56.421875 14.59375 \nQ 62.703125 22.609375 62.703125 36.375 \nQ 62.703125 50.203125 56.421875 58.203125 \nQ 50.140625 66.21875 39.40625 66.21875 \nz\nM 53.21875 1.3125 \nL 66.21875 -12.890625 \nL 54.296875 -12.890625 \nL 43.5 -1.21875 \nQ 41.890625 -1.3125 41.03125 -1.359375 \nQ 40.1875 -1.421875 39.40625 -1.421875 \nQ 24.03125 -1.421875 14.8125 8.859375 \nQ 5.609375 19.140625 5.609375 36.375 \nQ 5.609375 53.65625 14.8125 63.9375 \nQ 24.03125 74.21875 39.40625 74.21875 \nQ 54.734375 74.21875 63.90625 63.9375 \nQ 73.09375 53.65625 73.09375 36.375 \nQ 73.09375 23.6875 67.984375 14.640625 \nQ 62.890625 5.609375 53.21875 1.3125 \nz\n\" id=\"DejaVuSans-81\"/>\n      <path d=\"M 8.5 21.578125 \nL 8.5 54.6875 \nL 17.484375 54.6875 \nL 17.484375 21.921875 \nQ 17.484375 14.15625 20.5 10.265625 \nQ 23.53125 6.390625 29.59375 6.390625 \nQ 36.859375 6.390625 41.078125 11.03125 \nQ 45.3125 15.671875 45.3125 23.6875 \nL 45.3125 54.6875 \nL 54.296875 54.6875 \nL 54.296875 0 \nL 45.3125 0 \nL 45.3125 8.40625 \nQ 42.046875 3.421875 37.71875 1 \nQ 33.40625 -1.421875 27.6875 -1.421875 \nQ 18.265625 -1.421875 13.375 4.4375 \nQ 8.5 10.296875 8.5 21.578125 \nz\nM 31.109375 56 \nz\n\" id=\"DejaVuSans-117\"/>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 32.171875 -5.078125 \nQ 28.375 -14.84375 24.75 -17.8125 \nQ 21.140625 -20.796875 15.09375 -20.796875 \nL 7.90625 -20.796875 \nL 7.90625 -13.28125 \nL 13.1875 -13.28125 \nQ 16.890625 -13.28125 18.9375 -11.515625 \nQ 21 -9.765625 23.484375 -3.21875 \nL 25.09375 0.875 \nL 2.984375 54.6875 \nL 12.5 54.6875 \nL 29.59375 11.921875 \nL 46.6875 54.6875 \nL 56.203125 54.6875 \nz\n\" id=\"DejaVuSans-121\"/>\n      <path id=\"DejaVuSans-32\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n     </defs>\n     <g transform=\"translate(14.798437 95.477874)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-81\"/>\n      <use x=\"78.710938\" xlink:href=\"#DejaVuSans-117\"/>\n      <use x=\"142.089844\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"203.613281\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"244.726562\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"303.90625\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"335.693359\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"399.169922\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"460.351562\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"512.451172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"540.234375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"579.443359\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"607.226562\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"668.408203\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"731.787109\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 34.240625 90.24856 \nL 34.240625 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 102.17106 90.24856 \nL 102.17106 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 34.240625 90.24856 \nL 102.17106 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 34.240625 22.318125 \nL 102.17106 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_4\">\n    <!-- Head 1 -->\n    <defs>\n     <path d=\"M 9.8125 72.90625 \nL 19.671875 72.90625 \nL 19.671875 43.015625 \nL 55.515625 43.015625 \nL 55.515625 72.90625 \nL 65.375 72.90625 \nL 65.375 0 \nL 55.515625 0 \nL 55.515625 34.71875 \nL 19.671875 34.71875 \nL 19.671875 0 \nL 9.8125 0 \nz\n\" id=\"DejaVuSans-72\"/>\n     <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n     <path d=\"M 45.40625 46.390625 \nL 45.40625 75.984375 \nL 54.390625 75.984375 \nL 54.390625 0 \nL 45.40625 0 \nL 45.40625 8.203125 \nQ 42.578125 3.328125 38.25 0.953125 \nQ 33.9375 -1.421875 27.875 -1.421875 \nQ 17.96875 -1.421875 11.734375 6.484375 \nQ 5.515625 14.40625 5.515625 27.296875 \nQ 5.515625 40.1875 11.734375 48.09375 \nQ 17.96875 56 27.875 56 \nQ 33.9375 56 38.25 53.625 \nQ 42.578125 51.265625 45.40625 46.390625 \nz\nM 14.796875 27.296875 \nQ 14.796875 17.390625 18.875 11.75 \nQ 22.953125 6.109375 30.078125 6.109375 \nQ 37.203125 6.109375 41.296875 11.75 \nQ 45.40625 17.390625 45.40625 27.296875 \nQ 45.40625 37.203125 41.296875 42.84375 \nQ 37.203125 48.484375 30.078125 48.484375 \nQ 22.953125 48.484375 18.875 42.84375 \nQ 14.796875 37.203125 14.796875 27.296875 \nz\n\" id=\"DejaVuSans-100\"/>\n     <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n    </defs>\n    <g transform=\"translate(46.791467 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-49\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_2\">\n   <g id=\"patch_7\">\n    <path d=\"M 115.757147 90.24856 \nL 183.687582 90.24856 \nL 183.687582 22.318125 \nL 115.757147 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#pff58eac2d4)\">\n    <image height=\"68\" id=\"imagef01315a031\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"115.757147\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAUtJREFUeJzt2jFKA1EUQNH5w7cQrCwUERdgYyvYaGWnnQhuQNyCoJWL0A24AztLGyttbTQYO5HYBAeExP7iswj485V7yjyGPC4PBkLSx8HWuAnklcVo1OTTi3D2l7XTXqA2BgGDgEHAIGAQyO3sTDztunKbVMILAYOAQcAgYBAwCOS3u344XDjaK7hKHbwQMAgYBAwCBoF8+zQIh7sb2wVXqYMXAgYBg4BBwCBgEMi97jMcpvmlgqvUwQsBg4BBwCBgEDAI5Db9MB2Hfy76t7wQMAgYBAwCBgGDQBq9Pofv1rPltfDBk0HvN/aZOi8EDAIGAYOAQcAgkK9X18Ph8c1lwVXq4IWAQcAgYBAwCKTx8H2iH05Hj/fffn61uR8+s9N/mOSrivJCwCBgEDAIGAQMAumwmQtfu+fDl5K7VMELAYOAQcAgYBAwCHwBikYp9f9lpJwAAAAASUVORK5CYII=\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_3\">\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"119.153668\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"153.118886\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_4\">\n    <g id=\"ytick_3\">\n     <g id=\"line2d_7\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mdc56b2b14e\" y=\"25.714647\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_4\">\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mdc56b2b14e\" y=\"59.679864\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_8\">\n    <path d=\"M 115.757147 90.24856 \nL 115.757147 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_9\">\n    <path d=\"M 183.687582 90.24856 \nL 183.687582 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_10\">\n    <path d=\"M 115.757147 90.24856 \nL 183.687582 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_11\">\n    <path d=\"M 115.757147 22.318125 \nL 183.687582 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_5\">\n    <!-- Head 2 -->\n    <defs>\n     <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n    </defs>\n    <g transform=\"translate(128.307989 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-50\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_3\">\n   <g id=\"patch_12\">\n    <path d=\"M 197.273668 90.24856 \nL 265.204103 90.24856 \nL 265.204103 22.318125 \nL 197.273668 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p93fbffa995)\">\n    <image height=\"68\" id=\"image14801a6f9e\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"197.273668\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAALtJREFUeJzt3LsNwkAQQMEzKZRAf7gkCnQBJI5N/qRzykcz6Sarp413OfbXMSbW6302Gs99m85+2eXTC3wbQUKQECQECUFCkBAkBAlBQpAQJAQJQUKQECQECUFCkBAkBAlBQpAQJAQJQUKQECQECUFCkBAkBAlBQpAQJAQJQUKQECQECUFCkBAkBAlBQpAQJAQJQUKQECQECUFCkBAkBAlBQpAQJJbHuE2fIfzrw4MzLiQECUFCkBAkBIk3FpkLTSsg1S4AAAAASUVORK5CYII=\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_5\">\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"200.67019\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_6\">\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"234.635408\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_6\">\n    <g id=\"ytick_5\">\n     <g id=\"line2d_11\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mdc56b2b14e\" y=\"25.714647\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_6\">\n     <g id=\"line2d_12\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mdc56b2b14e\" y=\"59.679864\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_13\">\n    <path d=\"M 197.273668 90.24856 \nL 197.273668 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_14\">\n    <path d=\"M 265.204103 90.24856 \nL 265.204103 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_15\">\n    <path d=\"M 197.273668 90.24856 \nL 265.204103 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_16\">\n    <path d=\"M 197.273668 22.318125 \nL 265.204103 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_6\">\n    <!-- Head 3 -->\n    <defs>\n     <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n    </defs>\n    <g transform=\"translate(209.824511 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-51\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_4\">\n   <g id=\"patch_17\">\n    <path d=\"M 278.79019 90.24856 \nL 346.720625 90.24856 \nL 346.720625 22.318125 \nL 278.79019 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p2197aae3bf)\">\n    <image height=\"68\" id=\"image4c81892d0d\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"278.79019\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAaRJREFUeJzt2D1KA0EchvGdZGOCigRRm4A2CoqCRcAivY1ewD6FhdjYeQHP4Ck8gB+FItqYIIg3sLQSIsa4G/uXfUMkxa7w/Mr9M5vhYWDYhMHR/jByGg07KrdPsweVql0TqtN2VhSlvDdQNAQRBBEEEQQRBBEh6V7aa7e717YLm6+P2YNS7H9sqjb+znLCCREEEQQRBBEEEQQR8fDp1g63dtf8yu9+9vOK/3iOIq7df4cggiCCIIIgItwvNey10Opc+ZXuI642439sxKwoOCGCIIIggiCCIIIgIn7pfdlha27Br+x/mjdWJtxSvjghgiCCIIIggiCCICKuxyOa/Az8LE2znw9H/adafJwQQRBBEEEQQRBBEBHSj3d7Tz6sbtuFrc519iDxV3VYXB5/ZznhhAiCCIIIggiCCIKIkDzf2Gs3rGzahcnZcfaa9Q27pnxw8oet5YMTIggiCCIIIggi4qhctsP07sLOQnMne1Cfn3RPueKECIIIggiCCIIIgohwGM3aj7vz3ptdOEwT80bfOIQw/s5ywgkRBBEEEQQRBBEEEb8zmzoZat2IRQAAAABJRU5ErkJggg==\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_7\">\n    <g id=\"xtick_7\">\n     <g id=\"line2d_13\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"282.186712\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_8\">\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"316.151929\" xlink:href=\"#mc310a732f1\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_8\">\n    <g id=\"ytick_7\">\n     <g id=\"line2d_15\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mdc56b2b14e\" y=\"25.714647\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_8\">\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mdc56b2b14e\" y=\"59.679864\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_18\">\n    <path d=\"M 278.79019 90.24856 \nL 278.79019 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_19\">\n    <path d=\"M 346.720625 90.24856 \nL 346.720625 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_20\">\n    <path d=\"M 278.79019 90.24856 \nL 346.720625 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_21\">\n    <path d=\"M 278.79019 22.318125 \nL 346.720625 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_7\">\n    <!-- Head 4 -->\n    <defs>\n     <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n    </defs>\n    <g transform=\"translate(291.341033 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-52\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_5\">\n   <g id=\"patch_22\">\n    <path d=\"M 34.240625 194.026742 \nL 102.17106 194.026742 \nL 102.17106 126.096307 \nL 34.240625 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p83b5a7c60e)\">\n    <image height=\"68\" id=\"image5bf034a094\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"34.240625\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAaBJREFUeJzt2z9LglEYhvFz9KRpTUGEEEGbcw1BBNHYGn0OaWhr6TM0uFR7s1Nb3yBqDKJGAy2zEsQ/ve0354lC5PWF6zc+DwcOFweCVD+6vkycoV8/t1auuLMRnddPr8wztdaTuZsVubQvMGsIIggiCCIIIggiglteNZfNh5a5Wz+oROe9sflXPBN4IYIggiCCIIIggiAieO/NZaGYt08m39Hx1zg+zwpeiCCIIIggiCCICEm3bS5XNtfMXfIWP/c6Gk98qTTxQgRBBEEEQQRBBEFEcJ9dc5lfLNknB4PoeCGX7cbZvv0UEEQQRBBEEEQQRAT38W5vy2V71+9Hx0tz2W6c7dtPAUEEQQRBBEEEQUTw2/vm8ubozNztXZxE5znXmPhSaeKFCIIIggiCCIIIgojgC/Pmsj0c2SeH8X8yVwq/fOsoA3ghgiCCIIIggiDCD48Pzd9zJL2efbAU/5jzsXFnnqne3/7jaunghQiCCIIIggiCCIKIMHhumsvi7pa5Szqd6PylG/+I0znnqn+/V2p4IYIggiCCIIIggiDiB4IAQyPZJuT+AAAAAElFTkSuQmCC\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_9\">\n    <g id=\"xtick_9\">\n     <g id=\"line2d_17\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"37.637147\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 0 -->\n      <g transform=\"translate(34.455897 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_10\">\n     <g id=\"line2d_18\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"71.602364\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 5 -->\n      <g transform=\"translate(68.421114 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_10\">\n     <!-- Key positions -->\n     <defs>\n      <path d=\"M 9.8125 72.90625 \nL 19.671875 72.90625 \nL 19.671875 42.09375 \nL 52.390625 72.90625 \nL 65.09375 72.90625 \nL 28.90625 38.921875 \nL 67.671875 0 \nL 54.6875 0 \nL 19.671875 35.109375 \nL 19.671875 0 \nL 9.8125 0 \nz\n\" id=\"DejaVuSans-75\"/>\n     </defs>\n     <g transform=\"translate(35.142561 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_10\">\n    <g id=\"ytick_9\">\n     <g id=\"line2d_19\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mdc56b2b14e\" y=\"129.492829\"/>\n      </g>\n     </g>\n     <g id=\"text_11\">\n      <!-- 0 -->\n      <g transform=\"translate(20.878125 133.292047)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_10\">\n     <g id=\"line2d_20\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mdc56b2b14e\" y=\"163.458046\"/>\n      </g>\n     </g>\n     <g id=\"text_12\">\n      <!-- 5 -->\n      <g transform=\"translate(20.878125 167.257265)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_13\">\n     <!-- Query positions -->\n     <g transform=\"translate(14.798437 199.256055)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-81\"/>\n      <use x=\"78.710938\" xlink:href=\"#DejaVuSans-117\"/>\n      <use x=\"142.089844\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"203.613281\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"244.726562\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"303.90625\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"335.693359\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"399.169922\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"460.351562\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"512.451172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"540.234375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"579.443359\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"607.226562\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"668.408203\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"731.787109\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_23\">\n    <path d=\"M 34.240625 194.026742 \nL 34.240625 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_24\">\n    <path d=\"M 102.17106 194.026742 \nL 102.17106 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_25\">\n    <path d=\"M 34.240625 194.026742 \nL 102.17106 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_26\">\n    <path d=\"M 34.240625 126.096307 \nL 102.17106 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_14\">\n    <!-- Head 1 -->\n    <g transform=\"translate(46.791467 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-49\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_6\">\n   <g id=\"patch_27\">\n    <path d=\"M 115.757147 194.026742 \nL 183.687582 194.026742 \nL 183.687582 126.096307 \nL 115.757147 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p7edbfd76c1)\">\n    <image height=\"68\" id=\"image6e8619fcd6\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"115.757147\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAYRJREFUeJzt2kFKw0AUh/GXZBSVQiki2ANowa3H8AZu3HsAwRN4Ag/hzq3gygO4ceFeEEUFDRVatMm4/zMvYLNIlO+3nMfA8DEQ0jSry9dojvPxxBvZ8d11cj1eXbh7iqNTd9YXedcH6BuCCIIIggiCCIKIYFnmDt8XtTvLwkpyPa6ttz5Ul7ghgiCCIIIggiCCICJYdF92m+Uhvb74Xv40PcANEQQRBBEEEQQRweaf7nCyservzNMtY/nR9kyd4oYIggiCCIIIggiCiGBfc3c4cB6tjZZ9WewJboggiCCIIIggiCCICFY4v42aWWUNj9Da/8z5l3FDBEEEQQRBBEEEQUSwwcgd3pQzd3YwmybXs9291ofqEjdEEEQQRBBEEEQQRDT+cXdaNfxxd7SdXI8vT60P1SVuiCCIIIggiCCICFZX7vBwa+jO6of75Hp85inzrxBEEEQQRBBEEERkJ8XQ/V55dnvpb9wcJ9fj26O7J9/Z/8XRusENEQQRBBEEEQQRBBE/P3Y5mEC+XGAAAAAASUVORK5CYII=\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_11\">\n    <g id=\"xtick_11\">\n     <g id=\"line2d_21\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"119.153668\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_15\">\n      <!-- 0 -->\n      <g transform=\"translate(115.972418 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_12\">\n     <g id=\"line2d_22\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"153.118886\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_16\">\n      <!-- 5 -->\n      <g transform=\"translate(149.937636 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_17\">\n     <!-- Key positions -->\n     <g transform=\"translate(116.659083 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_12\">\n    <g id=\"ytick_11\">\n     <g id=\"line2d_23\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mdc56b2b14e\" y=\"129.492829\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_12\">\n     <g id=\"line2d_24\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mdc56b2b14e\" y=\"163.458046\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_28\">\n    <path d=\"M 115.757147 194.026742 \nL 115.757147 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_29\">\n    <path d=\"M 183.687582 194.026742 \nL 183.687582 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_30\">\n    <path d=\"M 115.757147 194.026742 \nL 183.687582 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_31\">\n    <path d=\"M 115.757147 126.096307 \nL 183.687582 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_18\">\n    <!-- Head 2 -->\n    <g transform=\"translate(128.307989 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-50\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_7\">\n   <g id=\"patch_32\">\n    <path d=\"M 197.273668 194.026742 \nL 265.204103 194.026742 \nL 265.204103 126.096307 \nL 197.273668 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p1492ff1061)\">\n    <image height=\"68\" id=\"imagefffdad8b0f\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"197.273668\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAaNJREFUeJzt2j1KA0EYh/FZd1JllZhCECSgnaCdrSAWYiE2ohewiJ3gBTyGhZfINWz8ANMYQYuAFmIUJZLoZu3/zAuRLSbC8yvnZTbDw0DIRzJsbhfOkDZPrJEr7m7Cg1rd3JOu75mzSTEV+wCThiCCIIIggiCCIMJft27N4drpojkrnh6D68nSaskjxcUNEQQRBBEEEQQRBBG+Ukntaf5tz1JjX56XO1Fk3BBBEEEQQRBBEOFXDjfM4ahzZe/86geXi/aFvaexPOax4uGGCIIIggiCCIIIggifLDTsae/Fnlkf7j7ey50oMm6IIIggiCCIIIggiPCuNmtPhwN7Vp0Or/c/y50oMm6IIIggiCCIIIggiEiaLjP/uHvWuzc3Fs8P4QfW5+0Xy2p/OFoc3BBBEEEQQRBBEEEQ4XfrmT0dhH+/dc65otsJrifVGft5vO3+PwQRBBEEEQQRfuto057mP+aoaF8G10fd8Ic+55xLD47HPlgs3BBBEEEQQRBBEEEQ4ZOdfXM4ap2bs2TO+O707bXsmaLihgiCCIIIggiCCIKIXzhbPFp7Hc+eAAAAAElFTkSuQmCC\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_13\">\n    <g id=\"xtick_13\">\n     <g id=\"line2d_25\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"200.67019\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_19\">\n      <!-- 0 -->\n      <g transform=\"translate(197.48894 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_14\">\n     <g id=\"line2d_26\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"234.635408\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_20\">\n      <!-- 5 -->\n      <g transform=\"translate(231.454158 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_21\">\n     <!-- Key positions -->\n     <g transform=\"translate(198.175605 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_14\">\n    <g id=\"ytick_13\">\n     <g id=\"line2d_27\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mdc56b2b14e\" y=\"129.492829\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_14\">\n     <g id=\"line2d_28\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mdc56b2b14e\" y=\"163.458046\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_33\">\n    <path d=\"M 197.273668 194.026742 \nL 197.273668 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_34\">\n    <path d=\"M 265.204103 194.026742 \nL 265.204103 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_35\">\n    <path d=\"M 197.273668 194.026742 \nL 265.204103 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_36\">\n    <path d=\"M 197.273668 126.096307 \nL 265.204103 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_22\">\n    <!-- Head 3 -->\n    <g transform=\"translate(209.824511 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-51\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_8\">\n   <g id=\"patch_37\">\n    <path d=\"M 278.79019 194.026742 \nL 346.720625 194.026742 \nL 346.720625 126.096307 \nL 278.79019 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#pcc05ae69f9)\">\n    <image height=\"68\" id=\"image72c9e954cc\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"278.79019\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAYdJREFUeJzt2zFKQ0EURuGZ5xCIpggB7WwkoK0IghtwDe5ALLIHQRehTTrtrGwECxdiIxIUBZGoIWpixv5nbkAGnFecr3yXB5fDhWCIfto/jM5Q7e5ZIxdfHpPPZ9cX5jvh4Nic1UVVeoG6IYggiCCIIIggiAhudc2e/kzMUfwapwfDYeZKZXEhgiCCIIIggiCCICLM/WidfNtvVj79vNnMXKksLkQQRBBEEEQQRIR4dWkOfW/TnrVX0oOtndydiuJCBEEEQQRBBEEEQUT4vH0wh0uhYb/p03/cxfZy7k5FcSGCIIIggiCCIIIgIoye3s3h3I9dl/7hkV9sZa5UFhciCCIIIggiCCIIIvz05tz+4W7X/pJ59nyffB7PTs13wlH/D6uVwYUIggiCCIIIggiCiOAGd/Z0Y9sc+Woh+Tx2OpkrlcWFCIIIggiCCIKI4N5ezWEcf9gz499DfHc9e6mSuBBBEEEQQRBBEEEQ4fddy/xO9WQ0+M9daoELEQQRBBEEEQQRBBG/9MY7IyGw9YoAAAAASUVORK5CYII=\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_15\">\n    <g id=\"xtick_15\">\n     <g id=\"line2d_29\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"282.186712\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_23\">\n      <!-- 0 -->\n      <g transform=\"translate(279.005462 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_16\">\n     <g id=\"line2d_30\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"316.151929\" xlink:href=\"#mc310a732f1\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_24\">\n      <!-- 5 -->\n      <g transform=\"translate(312.970679 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_25\">\n     <!-- Key positions -->\n     <g transform=\"translate(279.692126 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_16\">\n    <g id=\"ytick_15\">\n     <g id=\"line2d_31\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mdc56b2b14e\" y=\"129.492829\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_16\">\n     <g id=\"line2d_32\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mdc56b2b14e\" y=\"163.458046\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_38\">\n    <path d=\"M 278.79019 194.026742 \nL 278.79019 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_39\">\n    <path d=\"M 346.720625 194.026742 \nL 346.720625 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_40\">\n    <path d=\"M 278.79019 194.026742 \nL 346.720625 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_41\">\n    <path d=\"M 278.79019 126.096307 \nL 346.720625 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_26\">\n    <!-- Head 4 -->\n    <g transform=\"translate(291.341033 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-52\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_9\">\n   <g id=\"patch_42\">\n    <path clip-path=\"url(#p56e2abdaad)\" d=\"M 366.250625 165.250433 \nL 366.250625 164.804511 \nL 366.250625 51.540355 \nL 366.250625 51.094433 \nL 371.958425 51.094433 \nL 371.958425 51.540355 \nL 371.958425 164.804511 \nL 371.958425 165.250433 \nz\n\" style=\"fill:#ffffff;stroke:#ffffff;stroke-linejoin:miter;stroke-width:0.01;\"/>\n   </g>\n   <image height=\"114\" id=\"image320e00208d\" transform=\"scale(1 -1)translate(0 -114)\" width=\"6\" x=\"366\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAYAAAByCAYAAABwf6CfAAAABHNCSVQICAgIfAhkiAAAAMhJREFUSIm9lUkOxDAIBInk/381l5zGLPMBylJHKDmCugswjq967rLmW1bZxU+JDEq0iDeMYoZcLvfxgcI3WWGDkKggRcgMtEKFOykgcThBnTHYB81Kt+LzoGXAg2KruSFONjiXwBvFy0C/jEGGbiV3Xrwl2CAlNjF4Vio891y5esLVq5YBT1HSGxVkFaQ4MNq4LcdykSHDXe78BQMVRdNtwyeF93FbaQgHRZAisFwZjgpkwJIcFDgSJ8Wes0LF7wPGpoXTrUjxB/s0DEox/kcFAAAAAElFTkSuQmCC\" y=\"-51\"/>\n   <g id=\"matplotlib.axis_17\"/>\n   <g id=\"matplotlib.axis_18\">\n    <g id=\"ytick_17\">\n     <g id=\"line2d_33\">\n      <defs>\n       <path d=\"M 0 0 \nL 3.5 0 \n\" id=\"m93b542bceb\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m93b542bceb\" y=\"165.250433\"/>\n      </g>\n     </g>\n     <g id=\"text_27\">\n      <!-- 0.0 -->\n      <defs>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n      </defs>\n      <g transform=\"translate(378.958425 169.049652)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_18\">\n     <g id=\"line2d_34\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m93b542bceb\" y=\"142.309784\"/>\n      </g>\n     </g>\n     <g id=\"text_28\">\n      <!-- 0.2 -->\n      <g transform=\"translate(378.958425 146.109002)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_19\">\n     <g id=\"line2d_35\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m93b542bceb\" y=\"119.369134\"/>\n      </g>\n     </g>\n     <g id=\"text_29\">\n      <!-- 0.4 -->\n      <g transform=\"translate(378.958425 123.168353)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_20\">\n     <g id=\"line2d_36\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m93b542bceb\" y=\"96.428484\"/>\n      </g>\n     </g>\n     <g id=\"text_30\">\n      <!-- 0.6 -->\n      <defs>\n       <path d=\"M 33.015625 40.375 \nQ 26.375 40.375 22.484375 35.828125 \nQ 18.609375 31.296875 18.609375 23.390625 \nQ 18.609375 15.53125 22.484375 10.953125 \nQ 26.375 6.390625 33.015625 6.390625 \nQ 39.65625 6.390625 43.53125 10.953125 \nQ 47.40625 15.53125 47.40625 23.390625 \nQ 47.40625 31.296875 43.53125 35.828125 \nQ 39.65625 40.375 33.015625 40.375 \nz\nM 52.59375 71.296875 \nL 52.59375 62.3125 \nQ 48.875 64.0625 45.09375 64.984375 \nQ 41.3125 65.921875 37.59375 65.921875 \nQ 27.828125 65.921875 22.671875 59.328125 \nQ 17.53125 52.734375 16.796875 39.40625 \nQ 19.671875 43.65625 24.015625 45.921875 \nQ 28.375 48.1875 33.59375 48.1875 \nQ 44.578125 48.1875 50.953125 41.515625 \nQ 57.328125 34.859375 57.328125 23.390625 \nQ 57.328125 12.15625 50.6875 5.359375 \nQ 44.046875 -1.421875 33.015625 -1.421875 \nQ 20.359375 -1.421875 13.671875 8.265625 \nQ 6.984375 17.96875 6.984375 36.375 \nQ 6.984375 53.65625 15.1875 63.9375 \nQ 23.390625 74.21875 37.203125 74.21875 \nQ 40.921875 74.21875 44.703125 73.484375 \nQ 48.484375 72.75 52.59375 71.296875 \nz\n\" id=\"DejaVuSans-54\"/>\n      </defs>\n      <g transform=\"translate(378.958425 100.227703)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-54\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_21\">\n     <g id=\"line2d_37\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m93b542bceb\" y=\"73.487834\"/>\n      </g>\n     </g>\n     <g id=\"text_31\">\n      <!-- 0.8 -->\n      <defs>\n       <path d=\"M 31.78125 34.625 \nQ 24.75 34.625 20.71875 30.859375 \nQ 16.703125 27.09375 16.703125 20.515625 \nQ 16.703125 13.921875 20.71875 10.15625 \nQ 24.75 6.390625 31.78125 6.390625 \nQ 38.8125 6.390625 42.859375 10.171875 \nQ 46.921875 13.96875 46.921875 20.515625 \nQ 46.921875 27.09375 42.890625 30.859375 \nQ 38.875 34.625 31.78125 34.625 \nz\nM 21.921875 38.8125 \nQ 15.578125 40.375 12.03125 44.71875 \nQ 8.5 49.078125 8.5 55.328125 \nQ 8.5 64.0625 14.71875 69.140625 \nQ 20.953125 74.21875 31.78125 74.21875 \nQ 42.671875 74.21875 48.875 69.140625 \nQ 55.078125 64.0625 55.078125 55.328125 \nQ 55.078125 49.078125 51.53125 44.71875 \nQ 48 40.375 41.703125 38.8125 \nQ 48.828125 37.15625 52.796875 32.3125 \nQ 56.78125 27.484375 56.78125 20.515625 \nQ 56.78125 9.90625 50.3125 4.234375 \nQ 43.84375 -1.421875 31.78125 -1.421875 \nQ 19.734375 -1.421875 13.25 4.234375 \nQ 6.78125 9.90625 6.78125 20.515625 \nQ 6.78125 27.484375 10.78125 32.3125 \nQ 14.796875 37.15625 21.921875 38.8125 \nz\nM 18.3125 54.390625 \nQ 18.3125 48.734375 21.84375 45.5625 \nQ 25.390625 42.390625 31.78125 42.390625 \nQ 38.140625 42.390625 41.71875 45.5625 \nQ 45.3125 48.734375 45.3125 54.390625 \nQ 45.3125 60.0625 41.71875 63.234375 \nQ 38.140625 66.40625 31.78125 66.40625 \nQ 25.390625 66.40625 21.84375 63.234375 \nQ 18.3125 60.0625 18.3125 54.390625 \nz\n\" id=\"DejaVuSans-56\"/>\n      </defs>\n      <g transform=\"translate(378.958425 77.287053)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-56\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_43\">\n    <path d=\"M 366.250625 165.250433 \nL 366.250625 164.804511 \nL 366.250625 51.540355 \nL 366.250625 51.094433 \nL 371.958425 51.094433 \nL 371.958425 51.540355 \nL 371.958425 164.804511 \nL 371.958425 165.250433 \nz\n\" style=\"fill:none;stroke:#000000;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p933459a7d9\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"34.240625\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"pff58eac2d4\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"115.757147\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"p93fbffa995\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"197.273668\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"p2197aae3bf\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"278.79019\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"p83b5a7c60e\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"34.240625\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"p7edbfd76c1\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"115.757147\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"p1492ff1061\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"197.273668\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"pcc05ae69f9\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"278.79019\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"p56e2abdaad\">\n   <rect height=\"114.156\" width=\"5.7078\" x=\"366.250625\" y=\"51.094433\"/>\n  </clipPath>\n </defs>\n</svg>\n",
+            "text/plain": [
+              "<Figure size 504x252 with 9 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "show_heatmaps(enc_attention_weights, xlabel='Key positions',\n",
+        "                  ylabel='Query positions',\n",
+        "                  titles=['Head %d' % i\n",
+        "                          for i in range(1, 5)], figsize=(7, 3.5))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gG6i2tQFtpSi"
+      },
+      "source": [
+        "Next we visualize decoder attention heatmaps."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 51,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:46.335268Z",
+          "iopub.status.busy": "2022-04-07T04:22:46.334912Z",
+          "iopub.status.idle": "2022-04-07T04:22:46.597360Z",
+          "shell.execute_reply": "2022-04-07T04:22:46.596685Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:46.335230Z"
+        },
+        "id": "0GEyFQ5ctKj6",
+        "outputId": "714bd756-8b84-4575-dc5a-b912e8f6d609",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(torch.Size([2, 4, 6, 10]), torch.Size([2, 4, 6, 10]))"
+            ]
+          },
+          "execution_count": 51,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dec_attention_weights_2d = [\n",
+        "    head[0].tolist() for step in dec_attention_weight_seq for attn in step\n",
+        "    for blk in attn for head in blk]\n",
+        "dec_attention_weights_filled = torch.tensor(\n",
+        "    pd.DataFrame(dec_attention_weights_2d).fillna(0.0).values)\n",
+        "dec_attention_weights = dec_attention_weights_filled.reshape(\n",
+        "    (-1, 2, num_layers, num_heads, num_steps))\n",
+        "dec_self_attention_weights, dec_inter_attention_weights = \\\n",
+        "    dec_attention_weights.permute(1, 2, 3, 0, 4)\n",
+        "dec_self_attention_weights.shape, dec_inter_attention_weights.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "O9Jb3D3Zt97P"
+      },
+      "source": [
+        "Decoder self-attention."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 52,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 330
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:46.599207Z",
+          "iopub.status.busy": "2022-04-07T04:22:46.598946Z",
+          "iopub.status.idle": "2022-04-07T04:22:47.485134Z",
+          "shell.execute_reply": "2022-04-07T04:22:47.484412Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:46.599170Z"
+        },
+        "id": "RIK92fjltsav",
+        "outputId": "d1b2b60d-37a1-457e-b6e2-8789ec457b49",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"231.582992pt\" version=\"1.1\" viewBox=\"0 0 402.06155 231.582992\" width=\"402.06155pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 231.582992 \nL 402.06155 231.582992 \nL 402.06155 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 34.240625 90.24856 \nL 102.17106 90.24856 \nL 102.17106 22.318125 \nL 34.240625 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p633362a0e4)\">\n    <image height=\"68\" id=\"image8510389253\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"34.240625\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAQlJREFUeJzt2jEKwjAYQOFE3LQ3KDh6G69hB68jeg6P4ubkYGcRpGvj/qZk+KHC++YQwuMfEtpcpk9JQW79vnrtYXxEHSPNz3v12lXYKf6UQcAgYBAwCBgEDAIGAYOAQSBHXt1bDJu+eu11GsPO4YSAQcAgYBAwCBgEDAIGAYOAQcAgsI7cfCnvkxZOCBgEDAIGAYOAQcAgYBAwCBgE8pC66s8Ql+nVtHkp9V84cs5Ne0dxQsAgYBAwCBgEDAIGAYOAQcAgkOfvu/p+fep2TZufG6/6S+CEgEHAIGAQMAgYBAwCBgGDgEHAIJCPaVv9llnKXz6RnBAwCBgEDAIGAYOAQcAgYBAwCPwABYslpHUjyYIAAAAASUVORK5CYII=\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m4a5359bf59\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"39.901495\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_2\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"96.51019\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_3\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"mab43d2a564\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mab43d2a564\" y=\"27.978995\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 0 -->\n      <defs>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(20.878125 31.778213)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mab43d2a564\" y=\"50.622473\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 2 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(20.878125 54.421692)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_5\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mab43d2a564\" y=\"73.265951\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 4 -->\n      <defs>\n       <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n      </defs>\n      <g transform=\"translate(20.878125 77.06517)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_4\">\n     <!-- Query positions -->\n     <defs>\n      <path d=\"M 39.40625 66.21875 \nQ 28.65625 66.21875 22.328125 58.203125 \nQ 16.015625 50.203125 16.015625 36.375 \nQ 16.015625 22.609375 22.328125 14.59375 \nQ 28.65625 6.59375 39.40625 6.59375 \nQ 50.140625 6.59375 56.421875 14.59375 \nQ 62.703125 22.609375 62.703125 36.375 \nQ 62.703125 50.203125 56.421875 58.203125 \nQ 50.140625 66.21875 39.40625 66.21875 \nz\nM 53.21875 1.3125 \nL 66.21875 -12.890625 \nL 54.296875 -12.890625 \nL 43.5 -1.21875 \nQ 41.890625 -1.3125 41.03125 -1.359375 \nQ 40.1875 -1.421875 39.40625 -1.421875 \nQ 24.03125 -1.421875 14.8125 8.859375 \nQ 5.609375 19.140625 5.609375 36.375 \nQ 5.609375 53.65625 14.8125 63.9375 \nQ 24.03125 74.21875 39.40625 74.21875 \nQ 54.734375 74.21875 63.90625 63.9375 \nQ 73.09375 53.65625 73.09375 36.375 \nQ 73.09375 23.6875 67.984375 14.640625 \nQ 62.890625 5.609375 53.21875 1.3125 \nz\n\" id=\"DejaVuSans-81\"/>\n      <path d=\"M 8.5 21.578125 \nL 8.5 54.6875 \nL 17.484375 54.6875 \nL 17.484375 21.921875 \nQ 17.484375 14.15625 20.5 10.265625 \nQ 23.53125 6.390625 29.59375 6.390625 \nQ 36.859375 6.390625 41.078125 11.03125 \nQ 45.3125 15.671875 45.3125 23.6875 \nL 45.3125 54.6875 \nL 54.296875 54.6875 \nL 54.296875 0 \nL 45.3125 0 \nL 45.3125 8.40625 \nQ 42.046875 3.421875 37.71875 1 \nQ 33.40625 -1.421875 27.6875 -1.421875 \nQ 18.265625 -1.421875 13.375 4.4375 \nQ 8.5 10.296875 8.5 21.578125 \nz\nM 31.109375 56 \nz\n\" id=\"DejaVuSans-117\"/>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 32.171875 -5.078125 \nQ 28.375 -14.84375 24.75 -17.8125 \nQ 21.140625 -20.796875 15.09375 -20.796875 \nL 7.90625 -20.796875 \nL 7.90625 -13.28125 \nL 13.1875 -13.28125 \nQ 16.890625 -13.28125 18.9375 -11.515625 \nQ 21 -9.765625 23.484375 -3.21875 \nL 25.09375 0.875 \nL 2.984375 54.6875 \nL 12.5 54.6875 \nL 29.59375 11.921875 \nL 46.6875 54.6875 \nL 56.203125 54.6875 \nz\n\" id=\"DejaVuSans-121\"/>\n      <path id=\"DejaVuSans-32\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n     </defs>\n     <g transform=\"translate(14.798437 95.477874)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-81\"/>\n      <use x=\"78.710938\" xlink:href=\"#DejaVuSans-117\"/>\n      <use x=\"142.089844\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"203.613281\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"244.726562\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"303.90625\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"335.693359\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"399.169922\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"460.351562\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"512.451172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"540.234375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"579.443359\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"607.226562\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"668.408203\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"731.787109\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 34.240625 90.24856 \nL 34.240625 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 102.17106 90.24856 \nL 102.17106 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 34.240625 90.24856 \nL 102.17106 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 34.240625 22.318125 \nL 102.17106 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_5\">\n    <!-- Head 1 -->\n    <defs>\n     <path d=\"M 9.8125 72.90625 \nL 19.671875 72.90625 \nL 19.671875 43.015625 \nL 55.515625 43.015625 \nL 55.515625 72.90625 \nL 65.375 72.90625 \nL 65.375 0 \nL 55.515625 0 \nL 55.515625 34.71875 \nL 19.671875 34.71875 \nL 19.671875 0 \nL 9.8125 0 \nz\n\" id=\"DejaVuSans-72\"/>\n     <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n     <path d=\"M 45.40625 46.390625 \nL 45.40625 75.984375 \nL 54.390625 75.984375 \nL 54.390625 0 \nL 45.40625 0 \nL 45.40625 8.203125 \nQ 42.578125 3.328125 38.25 0.953125 \nQ 33.9375 -1.421875 27.875 -1.421875 \nQ 17.96875 -1.421875 11.734375 6.484375 \nQ 5.515625 14.40625 5.515625 27.296875 \nQ 5.515625 40.1875 11.734375 48.09375 \nQ 17.96875 56 27.875 56 \nQ 33.9375 56 38.25 53.625 \nQ 42.578125 51.265625 45.40625 46.390625 \nz\nM 14.796875 27.296875 \nQ 14.796875 17.390625 18.875 11.75 \nQ 22.953125 6.109375 30.078125 6.109375 \nQ 37.203125 6.109375 41.296875 11.75 \nQ 45.40625 17.390625 45.40625 27.296875 \nQ 45.40625 37.203125 41.296875 42.84375 \nQ 37.203125 48.484375 30.078125 48.484375 \nQ 22.953125 48.484375 18.875 42.84375 \nQ 14.796875 37.203125 14.796875 27.296875 \nz\n\" id=\"DejaVuSans-100\"/>\n     <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n    </defs>\n    <g transform=\"translate(46.791467 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-49\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_2\">\n   <g id=\"patch_7\">\n    <path d=\"M 115.757147 90.24856 \nL 183.687582 90.24856 \nL 183.687582 22.318125 \nL 115.757147 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p3e2c515c0c)\">\n    <image height=\"68\" id=\"image955e0b7138\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"115.757147\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAARRJREFUeJzt2zEOAUEUgOEdtkNcQKNWOIHCJVyBziFcQuUu4gii1qiRoJLs6P/qTbEJ8n/1y2Ty5xU7xab8uufqz616o/Bsp8V7/CSDgEHAIGAQMAgYBAwCBgGDQGqet/Cn+3u9KDq8MxyEZ+vNrujstrghYBAwCBgEDAIGAYOAQcAgYBAwCKTmcQ2/ZZrjvujw7nQenj2MJ+HZ2flUdI8SbggYBAwCBgGDgEHAIGAQMAgYBNKy6oc/3bevS5t3+QpuCBgEDAIGAYOAQcAgYBAwCBgE6lSl8HDOZf8JpBQ/+1u4IWAQMAgYBAwCBgGDgEHAIGAQMAjUuYq/T37xbVLKDQGDgEHAIGAQMAgYBAwCBgGDwAcH7R6n+PDJswAAAABJRU5ErkJggg==\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_3\">\n    <g id=\"xtick_3\">\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"121.418016\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"178.026712\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_4\">\n    <g id=\"ytick_4\">\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mab43d2a564\" y=\"27.978995\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_5\">\n     <g id=\"line2d_9\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mab43d2a564\" y=\"50.622473\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_6\">\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mab43d2a564\" y=\"73.265951\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_8\">\n    <path d=\"M 115.757147 90.24856 \nL 115.757147 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_9\">\n    <path d=\"M 183.687582 90.24856 \nL 183.687582 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_10\">\n    <path d=\"M 115.757147 90.24856 \nL 183.687582 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_11\">\n    <path d=\"M 115.757147 22.318125 \nL 183.687582 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_6\">\n    <!-- Head 2 -->\n    <g transform=\"translate(128.307989 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-50\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_3\">\n   <g id=\"patch_12\">\n    <path d=\"M 197.273668 90.24856 \nL 265.204103 90.24856 \nL 265.204103 22.318125 \nL 197.273668 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p322bbd8680)\">\n    <image height=\"68\" id=\"imaged81d773ccf\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"197.273668\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAARFJREFUeJzt2DGKAkEQQNFqGUHQZMVI0GwTb+QJlr2Ft9AjeCITAwPFdCOjFdv8R9XBoMJ/cdE0nwpmujzOhxpJZTrPjkZERL3/p2f3y1V6dn09Nt2jxaC3kz+UQcAgYBAwCBgEDAIGAYOAQaCLyVdvh29m3/nZv1N6ttb030ZERJRS0rNuCBgEDAIGAYOAQcAgYBAwCBgEDAJdDEfp4d/xounw7e3cep+Xc0PAIGAQMAgYBAwCBgGDgEHAINC1PNHXaHv+/0RuCBgEDAIGAYOAQcAgYBAwCBgEyk9M0t/ju9ulz7u8BTcEDAIGAYOAQcAgYBAwCBgEDAIGAYOAQcAgYBAwCBgEDAIGAYOAQcAg8ATi/hmFep3hzwAAAABJRU5ErkJggg==\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_5\">\n    <g id=\"xtick_5\">\n     <g id=\"line2d_11\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"202.934538\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_6\">\n     <g id=\"line2d_12\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"259.543234\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_6\">\n    <g id=\"ytick_7\">\n     <g id=\"line2d_13\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mab43d2a564\" y=\"27.978995\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_8\">\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mab43d2a564\" y=\"50.622473\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_9\">\n     <g id=\"line2d_15\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mab43d2a564\" y=\"73.265951\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_13\">\n    <path d=\"M 197.273668 90.24856 \nL 197.273668 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_14\">\n    <path d=\"M 265.204103 90.24856 \nL 265.204103 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_15\">\n    <path d=\"M 197.273668 90.24856 \nL 265.204103 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_16\">\n    <path d=\"M 197.273668 22.318125 \nL 265.204103 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_7\">\n    <!-- Head 3 -->\n    <defs>\n     <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n    </defs>\n    <g transform=\"translate(209.824511 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-51\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_4\">\n   <g id=\"patch_17\">\n    <path d=\"M 278.79019 90.24856 \nL 346.720625 90.24856 \nL 346.720625 22.318125 \nL 278.79019 22.318125 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#peec8be5c0d)\">\n    <image height=\"68\" id=\"imagee21914b1dc\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"278.79019\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAPZJREFUeJzt1zEKwkAQQNGMRBCSwgNo4ekUvFBuZ+MBUhgQLNb+V7PFYiL/1cOyfKbYjbLMpftzt+GUnt01vMcmGQQMAgYBg4BBwCBgEDAIGARiLU/3muf1tDyb3cMNAYOAQcAgYBAwCBgEDAIGAYOAQaAvJf+ViYiqw+/DOT3b8n9Sww0Bg4BBwCBgEDAIGAQMAgYBg0BcuzH9dl/L87olNwQMAgYBg4BBwCBgEDAIGAQMAv3lsE8Pl9dcdXiMx9r7/JwbAgYBg4BBwCBgEDAIGAQMAgYBg0D/eH/Sw1v8m9RyQ8AgYBAwCBgEDAIGAYOAQcAg8AXdGhvlWhsCbwAAAABJRU5ErkJggg==\" y=\"-22.24856\"/>\n   </g>\n   <g id=\"matplotlib.axis_7\">\n    <g id=\"xtick_7\">\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"284.45106\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_8\">\n     <g id=\"line2d_17\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"341.059755\" xlink:href=\"#m4a5359bf59\" y=\"90.24856\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_8\">\n    <g id=\"ytick_10\">\n     <g id=\"line2d_18\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mab43d2a564\" y=\"27.978995\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_11\">\n     <g id=\"line2d_19\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mab43d2a564\" y=\"50.622473\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_12\">\n     <g id=\"line2d_20\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mab43d2a564\" y=\"73.265951\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_18\">\n    <path d=\"M 278.79019 90.24856 \nL 278.79019 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_19\">\n    <path d=\"M 346.720625 90.24856 \nL 346.720625 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_20\">\n    <path d=\"M 278.79019 90.24856 \nL 346.720625 90.24856 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_21\">\n    <path d=\"M 278.79019 22.318125 \nL 346.720625 22.318125 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_8\">\n    <!-- Head 4 -->\n    <g transform=\"translate(291.341033 16.318125)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-52\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_5\">\n   <g id=\"patch_22\">\n    <path d=\"M 34.240625 194.026742 \nL 102.17106 194.026742 \nL 102.17106 126.096307 \nL 34.240625 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p01b1e8fede)\">\n    <image height=\"68\" id=\"image682657a6bc\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"34.240625\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAUtJREFUeJzt2j8uRFEUgPF7ZvxpiFBIdFqNJdiFNWjYAZU/jc40CptQ6CSWYAuE6JgImsnMffqvOreYeInvV5/cnHy5xbvJi/r13pWs2TQ9WkopZbiYHo3BID17ur7dtMbJ+Ck9m9/inzAIGAQMAgYBg4BBwCBgEDAIxOzxPv3pPrk8azp8+eIqPdt1+RdEbGw17RELS+lZbwgYBAwCBgGDgEHAIGAQMAgYBAwCMd7bTT8i1u4e2k6fTtKj9fYmPTvcP2rbo4E3BAwCBgGDgEHAIGAQMAgYBAwCcRir6U/30fdL0+FdrflFGv4gmqd+bNEjBgGDgEHAIGAQMAgYBAwCBoGoH2/pT/fjzZ2mw88/n5sX+mveEDAIGAQMAgYBg4BBwCBgEDAIGATioKyk3zLXP6/z3KUXvCFgEDAIGAQMAgYBg4BBwCBgEPgF968t1cnKkBMAAAAASUVORK5CYII=\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_9\">\n    <g id=\"xtick_9\">\n     <g id=\"line2d_21\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"39.901495\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 0 -->\n      <g transform=\"translate(36.720245 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_10\">\n     <g id=\"line2d_22\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"96.51019\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_10\">\n      <!-- 5 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(93.32894 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_11\">\n     <!-- Key positions -->\n     <defs>\n      <path d=\"M 9.8125 72.90625 \nL 19.671875 72.90625 \nL 19.671875 42.09375 \nL 52.390625 72.90625 \nL 65.09375 72.90625 \nL 28.90625 38.921875 \nL 67.671875 0 \nL 54.6875 0 \nL 19.671875 35.109375 \nL 19.671875 0 \nL 9.8125 0 \nz\n\" id=\"DejaVuSans-75\"/>\n     </defs>\n     <g transform=\"translate(35.142561 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_10\">\n    <g id=\"ytick_13\">\n     <g id=\"line2d_23\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mab43d2a564\" y=\"131.757176\"/>\n      </g>\n     </g>\n     <g id=\"text_12\">\n      <!-- 0 -->\n      <g transform=\"translate(20.878125 135.556395)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_14\">\n     <g id=\"line2d_24\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mab43d2a564\" y=\"154.400655\"/>\n      </g>\n     </g>\n     <g id=\"text_13\">\n      <!-- 2 -->\n      <g transform=\"translate(20.878125 158.199873)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_15\">\n     <g id=\"line2d_25\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#mab43d2a564\" y=\"177.044133\"/>\n      </g>\n     </g>\n     <g id=\"text_14\">\n      <!-- 4 -->\n      <g transform=\"translate(20.878125 180.843352)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_15\">\n     <!-- Query positions -->\n     <g transform=\"translate(14.798437 199.256055)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-81\"/>\n      <use x=\"78.710938\" xlink:href=\"#DejaVuSans-117\"/>\n      <use x=\"142.089844\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"203.613281\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"244.726562\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"303.90625\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"335.693359\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"399.169922\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"460.351562\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"512.451172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"540.234375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"579.443359\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"607.226562\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"668.408203\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"731.787109\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_23\">\n    <path d=\"M 34.240625 194.026742 \nL 34.240625 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_24\">\n    <path d=\"M 102.17106 194.026742 \nL 102.17106 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_25\">\n    <path d=\"M 34.240625 194.026742 \nL 102.17106 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_26\">\n    <path d=\"M 34.240625 126.096307 \nL 102.17106 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_16\">\n    <!-- Head 1 -->\n    <g transform=\"translate(46.791467 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-49\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_6\">\n   <g id=\"patch_27\">\n    <path d=\"M 115.757147 194.026742 \nL 183.687582 194.026742 \nL 183.687582 126.096307 \nL 115.757147 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#pf89901900f)\">\n    <image height=\"68\" id=\"image89b4f76d93\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"115.757147\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAATRJREFUeJzt2jFKA0EUgOGZJZ0pBK0Doh7BgFcQPEfAHMVa1DN4CQ9ip41FVJIsacxu+r96r1hc4f/qx/D4M8UOpHabr75E7dbh0VJKqUfHqfmh3J+chWebAff4lwwCBgGDgEHAIGAQMAgYBAwCtW9/4p/uSf16FZ59OL8Kzy4/31J71Cb+u3tDwCBgEDAIGAQMAgYBg4BBwCBgEJj0+9/49G6TOvz5Yh6ezbxPMm+TLG8IGAQMAgYBg4BBwCBgEDAIGAQm3etLeLi5vkkdfnt5Gp4d8nM8YxxbjIhBwCBgEDAIGAQMAgYBg4BBoHbb7/A/iO6ms9Thj+17eqG/5g0Bg4BBwCBgEDAIGAQMAgYBg4BBoC7KNPyWeWo/htxlFLwhYBAwCBgEDAIGAYOAQcAgYBA4AGlGJ1fVKNPFAAAAAElFTkSuQmCC\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_11\">\n    <g id=\"xtick_11\">\n     <g id=\"line2d_26\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"121.418016\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_17\">\n      <!-- 0 -->\n      <g transform=\"translate(118.236766 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_12\">\n     <g id=\"line2d_27\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"178.026712\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_18\">\n      <!-- 5 -->\n      <g transform=\"translate(174.845462 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_19\">\n     <!-- Key positions -->\n     <g transform=\"translate(116.659083 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_12\">\n    <g id=\"ytick_16\">\n     <g id=\"line2d_28\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mab43d2a564\" y=\"131.757176\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_17\">\n     <g id=\"line2d_29\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mab43d2a564\" y=\"154.400655\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_18\">\n     <g id=\"line2d_30\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#mab43d2a564\" y=\"177.044133\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_28\">\n    <path d=\"M 115.757147 194.026742 \nL 115.757147 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_29\">\n    <path d=\"M 183.687582 194.026742 \nL 183.687582 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_30\">\n    <path d=\"M 115.757147 194.026742 \nL 183.687582 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_31\">\n    <path d=\"M 115.757147 126.096307 \nL 183.687582 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_20\">\n    <!-- Head 2 -->\n    <g transform=\"translate(128.307989 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-50\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_7\">\n   <g id=\"patch_32\">\n    <path d=\"M 197.273668 194.026742 \nL 265.204103 194.026742 \nL 265.204103 126.096307 \nL 197.273668 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p4cd36727c5)\">\n    <image height=\"68\" id=\"image1607b15d92\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"197.273668\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAU1JREFUeJzt1zFKQ0EUQNE/368EFARBsLIUrERwCTbBHVgLIrgMdQ1xHSaQThAEC5ugRTobQRAkIFipPxZ2t3qvCAq5p348hssUM+Xz7GhaBS2cnkdHfzVL4dF2fBeerTe3U8dob6/iu1Ob54BBwCBgEDAIGAQMAgYBg4BBoHyPrsNP96ppUsunN4PwbN09jO+dvKbOUW/txWdTm+eAQcAgYBAwCBgEDAIGAYOAQcAgUNrJS/wv8/6WWj7Y3Q/PHjw9hGdLs5g6R4Y3BAwCBgGDgEHAIGAQMAgYBAwCpb+2EX66d++HueWr6/HZznJq96x4Q8AgYBAwCBgEDAIGAYOAQcAgUL76l+Gn++PJRWr5zniUPtBf84aAQcAgYBAwCBgEDAIGAYOAQcAgUI6rlfBfpvfxPMuz/AveEDAIGAQMAgYBg4BBwCBgEDAI/ACTwCsvb5UhXQAAAABJRU5ErkJggg==\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_13\">\n    <g id=\"xtick_13\">\n     <g id=\"line2d_31\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"202.934538\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_21\">\n      <!-- 0 -->\n      <g transform=\"translate(199.753288 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_14\">\n     <g id=\"line2d_32\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"259.543234\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_22\">\n      <!-- 5 -->\n      <g transform=\"translate(256.361984 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_23\">\n     <!-- Key positions -->\n     <g transform=\"translate(198.175605 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_14\">\n    <g id=\"ytick_19\">\n     <g id=\"line2d_33\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mab43d2a564\" y=\"131.757176\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_20\">\n     <g id=\"line2d_34\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mab43d2a564\" y=\"154.400655\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_21\">\n     <g id=\"line2d_35\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#mab43d2a564\" y=\"177.044133\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_33\">\n    <path d=\"M 197.273668 194.026742 \nL 197.273668 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_34\">\n    <path d=\"M 265.204103 194.026742 \nL 265.204103 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_35\">\n    <path d=\"M 197.273668 194.026742 \nL 265.204103 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_36\">\n    <path d=\"M 197.273668 126.096307 \nL 265.204103 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_24\">\n    <!-- Head 3 -->\n    <g transform=\"translate(209.824511 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-51\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_8\">\n   <g id=\"patch_37\">\n    <path d=\"M 278.79019 194.026742 \nL 346.720625 194.026742 \nL 346.720625 126.096307 \nL 278.79019 126.096307 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p051e628456)\">\n    <image height=\"68\" id=\"imagec3c45c190d\" transform=\"scale(1 -1)translate(0 -68)\" width=\"68\" x=\"278.79019\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAABHNCSVQICAgIfAhkiAAAAQZJREFUeJzt2i8OwjAYQPHuj2NHINwGzxFwEAweyQ1wGC5HkAgCTELxT30VS7bwfvpL07zUtFv1fd5zCqqaNjo6KvtuEZ6tB9zHJBkEDAIGAYOAQcAgYBAwCBgE2lQ3gy3+uRzDs/X6EJ59rZZF+zi9r/F9FK38BwwCBgGDgEHAIGAQMAgYBAwCBoEq94/wZ4hS29k8PHvub0Nto4gnBAwCBgGDgEHAIGAQMAgYBAwCBgGDgEHAIGAQMAgYBAwCBgGDgEGgzTn+6L4r+Ik+pfG8pJfwhIBBwCBgEDAIGAQMAgYBg4BBwCBQbVIXvsxM8W5SyhMCBgGDgEHAIGAQMAgYBAwCBoEfiKocusIlhccAAAAASUVORK5CYII=\" y=\"-126.026742\"/>\n   </g>\n   <g id=\"matplotlib.axis_15\">\n    <g id=\"xtick_15\">\n     <g id=\"line2d_36\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"284.45106\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_25\">\n      <!-- 0 -->\n      <g transform=\"translate(281.26981 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_16\">\n     <g id=\"line2d_37\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"341.059755\" xlink:href=\"#m4a5359bf59\" y=\"194.026742\"/>\n      </g>\n     </g>\n     <g id=\"text_26\">\n      <!-- 5 -->\n      <g transform=\"translate(337.878505 208.625179)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_27\">\n     <!-- Key positions -->\n     <g transform=\"translate(279.692126 222.303304)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_16\">\n    <g id=\"ytick_22\">\n     <g id=\"line2d_38\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mab43d2a564\" y=\"131.757176\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_23\">\n     <g id=\"line2d_39\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mab43d2a564\" y=\"154.400655\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_24\">\n     <g id=\"line2d_40\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#mab43d2a564\" y=\"177.044133\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_38\">\n    <path d=\"M 278.79019 194.026742 \nL 278.79019 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_39\">\n    <path d=\"M 346.720625 194.026742 \nL 346.720625 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_40\">\n    <path d=\"M 278.79019 194.026742 \nL 346.720625 194.026742 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_41\">\n    <path d=\"M 278.79019 126.096307 \nL 346.720625 126.096307 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_28\">\n    <!-- Head 4 -->\n    <g transform=\"translate(291.341033 120.096307)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-52\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_9\">\n   <g id=\"patch_42\">\n    <path clip-path=\"url(#pca044a796d)\" d=\"M 366.250625 165.250433 \nL 366.250625 164.804511 \nL 366.250625 51.540355 \nL 366.250625 51.094433 \nL 371.958425 51.094433 \nL 371.958425 51.540355 \nL 371.958425 164.804511 \nL 371.958425 165.250433 \nz\n\" style=\"fill:#ffffff;stroke:#ffffff;stroke-linejoin:miter;stroke-width:0.01;\"/>\n   </g>\n   <image height=\"114\" id=\"image1e99a29314\" transform=\"scale(1 -1)translate(0 -114)\" width=\"6\" x=\"366\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAYAAAByCAYAAABwf6CfAAAABHNCSVQICAgIfAhkiAAAAMhJREFUSIm9lUkOxDAIBInk/381l5zGLPMBylJHKDmCugswjq967rLmW1bZxU+JDEq0iDeMYoZcLvfxgcI3WWGDkKggRcgMtEKFOykgcThBnTHYB81Kt+LzoGXAg2KruSFONjiXwBvFy0C/jEGGbiV3Xrwl2CAlNjF4Vio891y5esLVq5YBT1HSGxVkFaQ4MNq4LcdykSHDXe78BQMVRdNtwyeF93FbaQgHRZAisFwZjgpkwJIcFDgSJ8Wes0LF7wPGpoXTrUjxB/s0DEox/kcFAAAAAElFTkSuQmCC\" y=\"-51\"/>\n   <g id=\"matplotlib.axis_17\"/>\n   <g id=\"matplotlib.axis_18\">\n    <g id=\"ytick_25\">\n     <g id=\"line2d_41\">\n      <defs>\n       <path d=\"M 0 0 \nL 3.5 0 \n\" id=\"m6c604647a7\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m6c604647a7\" y=\"165.250433\"/>\n      </g>\n     </g>\n     <g id=\"text_29\">\n      <!-- 0.0 -->\n      <defs>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n      </defs>\n      <g transform=\"translate(378.958425 169.049652)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_26\">\n     <g id=\"line2d_42\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m6c604647a7\" y=\"142.419233\"/>\n      </g>\n     </g>\n     <g id=\"text_30\">\n      <!-- 0.2 -->\n      <g transform=\"translate(378.958425 146.218452)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_27\">\n     <g id=\"line2d_43\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m6c604647a7\" y=\"119.588033\"/>\n      </g>\n     </g>\n     <g id=\"text_31\">\n      <!-- 0.4 -->\n      <g transform=\"translate(378.958425 123.387252)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_28\">\n     <g id=\"line2d_44\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m6c604647a7\" y=\"96.756833\"/>\n      </g>\n     </g>\n     <g id=\"text_32\">\n      <!-- 0.6 -->\n      <defs>\n       <path d=\"M 33.015625 40.375 \nQ 26.375 40.375 22.484375 35.828125 \nQ 18.609375 31.296875 18.609375 23.390625 \nQ 18.609375 15.53125 22.484375 10.953125 \nQ 26.375 6.390625 33.015625 6.390625 \nQ 39.65625 6.390625 43.53125 10.953125 \nQ 47.40625 15.53125 47.40625 23.390625 \nQ 47.40625 31.296875 43.53125 35.828125 \nQ 39.65625 40.375 33.015625 40.375 \nz\nM 52.59375 71.296875 \nL 52.59375 62.3125 \nQ 48.875 64.0625 45.09375 64.984375 \nQ 41.3125 65.921875 37.59375 65.921875 \nQ 27.828125 65.921875 22.671875 59.328125 \nQ 17.53125 52.734375 16.796875 39.40625 \nQ 19.671875 43.65625 24.015625 45.921875 \nQ 28.375 48.1875 33.59375 48.1875 \nQ 44.578125 48.1875 50.953125 41.515625 \nQ 57.328125 34.859375 57.328125 23.390625 \nQ 57.328125 12.15625 50.6875 5.359375 \nQ 44.046875 -1.421875 33.015625 -1.421875 \nQ 20.359375 -1.421875 13.671875 8.265625 \nQ 6.984375 17.96875 6.984375 36.375 \nQ 6.984375 53.65625 15.1875 63.9375 \nQ 23.390625 74.21875 37.203125 74.21875 \nQ 40.921875 74.21875 44.703125 73.484375 \nQ 48.484375 72.75 52.59375 71.296875 \nz\n\" id=\"DejaVuSans-54\"/>\n      </defs>\n      <g transform=\"translate(378.958425 100.556052)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-54\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_29\">\n     <g id=\"line2d_45\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m6c604647a7\" y=\"73.925633\"/>\n      </g>\n     </g>\n     <g id=\"text_33\">\n      <!-- 0.8 -->\n      <defs>\n       <path d=\"M 31.78125 34.625 \nQ 24.75 34.625 20.71875 30.859375 \nQ 16.703125 27.09375 16.703125 20.515625 \nQ 16.703125 13.921875 20.71875 10.15625 \nQ 24.75 6.390625 31.78125 6.390625 \nQ 38.8125 6.390625 42.859375 10.171875 \nQ 46.921875 13.96875 46.921875 20.515625 \nQ 46.921875 27.09375 42.890625 30.859375 \nQ 38.875 34.625 31.78125 34.625 \nz\nM 21.921875 38.8125 \nQ 15.578125 40.375 12.03125 44.71875 \nQ 8.5 49.078125 8.5 55.328125 \nQ 8.5 64.0625 14.71875 69.140625 \nQ 20.953125 74.21875 31.78125 74.21875 \nQ 42.671875 74.21875 48.875 69.140625 \nQ 55.078125 64.0625 55.078125 55.328125 \nQ 55.078125 49.078125 51.53125 44.71875 \nQ 48 40.375 41.703125 38.8125 \nQ 48.828125 37.15625 52.796875 32.3125 \nQ 56.78125 27.484375 56.78125 20.515625 \nQ 56.78125 9.90625 50.3125 4.234375 \nQ 43.84375 -1.421875 31.78125 -1.421875 \nQ 19.734375 -1.421875 13.25 4.234375 \nQ 6.78125 9.90625 6.78125 20.515625 \nQ 6.78125 27.484375 10.78125 32.3125 \nQ 14.796875 37.15625 21.921875 38.8125 \nz\nM 18.3125 54.390625 \nQ 18.3125 48.734375 21.84375 45.5625 \nQ 25.390625 42.390625 31.78125 42.390625 \nQ 38.140625 42.390625 41.71875 45.5625 \nQ 45.3125 48.734375 45.3125 54.390625 \nQ 45.3125 60.0625 41.71875 63.234375 \nQ 38.140625 66.40625 31.78125 66.40625 \nQ 25.390625 66.40625 21.84375 63.234375 \nQ 18.3125 60.0625 18.3125 54.390625 \nz\n\" id=\"DejaVuSans-56\"/>\n      </defs>\n      <g transform=\"translate(378.958425 77.724852)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-56\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_30\">\n     <g id=\"line2d_46\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m6c604647a7\" y=\"51.094433\"/>\n      </g>\n     </g>\n     <g id=\"text_34\">\n      <!-- 1.0 -->\n      <g transform=\"translate(378.958425 54.893652)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_43\">\n    <path d=\"M 366.250625 165.250433 \nL 366.250625 164.804511 \nL 366.250625 51.540355 \nL 366.250625 51.094433 \nL 371.958425 51.094433 \nL 371.958425 51.540355 \nL 371.958425 164.804511 \nL 371.958425 165.250433 \nz\n\" style=\"fill:none;stroke:#000000;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p633362a0e4\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"34.240625\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"p3e2c515c0c\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"115.757147\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"p322bbd8680\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"197.273668\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"peec8be5c0d\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"278.79019\" y=\"22.318125\"/>\n  </clipPath>\n  <clipPath id=\"p01b1e8fede\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"34.240625\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"pf89901900f\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"115.757147\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"p4cd36727c5\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"197.273668\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"p051e628456\">\n   <rect height=\"67.930435\" width=\"67.930435\" x=\"278.79019\" y=\"126.096307\"/>\n  </clipPath>\n  <clipPath id=\"pca044a796d\">\n   <rect height=\"114.156\" width=\"5.7078\" x=\"366.250625\" y=\"51.094433\"/>\n  </clipPath>\n </defs>\n</svg>\n",
+            "text/plain": [
+              "<Figure size 504x252 with 9 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Plus one to include the beginning-of-sequence token\n",
+        "show_heatmaps(\n",
+        "    dec_self_attention_weights[:, :, :, :len(translation.split()) + 1],\n",
+        "    xlabel='Key positions', ylabel='Query positions',\n",
+        "    titles=['Head %d' % i for i in range(1, 5)], figsize=(7, 3.5))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cab19ZpWuI0A"
+      },
+      "source": [
+        "Decoder encoder-attention."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 53,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 299
+        },
+        "execution": {
+          "iopub.execute_input": "2022-04-07T04:22:47.487310Z",
+          "iopub.status.busy": "2022-04-07T04:22:47.486839Z",
+          "iopub.status.idle": "2022-04-07T04:22:48.254575Z",
+          "shell.execute_reply": "2022-04-07T04:22:48.253892Z",
+          "shell.execute_reply.started": "2022-04-07T04:22:47.487273Z"
+        },
+        "id": "vASzp_5tt_cH",
+        "outputId": "80e8801d-7d6a-42ef-d32f-2d9b2eed05e5",
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"208.108094pt\" version=\"1.1\" viewBox=\"0 0 402.06155 208.108094\" width=\"402.06155pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 208.108094 \nL 402.06155 208.108094 \nL 402.06155 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 34.240625 66.773662 \nL 102.17106 66.773662 \nL 102.17106 26.015401 \nL 34.240625 26.015401 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p3087a38390)\">\n    <image height=\"41\" id=\"image1c9ca8c636\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"34.240625\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAARxJREFUaIHt2KFKBEEcgPGd2wVRtJh8AsEi2sRuMVh9AvEVjCaLTYPVIBaTYPIJTDbBqFi13GkQccf+MX9ZuDAXvl+c4X87fAwcu6mffOQm0F+dRltNnoyL62lzK5xpt/fCvVkxqn2AWWMQMAgYBAwCBoF0t7wS/u3uPj/Ekz/f5fX5pfhhcwuDD1aLNwQMAgYBg4BBwCCQ+vF7/LZ7cxZPrq4Xl/P9bTjSHZ0PP1kl3hAwCBgEDAIGAYNAl9ou3MyvL+Feu7NfXP/9up72TFV5Q8AgYBAwCBgE0mGzGL7cXXy+xZO5L//gqJ36UDV5Q8AgYBAwCBgEDAL/f1O9PIkn1zaKy/npMRzpDo4HH6wWbwgYBAwCBgGDgEHgD+g+L76LCIXQAAAAAElFTkSuQmCC\" y=\"-25.773662\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m4a3956874e\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"37.637147\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_2\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"71.602364\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_3\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"m34af0ee076\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m34af0ee076\" y=\"29.411923\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 0 -->\n      <defs>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(20.878125 33.211141)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m34af0ee076\" y=\"63.37714\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 5 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(20.878125 67.176359)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_3\">\n     <!-- Query positions -->\n     <defs>\n      <path d=\"M 39.40625 66.21875 \nQ 28.65625 66.21875 22.328125 58.203125 \nQ 16.015625 50.203125 16.015625 36.375 \nQ 16.015625 22.609375 22.328125 14.59375 \nQ 28.65625 6.59375 39.40625 6.59375 \nQ 50.140625 6.59375 56.421875 14.59375 \nQ 62.703125 22.609375 62.703125 36.375 \nQ 62.703125 50.203125 56.421875 58.203125 \nQ 50.140625 66.21875 39.40625 66.21875 \nz\nM 53.21875 1.3125 \nL 66.21875 -12.890625 \nL 54.296875 -12.890625 \nL 43.5 -1.21875 \nQ 41.890625 -1.3125 41.03125 -1.359375 \nQ 40.1875 -1.421875 39.40625 -1.421875 \nQ 24.03125 -1.421875 14.8125 8.859375 \nQ 5.609375 19.140625 5.609375 36.375 \nQ 5.609375 53.65625 14.8125 63.9375 \nQ 24.03125 74.21875 39.40625 74.21875 \nQ 54.734375 74.21875 63.90625 63.9375 \nQ 73.09375 53.65625 73.09375 36.375 \nQ 73.09375 23.6875 67.984375 14.640625 \nQ 62.890625 5.609375 53.21875 1.3125 \nz\n\" id=\"DejaVuSans-81\"/>\n      <path d=\"M 8.5 21.578125 \nL 8.5 54.6875 \nL 17.484375 54.6875 \nL 17.484375 21.921875 \nQ 17.484375 14.15625 20.5 10.265625 \nQ 23.53125 6.390625 29.59375 6.390625 \nQ 36.859375 6.390625 41.078125 11.03125 \nQ 45.3125 15.671875 45.3125 23.6875 \nL 45.3125 54.6875 \nL 54.296875 54.6875 \nL 54.296875 0 \nL 45.3125 0 \nL 45.3125 8.40625 \nQ 42.046875 3.421875 37.71875 1 \nQ 33.40625 -1.421875 27.6875 -1.421875 \nQ 18.265625 -1.421875 13.375 4.4375 \nQ 8.5 10.296875 8.5 21.578125 \nz\nM 31.109375 56 \nz\n\" id=\"DejaVuSans-117\"/>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 32.171875 -5.078125 \nQ 28.375 -14.84375 24.75 -17.8125 \nQ 21.140625 -20.796875 15.09375 -20.796875 \nL 7.90625 -20.796875 \nL 7.90625 -13.28125 \nL 13.1875 -13.28125 \nQ 16.890625 -13.28125 18.9375 -11.515625 \nQ 21 -9.765625 23.484375 -3.21875 \nL 25.09375 0.875 \nL 2.984375 54.6875 \nL 12.5 54.6875 \nL 29.59375 11.921875 \nL 46.6875 54.6875 \nL 56.203125 54.6875 \nz\n\" id=\"DejaVuSans-121\"/>\n      <path id=\"DejaVuSans-32\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n     </defs>\n     <g transform=\"translate(14.798437 85.589063)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-81\"/>\n      <use x=\"78.710938\" xlink:href=\"#DejaVuSans-117\"/>\n      <use x=\"142.089844\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"203.613281\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"244.726562\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"303.90625\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"335.693359\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"399.169922\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"460.351562\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"512.451172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"540.234375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"579.443359\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"607.226562\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"668.408203\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"731.787109\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 34.240625 66.773662 \nL 34.240625 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 102.17106 66.773662 \nL 102.17106 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 34.240625 66.773662 \nL 102.17106 66.773662 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 34.240625 26.015401 \nL 102.17106 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_4\">\n    <!-- Head 1 -->\n    <defs>\n     <path d=\"M 9.8125 72.90625 \nL 19.671875 72.90625 \nL 19.671875 43.015625 \nL 55.515625 43.015625 \nL 55.515625 72.90625 \nL 65.375 72.90625 \nL 65.375 0 \nL 55.515625 0 \nL 55.515625 34.71875 \nL 19.671875 34.71875 \nL 19.671875 0 \nL 9.8125 0 \nz\n\" id=\"DejaVuSans-72\"/>\n     <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n     <path d=\"M 45.40625 46.390625 \nL 45.40625 75.984375 \nL 54.390625 75.984375 \nL 54.390625 0 \nL 45.40625 0 \nL 45.40625 8.203125 \nQ 42.578125 3.328125 38.25 0.953125 \nQ 33.9375 -1.421875 27.875 -1.421875 \nQ 17.96875 -1.421875 11.734375 6.484375 \nQ 5.515625 14.40625 5.515625 27.296875 \nQ 5.515625 40.1875 11.734375 48.09375 \nQ 17.96875 56 27.875 56 \nQ 33.9375 56 38.25 53.625 \nQ 42.578125 51.265625 45.40625 46.390625 \nz\nM 14.796875 27.296875 \nQ 14.796875 17.390625 18.875 11.75 \nQ 22.953125 6.109375 30.078125 6.109375 \nQ 37.203125 6.109375 41.296875 11.75 \nQ 45.40625 17.390625 45.40625 27.296875 \nQ 45.40625 37.203125 41.296875 42.84375 \nQ 37.203125 48.484375 30.078125 48.484375 \nQ 22.953125 48.484375 18.875 42.84375 \nQ 14.796875 37.203125 14.796875 27.296875 \nz\n\" id=\"DejaVuSans-100\"/>\n     <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n    </defs>\n    <g transform=\"translate(46.791467 20.015401)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-49\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_2\">\n   <g id=\"patch_7\">\n    <path d=\"M 115.757147 66.773662 \nL 183.687582 66.773662 \nL 183.687582 26.015401 \nL 115.757147 26.015401 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p1209859591)\">\n    <image height=\"41\" id=\"image6567dba2d2\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"115.757147\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAARRJREFUaIHt169KBFEYQPG5uxMEfQGxaLD6GFaxbtq2YhKTj2AwGAyCRt/CoNEiW2XX4h+wiYYBFXbGfrifKIIzwvnF+3GHy+HCcNPs5qopAs3DJBoVxetzfv3jPdzS3xjF3+uIXtsH6BqDgEHAIGAQMAiUaWk1HNanB+EsbQ7yg/vb356pVd4QMAgYBAwCBgGDQGqql/C1W0+vw41Pw+3s+uLZSbint7L2g6O1wxsCBgGDgEHAIGAQKL8a3g22wtny5Xl2vR5fxB/0t/v/GAQMAgYBg0AaFQvh4+64evzLs3SCNwQMAgYBg4BBwCBQHu2uh8PmrQpns8O97Hp/Zz/ck+bmv3+ylnhDwCBgEDAIGAQMAp+sECs1C4v+IwAAAABJRU5ErkJggg==\" y=\"-25.773662\"/>\n   </g>\n   <g id=\"matplotlib.axis_3\">\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"119.153668\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"153.118886\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_4\">\n    <g id=\"ytick_3\">\n     <g id=\"line2d_7\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#m34af0ee076\" y=\"29.411923\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_4\">\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#m34af0ee076\" y=\"63.37714\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_8\">\n    <path d=\"M 115.757147 66.773662 \nL 115.757147 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_9\">\n    <path d=\"M 183.687582 66.773662 \nL 183.687582 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_10\">\n    <path d=\"M 115.757147 66.773662 \nL 183.687582 66.773662 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_11\">\n    <path d=\"M 115.757147 26.015401 \nL 183.687582 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_5\">\n    <!-- Head 2 -->\n    <defs>\n     <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n    </defs>\n    <g transform=\"translate(128.307989 20.015401)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-50\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_3\">\n   <g id=\"patch_12\">\n    <path d=\"M 197.273668 66.773662 \nL 265.204103 66.773662 \nL 265.204103 26.015401 \nL 197.273668 26.015401 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#pf6164669cf)\">\n    <image height=\"41\" id=\"image276a2b20e2\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"197.273668\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAARdJREFUaIHt2T1KA1EUQOF5E1EI/tQiWlhYC6JgLYJbiBsQbd2MloJLiJ2CXdAipWIrLkAIg5UT+8O7wSD4pjhf+YZLLocHQ5I0bT6nVeD98CB6VG0+3GfP29FdONM7GoTPuqIuvUDXGAQMAgYBg4BBYKF9ew4frq4sxpNfk+xxvX/8152K8oaAQcAgYBAwCBgE0nhjK/y2u/s6Dgfbl1H2vN7Ziz9sqT/HamV4Q8AgYBAwCBgEDAJp1o/MzeAkHOxf32bP2+FNONM7vZxjtTK8IWAQMAgYBAwCM98y30/x35JpfTt7Prk4D2fWho+/36wQbwgYBAwCBgGDgEEgnVXL4Wv3qvn4z106wRsCBgGDgEHAIGAQ+AG6LS3n6jjVxwAAAABJRU5ErkJggg==\" y=\"-25.773662\"/>\n   </g>\n   <g id=\"matplotlib.axis_5\">\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"200.67019\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_6\">\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"234.635408\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_6\">\n    <g id=\"ytick_5\">\n     <g id=\"line2d_11\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#m34af0ee076\" y=\"29.411923\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_6\">\n     <g id=\"line2d_12\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#m34af0ee076\" y=\"63.37714\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_13\">\n    <path d=\"M 197.273668 66.773662 \nL 197.273668 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_14\">\n    <path d=\"M 265.204103 66.773662 \nL 265.204103 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_15\">\n    <path d=\"M 197.273668 66.773662 \nL 265.204103 66.773662 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_16\">\n    <path d=\"M 197.273668 26.015401 \nL 265.204103 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_6\">\n    <!-- Head 3 -->\n    <defs>\n     <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n    </defs>\n    <g transform=\"translate(209.824511 20.015401)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-51\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_4\">\n   <g id=\"patch_17\">\n    <path d=\"M 278.79019 66.773662 \nL 346.720625 66.773662 \nL 346.720625 26.015401 \nL 278.79019 26.015401 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p175ffdd866)\">\n    <image height=\"41\" id=\"imagec180f948a3\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"278.79019\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAAS9JREFUaIHt2aFLg0EcxvH35ovJsGRU0OziqlHBMPE/sDjE/8FoMKwYJkwEg2jWIFoVhsEgzC42QRgMk5Ob/eEe2JtuwvcT7/iN48vB8bIQP94mhfG+ue22iqWTw+T65KVvZ8qDI7s3K2q5DzBrCCIIIggiCCIIIkK7WLDPbvdzYAfj4DH9gysNO1NbXK5wtDy4IYIggiCCIIIggiAi/N507bP7c3VtB+d3WumN8djOzLXa058sE26IIIggiCCIIIggiAjxe2if3efVNTvYvL9Irsdex86Ux5cVjpYHN0QQRBBEEEQQRJSxf2s3m3fndu91aze53uil/+L8L7ghgiCCIIIggiCCICLE0Zf9uBturNvB+tlpcn20t+9nHp4qHC0PboggiCCIIIggiCCI+ANaVTSGCxkADwAAAABJRU5ErkJggg==\" y=\"-25.773662\"/>\n   </g>\n   <g id=\"matplotlib.axis_7\">\n    <g id=\"xtick_7\">\n     <g id=\"line2d_13\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"282.186712\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_8\">\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"316.151929\" xlink:href=\"#m4a3956874e\" y=\"66.773662\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_8\">\n    <g id=\"ytick_7\">\n     <g id=\"line2d_15\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#m34af0ee076\" y=\"29.411923\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_8\">\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#m34af0ee076\" y=\"63.37714\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_18\">\n    <path d=\"M 278.79019 66.773662 \nL 278.79019 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_19\">\n    <path d=\"M 346.720625 66.773662 \nL 346.720625 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_20\">\n    <path d=\"M 278.79019 66.773662 \nL 346.720625 66.773662 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_21\">\n    <path d=\"M 278.79019 26.015401 \nL 346.720625 26.015401 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_7\">\n    <!-- Head 4 -->\n    <defs>\n     <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n    </defs>\n    <g transform=\"translate(291.341033 20.015401)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-52\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_5\">\n   <g id=\"patch_22\">\n    <path d=\"M 34.240625 170.551844 \nL 102.17106 170.551844 \nL 102.17106 129.793583 \nL 34.240625 129.793583 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p599a40ff73)\">\n    <image height=\"41\" id=\"image49326b9b68\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"34.240625\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAARFJREFUaIHt2j9KA0EYQPH5dMXCKGKTwohY+wcrj5IrWHoPL+AFvENAwTpY2dnYWVoFbQTJ2D/mg4CR3eL9yhlmd3gMDAsbL0fHtSQu5o/ZVCk/3+3x7Z10Sewe5M8biI2+NzA0BgGDgEHAIGAQiOsySq/du6/39b4sYq3P+w+eEDAIGAQMAgYBg0AsFx/ptbu8v81Xjg/b45+LdMnm9GbljfXFEwIGAYOAQcAgYBDootvKZycn+dzefnO4Pj3ka6Yr7qpHnhAwCBgEDAIGga7W9Nuu1LfXdC5OL9vjZ+d/3lSfPCFgEDAIGAQMAgaBmI8n6b179TzLV2Z/CkXeOEbtD8Ih8YSAQcAgYBAwCBgEfgEIHCB29tZ2mAAAAABJRU5ErkJggg==\" y=\"-129.551844\"/>\n   </g>\n   <g id=\"matplotlib.axis_9\">\n    <g id=\"xtick_9\">\n     <g id=\"line2d_17\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"37.637147\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 0 -->\n      <g transform=\"translate(34.455897 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_10\">\n     <g id=\"line2d_18\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"71.602364\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 5 -->\n      <g transform=\"translate(68.421114 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_10\">\n     <!-- Key positions -->\n     <defs>\n      <path d=\"M 9.8125 72.90625 \nL 19.671875 72.90625 \nL 19.671875 42.09375 \nL 52.390625 72.90625 \nL 65.09375 72.90625 \nL 28.90625 38.921875 \nL 67.671875 0 \nL 54.6875 0 \nL 19.671875 35.109375 \nL 19.671875 0 \nL 9.8125 0 \nz\n\" id=\"DejaVuSans-75\"/>\n     </defs>\n     <g transform=\"translate(35.142561 198.828406)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_10\">\n    <g id=\"ytick_9\">\n     <g id=\"line2d_19\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m34af0ee076\" y=\"133.190104\"/>\n      </g>\n     </g>\n     <g id=\"text_11\">\n      <!-- 0 -->\n      <g transform=\"translate(20.878125 136.989323)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_10\">\n     <g id=\"line2d_20\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"34.240625\" xlink:href=\"#m34af0ee076\" y=\"167.155322\"/>\n      </g>\n     </g>\n     <g id=\"text_12\">\n      <!-- 5 -->\n      <g transform=\"translate(20.878125 170.954541)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_13\">\n     <!-- Query positions -->\n     <g transform=\"translate(14.798437 189.367244)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-81\"/>\n      <use x=\"78.710938\" xlink:href=\"#DejaVuSans-117\"/>\n      <use x=\"142.089844\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"203.613281\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"244.726562\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"303.90625\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"335.693359\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"399.169922\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"460.351562\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"512.451172\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"540.234375\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"579.443359\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"607.226562\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"668.408203\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"731.787109\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_23\">\n    <path d=\"M 34.240625 170.551844 \nL 34.240625 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_24\">\n    <path d=\"M 102.17106 170.551844 \nL 102.17106 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_25\">\n    <path d=\"M 34.240625 170.551844 \nL 102.17106 170.551844 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_26\">\n    <path d=\"M 34.240625 129.793583 \nL 102.17106 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_14\">\n    <!-- Head 1 -->\n    <g transform=\"translate(46.791467 123.793583)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-49\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_6\">\n   <g id=\"patch_27\">\n    <path d=\"M 115.757147 170.551844 \nL 183.687582 170.551844 \nL 183.687582 129.793583 \nL 115.757147 129.793583 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p50453703ad)\">\n    <image height=\"41\" id=\"imagedb049742ed\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"115.757147\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAARNJREFUaIHt2jFKA0EcRvHZZMFAFMTGwiIXEC0kjSfxBl7EO+QGYuUN9AAqImgnYiGCQSQIClq4Y/+YfyFbTIT3K/djyfAYSJE03ftrToHu/CSaUr65Kj7/eXwK31mZnYbbshjUPsCyMQgYBAwCBgGDQJu+PsMxX1+EWzPdLz4fLha9D1WTNwQMAgYBg4BBwCDQptE4HL/vHsJttLtXHiaTvmeqyhsCBgGDgEHAIGAQaNNgGI73l8/htnMUfO3O43f+A28IGAQMAgYBg0DbnR2H4/bBNNzy20t52Nzqe6aqvCFgEDAIGAQMAgaB5jCthv8gms1vwxfzR/kny2ZtI/6w8fofjlaHNwQMAgYBg4BBwCDwC2VTKbzIJbLFAAAAAElFTkSuQmCC\" y=\"-129.551844\"/>\n   </g>\n   <g id=\"matplotlib.axis_11\">\n    <g id=\"xtick_11\">\n     <g id=\"line2d_21\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"119.153668\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_15\">\n      <!-- 0 -->\n      <g transform=\"translate(115.972418 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_12\">\n     <g id=\"line2d_22\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"153.118886\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_16\">\n      <!-- 5 -->\n      <g transform=\"translate(149.937636 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_17\">\n     <!-- Key positions -->\n     <g transform=\"translate(116.659083 198.828406)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_12\">\n    <g id=\"ytick_11\">\n     <g id=\"line2d_23\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#m34af0ee076\" y=\"133.190104\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_12\">\n     <g id=\"line2d_24\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"115.757147\" xlink:href=\"#m34af0ee076\" y=\"167.155322\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_28\">\n    <path d=\"M 115.757147 170.551844 \nL 115.757147 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_29\">\n    <path d=\"M 183.687582 170.551844 \nL 183.687582 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_30\">\n    <path d=\"M 115.757147 170.551844 \nL 183.687582 170.551844 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_31\">\n    <path d=\"M 115.757147 129.793583 \nL 183.687582 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_18\">\n    <!-- Head 2 -->\n    <g transform=\"translate(128.307989 123.793583)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-50\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_7\">\n   <g id=\"patch_32\">\n    <path d=\"M 197.273668 170.551844 \nL 265.204103 170.551844 \nL 265.204103 129.793583 \nL 197.273668 129.793583 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p046858c8d8)\">\n    <image height=\"41\" id=\"image299c4d85f3\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"197.273668\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAAS5JREFUaIHt2DFLQlEYh/F74k4tDuHk4FCIoULQ5ObqYKND0gco8VO0hINOzg3R2qI4OTQ0BQWBQ5vo0CL1AcLubf9zXlEcjsPzG8/hhZeHAxeu+72up5HB5XLWVbR8evGeZ5s1cybu3Jl3++Ig9AL7hiCCIIIggiCCIMIly7n52X04PjcHW/0b7/ms+2jOnLy/bbFaGLwQQRBBEEEQQRBBEOFWr2PzsxvNP82r3tWt97x9UTZnDu+Hm28WCC9EEEQQRBBEEEQQRLjk58v87E7PquZgvnDkPU//EnMmM3refLNAeCGCIIIggiCCICJe9yU5vbTvXLHkPU+nHzsvFRIvRBBEEEQQRBBEEETEg8W3eTloNM27dOL/P+pKlZ2XCokXIggiCCIIIggiCCL+AdhsLzP+bBpVAAAAAElFTkSuQmCC\" y=\"-129.551844\"/>\n   </g>\n   <g id=\"matplotlib.axis_13\">\n    <g id=\"xtick_13\">\n     <g id=\"line2d_25\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"200.67019\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_19\">\n      <!-- 0 -->\n      <g transform=\"translate(197.48894 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_14\">\n     <g id=\"line2d_26\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"234.635408\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_20\">\n      <!-- 5 -->\n      <g transform=\"translate(231.454158 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_21\">\n     <!-- Key positions -->\n     <g transform=\"translate(198.175605 198.828406)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_14\">\n    <g id=\"ytick_13\">\n     <g id=\"line2d_27\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#m34af0ee076\" y=\"133.190104\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_14\">\n     <g id=\"line2d_28\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"197.273668\" xlink:href=\"#m34af0ee076\" y=\"167.155322\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_33\">\n    <path d=\"M 197.273668 170.551844 \nL 197.273668 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_34\">\n    <path d=\"M 265.204103 170.551844 \nL 265.204103 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_35\">\n    <path d=\"M 197.273668 170.551844 \nL 265.204103 170.551844 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_36\">\n    <path d=\"M 197.273668 129.793583 \nL 265.204103 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_22\">\n    <!-- Head 3 -->\n    <g transform=\"translate(209.824511 123.793583)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-51\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_8\">\n   <g id=\"patch_37\">\n    <path d=\"M 278.79019 170.551844 \nL 346.720625 170.551844 \nL 346.720625 129.793583 \nL 278.79019 129.793583 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g clip-path=\"url(#p911df8b425)\">\n    <image height=\"41\" id=\"image49cfd84542\" transform=\"scale(1 -1)translate(0 -41)\" width=\"68\" x=\"278.79019\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAEQAAAApCAYAAACMeY82AAAABHNCSVQICAgIfAhkiAAAASRJREFUaIHt2rFKw1AYhuEcDbTgIi6ldyB0EFQQLMWtWyeXQmcnXbwC8SK8A4dcgd1dih1cFKSlS3FwEzpYyJDG/eN8YHFIC+8znp8fDi+BQNqwmr+XibEaDd0oue7fR88fsju7s9u7srNNsVP1BTYNQQRBBEEEQQRBRCimY/vaXd7e2MX6yWH0PH+b2Z29x6c1rlYNnhBBEEEQQRBBEEEQkYaDph3WO8d2Vkzir9eP0afdOf37vSrDEyIIIggiCCIIIggi0qQo/DTP/WK3Gz1/zl7tDq/dLUQQQRBBEEEQkZbfX3a4GL7Y2X7rKHo+aDX+fakq8YQIggiCCIIIggiCiPBz2bY/ZdYuzuxiOYt/Uw3nHbvDP4i2EEEEQQRBBEEEQcQvZcMuPc/UQQwAAAAASUVORK5CYII=\" y=\"-129.551844\"/>\n   </g>\n   <g id=\"matplotlib.axis_15\">\n    <g id=\"xtick_15\">\n     <g id=\"line2d_29\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"282.186712\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_23\">\n      <!-- 0 -->\n      <g transform=\"translate(279.005462 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_16\">\n     <g id=\"line2d_30\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"316.151929\" xlink:href=\"#m4a3956874e\" y=\"170.551844\"/>\n      </g>\n     </g>\n     <g id=\"text_24\">\n      <!-- 5 -->\n      <g transform=\"translate(312.970679 185.150281)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_25\">\n     <!-- Key positions -->\n     <g transform=\"translate(279.692126 198.828406)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-75\"/>\n      <use x=\"60.576172\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"122.099609\" xlink:href=\"#DejaVuSans-121\"/>\n      <use x=\"181.279297\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"213.066406\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"276.542969\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"337.724609\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"389.824219\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"417.607422\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"456.816406\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"484.599609\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"545.78125\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"609.160156\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_16\">\n    <g id=\"ytick_15\">\n     <g id=\"line2d_31\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#m34af0ee076\" y=\"133.190104\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_16\">\n     <g id=\"line2d_32\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"278.79019\" xlink:href=\"#m34af0ee076\" y=\"167.155322\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_38\">\n    <path d=\"M 278.79019 170.551844 \nL 278.79019 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_39\">\n    <path d=\"M 346.720625 170.551844 \nL 346.720625 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_40\">\n    <path d=\"M 278.79019 170.551844 \nL 346.720625 170.551844 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_41\">\n    <path d=\"M 278.79019 129.793583 \nL 346.720625 129.793583 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"text_26\">\n    <!-- Head 4 -->\n    <g transform=\"translate(291.341033 123.793583)scale(0.12 -0.12)\">\n     <use xlink:href=\"#DejaVuSans-72\"/>\n     <use x=\"75.195312\" xlink:href=\"#DejaVuSans-101\"/>\n     <use x=\"136.71875\" xlink:href=\"#DejaVuSans-97\"/>\n     <use x=\"197.998047\" xlink:href=\"#DejaVuSans-100\"/>\n     <use x=\"261.474609\" xlink:href=\"#DejaVuSans-32\"/>\n     <use x=\"293.261719\" xlink:href=\"#DejaVuSans-52\"/>\n    </g>\n   </g>\n  </g>\n  <g id=\"axes_9\">\n   <g id=\"patch_42\">\n    <path clip-path=\"url(#p176b7f6e02)\" d=\"M 366.250625 155.361622 \nL 366.250625 154.9157 \nL 366.250625 41.651544 \nL 366.250625 41.205622 \nL 371.958425 41.205622 \nL 371.958425 41.651544 \nL 371.958425 154.9157 \nL 371.958425 155.361622 \nz\n\" style=\"fill:#ffffff;stroke:#ffffff;stroke-linejoin:miter;stroke-width:0.01;\"/>\n   </g>\n   <image height=\"114\" id=\"image4285b12d74\" transform=\"scale(1 -1)translate(0 -114)\" width=\"6\" x=\"366\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAYAAAByCAYAAABwf6CfAAAABHNCSVQICAgIfAhkiAAAANRJREFUSInFlkEOwzAIBLcS/39qTz05gPsBptJalppj0O6wGEd57c97a3hCXdN7hbqhsEcnhTYpiLGZca/AAe0cWKikAsJxJKTIx7Ty4SpikBW3+9ccee08WIGMmznc8ziB01IfDBHvhz9EsNoXc/jtHswKc9iFpDtIigM4M+Bj6cP7wRWlrngZoFAJ7TZ99LFQqKCRFBZsODISp+szZidFJjFmgaLp1wBiKEqooHYPrEiBjFnwI2DaVgifb4cUC1eUAmJXcD0Uyw6IVqhY9nn4DFvxBekTC0g9bfR5AAAAAElFTkSuQmCC\" y=\"-41\"/>\n   <g id=\"matplotlib.axis_17\"/>\n   <g id=\"matplotlib.axis_18\">\n    <g id=\"ytick_17\">\n     <g id=\"line2d_33\">\n      <defs>\n       <path d=\"M 0 0 \nL 3.5 0 \n\" id=\"m0f0bcf8d7d\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m0f0bcf8d7d\" y=\"155.361622\"/>\n      </g>\n     </g>\n     <g id=\"text_27\">\n      <!-- 0.0 -->\n      <defs>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n      </defs>\n      <g transform=\"translate(378.958425 159.160841)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_18\">\n     <g id=\"line2d_34\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m0f0bcf8d7d\" y=\"115.897029\"/>\n      </g>\n     </g>\n     <g id=\"text_28\">\n      <!-- 0.2 -->\n      <g transform=\"translate(378.958425 119.696248)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_19\">\n     <g id=\"line2d_35\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"371.958425\" xlink:href=\"#m0f0bcf8d7d\" y=\"76.432436\"/>\n      </g>\n     </g>\n     <g id=\"text_29\">\n      <!-- 0.4 -->\n      <g transform=\"translate(378.958425 80.231654)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"patch_43\">\n    <path d=\"M 366.250625 155.361622 \nL 366.250625 154.9157 \nL 366.250625 41.651544 \nL 366.250625 41.205622 \nL 371.958425 41.205622 \nL 371.958425 41.651544 \nL 371.958425 154.9157 \nL 371.958425 155.361622 \nz\n\" style=\"fill:none;stroke:#000000;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p3087a38390\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"34.240625\" y=\"26.015401\"/>\n  </clipPath>\n  <clipPath id=\"p1209859591\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"115.757147\" y=\"26.015401\"/>\n  </clipPath>\n  <clipPath id=\"pf6164669cf\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"197.273668\" y=\"26.015401\"/>\n  </clipPath>\n  <clipPath id=\"p175ffdd866\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"278.79019\" y=\"26.015401\"/>\n  </clipPath>\n  <clipPath id=\"p599a40ff73\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"34.240625\" y=\"129.793583\"/>\n  </clipPath>\n  <clipPath id=\"p50453703ad\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"115.757147\" y=\"129.793583\"/>\n  </clipPath>\n  <clipPath id=\"p046858c8d8\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"197.273668\" y=\"129.793583\"/>\n  </clipPath>\n  <clipPath id=\"p911df8b425\">\n   <rect height=\"40.758261\" width=\"67.930435\" x=\"278.79019\" y=\"129.793583\"/>\n  </clipPath>\n  <clipPath id=\"p176b7f6e02\">\n   <rect height=\"114.156\" width=\"5.7078\" x=\"366.250625\" y=\"41.205622\"/>\n  </clipPath>\n </defs>\n</svg>\n",
+            "text/plain": [
+              "<Figure size 504x252 with 9 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "show_heatmaps(dec_inter_attention_weights, xlabel='Key positions',\n",
+        "                  ylabel='Query positions',\n",
+        "                  titles=['Head %d' % i\n",
+        "                          for i in range(1, 5)], figsize=(7, 3.5))"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "transformers_jax.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
## Description

Converted `transformer_torch.ipynb`to `transformer_jax.ipynb`.

### Colab link

https://colab.research.google.com/drive/1qSV90T4LsdW24EgON_EKvPeyLdCFRY_E?usp=sharing

### Issue 

https://github.com/probml/pyprobml/issues/686



## Checklist:

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

## Notes
Code from `multi_head_attention_jax` and `positional_encoding_jax` is used with a few error fixings and modifications. `multi_head_attention` in this code is now returning the attention weights. 
