### PR TITLE
Add `multi_gpu_training_jax.ipynb` for `multi_gpu_training_torch.ipynb`

### DIFF
--- a/notebooks-d2l/multi_gpu_training_jax.ipynb
+++ b/notebooks-d2l/multi_gpu_training_jax.ipynb
@@ -1,0 +1,611 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "multi_gpu_training_jax.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UeG2yP57tJBX"
+      },
+      "source": [
+        "#Train a CNN on multiple GPUs using data parallelism.\n",
+        "\n",
+        "Based on sec 12.5 of http://d2l.ai/chapter_computational-performance/multiple-gpus.html.\n",
+        "\n",
+        "Since writing JAX requires a completely different mindset from that of PyTorch, translating the notebook work-by-word would inevitably lead to JAX code with a PyTorch \"accent\". To avoid that, I created an idiomatic JAX/Flax implementation of multi-device training from scratch. It borrows some code from the official [Parallel Evaluation in JAX](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html) notebook (which trains a linear regression model), and follows roughly the same narration as [the original D2L notebook](https://github.com/probml/probml-notebooks/blob/main/notebooks-d2l/multi_gpu_training_torch.ipynb).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q flax"
+      ],
+      "metadata": {
+        "id": "mWzcqJYfTnHQ"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Preparation\n",
+        "\n",
+        "Not everyone can enjoy the luxury of a TPU runtime on CoLab, and the GPU runtime only provides one GPU instance, so we are going to stick with a humble CPU runtime to make the notebook more accessible. When JAX is running on CPU, we can emulate an arbitrary number of devices with an XLA flag. Of course, this is for illustration purposes only, and won't make your code run any faster."
+      ],
+      "metadata": {
+        "id": "lw3DOelgaH79"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=8'"
+      ],
+      "metadata": {
+        "id": "Ge96dkA3aJJZ"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9_2hHiscs-cH"
+      },
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "from IPython import display \n",
+        "\n",
+        "import jax\n",
+        "import jax.numpy as jnp                 # JAX NumPy\n",
+        "import flax\n",
+        "from flax import linen as nn            # The Linen API\n",
+        "from flax.training import train_state   # Useful dataclass to keep train state\n",
+        "import optax                            # Optimizers\n",
+        "import tensorflow_datasets as tfds      # TFDS for Fashion MNIST\n",
+        "\n",
+        "import os\n",
+        "import functools\n",
+        "from typing import Tuple"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now we have 8 devices"
+      ],
+      "metadata": {
+        "id": "0rtKqT0PirRM"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "jax.devices()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "fDIwkYaHit9A",
+        "outputId": "4abc9b9e-e21a-455b-ba52-e23e230460e3"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[CpuDevice(id=0),\n",
+              " CpuDevice(id=1),\n",
+              " CpuDevice(id=2),\n",
+              " CpuDevice(id=3),\n",
+              " CpuDevice(id=4),\n",
+              " CpuDevice(id=5),\n",
+              " CpuDevice(id=6),\n",
+              " CpuDevice(id=7)]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 4
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ngd9TmIVuAN6"
+      },
+      "source": [
+        "## Model\n",
+        "\n",
+        "We use the CNN from the [Flax README](https://github.com/google/flax#what-does-flax-look-like) as a demonstration. Training with multiple device does not require any change to the model, so you can replace it with your favourite network, as long as it outputs a 10-width logit for each input instance."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EgrwcqORtJdL"
+      },
+      "source": [
+        "class CNN(nn.Module):\n",
+        "    @nn.compact\n",
+        "    def __call__(self, x):\n",
+        "        x = nn.Conv(features=32, kernel_size=(3, 3))(x)\n",
+        "        x = nn.relu(x)\n",
+        "        x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))\n",
+        "        x = nn.Conv(features=64, kernel_size=(3, 3))(x)\n",
+        "        x = nn.relu(x)\n",
+        "        x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))\n",
+        "        x = x.reshape((x.shape[0], -1))  # flatten\n",
+        "        x = nn.Dense(features=256)(x)\n",
+        "        x = nn.relu(x)\n",
+        "        x = nn.Dense(features=10)(x)\n",
+        "        x = nn.log_softmax(x)\n",
+        "        return x"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Gp-2SIaUv_Hh"
+      },
+      "source": [
+        "## Data loading\n",
+        "\n",
+        "We load the Fashion MNIST dataset with TFDS."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ilYJZjkq6C9D",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "99e5e3a0-3e9d-4f4a-a51e-b29b159beca2"
+      },
+      "source": [
+        "def get_datasets(split):\n",
+        "    \"\"\"Load MNIST train/test dataset into memory.\"\"\"\n",
+        "    ds_builder = tfds.builder('fashion_mnist')\n",
+        "    ds_builder.download_and_prepare()\n",
+        "    ds = tfds.as_numpy(ds_builder.as_dataset(split=split, batch_size=-1))\n",
+        "    x = jnp.array(ds['image']/255.)\n",
+        "    y = jnp.array(ds['label'])\n",
+        "    return x, y\n",
+        "\n",
+        "train_x, train_y = get_datasets('train')"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.data.Dataset.get_single_element()`.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.data.Dataset.get_single_element()`.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note that TFDS uses the NHWC format, which mean \"channel\" dimension is the last axis. This is different from the NCHW format used by other data loaders, e.g. `torchvision.datasets.FashionMNIST`."
+      ],
+      "metadata": {
+        "id": "AXHKMIT3l9sn"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "assert train_x.shape == (60000, 28, 28, 1)\n",
+        "assert train_y.shape == (60000,)"
+      ],
+      "metadata": {
+        "id": "ZNKQTc7qk-1k"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We split the training set into mini-batches of 256 instances, so that each of the 8 devices will handle 32 instances within each batch. Note that the \"total batch size\" must be divisible by the number of devices. However, it is okay if the number of training instances cannot be evenly divided by the total batch size (256). While one can handle the leftover with a bit more work, we skip the incomplete batches for simplicity."
+      ],
+      "metadata": {
+        "id": "hSmaIDbwoVJT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "total_batch_size = 256\n",
+        "n_devices = jax.local_device_count()\n",
+        "local_batch_size = total_batch_size // n_devices\n",
+        "assert local_batch_size * n_devices == total_batch_size\n",
+        "\n",
+        "device_total = local_batch_size * n_devices\n",
+        "train_x = train_x[:len(train_x)//device_total*device_total]\n",
+        "train_y = train_y[:len(train_y)//device_total*device_total]\n",
+        "\n",
+        "train_x = train_x.reshape(-1, local_batch_size, 28, 28, 1)\n",
+        "train_y = train_y.reshape(-1, local_batch_size)"
+      ],
+      "metadata": {
+        "id": "SBiGVDjAqtZq"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JPF2qz7Xvn0p"
+      },
+      "source": [
+        "We are going to use `jax.pmap`, which requires us to manually distribute data across the devices. More specifically, we need to transform both the images and their labels to the shape `[batch_per_device, num_devices, batch_size, ...]`. That way, the leading dimension of each \"local batch\" will be equal to `num_devices`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0St4qm0RvhmV"
+      },
+      "source": [
+        "def split(arr):\n",
+        "  \"\"\"Splits the first axis of `arr` evenly across the number of devices.\"\"\"\n",
+        "  return arr.reshape(arr.shape[0] // n_devices, n_devices, *arr.shape[1:])\n",
+        "\n",
+        "train_x = split(train_x)\n",
+        "train_y = split(train_y)"
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To clarify, we have 8 devices, each of which will handle 234 local batches of 32 instances."
+      ],
+      "metadata": {
+        "id": "mv9sY-CardUL"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "assert train_x.shape == (234, n_devices, local_batch_size, 28, 28, 1)\n",
+        "assert train_y.shape == (234, n_devices, local_batch_size)"
+      ],
+      "metadata": {
+        "id": "MH6ZPkK8rV8Q"
+      },
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "prMQdt8MO8nf"
+      },
+      "source": [
+        "## Parallel training\n",
+        "\n",
+        "Parallel training with JAX is as simple as decorating the `update` function with `jax.pmap` and synchronising gradients across devices with `jax.lax.pmean`. See the comments for more details."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def create_train_state(rng, learning_rate):\n",
+        "    \"\"\"Creates initial `TrainState`.\"\"\"\n",
+        "    cnn = CNN()\n",
+        "    params = cnn.init(rng, jnp.ones((1, 28, 28, 1)))['params']\n",
+        "    tx = optax.adam(learning_rate)\n",
+        "    state = train_state.TrainState.create(\n",
+        "        apply_fn=cnn.apply, params=params, tx=tx)\n",
+        "    return state"
+      ],
+      "metadata": {
+        "id": "ki9NdoZiuV1Z"
+      },
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def loss_fn(params, xs, ys):\n",
+        "    logits = CNN().apply({'params': params}, xs)\n",
+        "    one_hot = jax.nn.one_hot(ys, num_classes=10)\n",
+        "    loss = jnp.sum(optax.softmax_cross_entropy(logits=logits, labels=one_hot))\n",
+        "    return loss"
+      ],
+      "metadata": {
+        "id": "TdsnJVL9xa_n"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@functools.partial(jax.pmap, axis_name='batch')\n",
+        "def update(state: train_state.TrainState, xs: jnp.ndarray, ys: jnp.ndarray) -> Tuple[train_state.TrainState, jnp.ndarray]:\n",
+        "    \"\"\"Performs one update step on params using the given data.\"\"\"\n",
+        "    # Compute the gradients on the given minibatch (individually on each device).\n",
+        "    grad_fn = jax.value_and_grad(loss_fn)\n",
+        "    loss, grads = grad_fn(state.params, xs, ys)\n",
+        "\n",
+        "    # Combine the gradient across all devices (by taking their mean).\n",
+        "    grads = jax.lax.pmean(grads, axis_name='batch')\n",
+        "\n",
+        "    # Also combine the loss. Unnecessary for the update, but useful for logging.\n",
+        "    loss = jax.lax.pmean(loss, axis_name='batch')\n",
+        "\n",
+        "    # Each device performs its own update, but since we start with the same params\n",
+        "    # and synchronise gradients, the params stay in sync.\n",
+        "    state = state.apply_gradients(grads=grads)\n",
+        "\n",
+        "    return state, loss"
+      ],
+      "metadata": {
+        "id": "JCAsxBFGupLs"
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We are *summing* the gradient within a batch, and *averaging* it across devices. You need to keep this fact in mind when choosing the learning rate."
+      ],
+      "metadata": {
+        "id": "jyELnYufcpaP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Initialise parameters\n",
+        "rng = jax.random.PRNGKey(42)\n",
+        "rng, init_rng = jax.random.split(rng)\n",
+        "learning_rate = 0.2\n",
+        "state = create_train_state(init_rng, learning_rate)\n",
+        "del init_rng  # Must not be used anymore."
+      ],
+      "metadata": {
+        "id": "gC9S-jFKywdq"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jG99sNIE9gAd"
+      },
+      "source": [
+        "# Learning curve\n",
+        "\n",
+        "The traing loop mostly stays the same. Note that we need to replicate the parameters across all devices when creating the train state, and remove that extra leading dimension when the training is done."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_epochs = 5\n",
+        "\n",
+        "# Replicate across devices.\n",
+        "replicated_states = flax.jax_utils.replicate(state)\n",
+        "\n",
+        "# Actual training loop.\n",
+        "losses = []\n",
+        "for i in range(num_epochs):\n",
+        "    loss = 0\n",
+        "    for batch_x, batch_y in zip(train_x, train_y):\n",
+        "        # This is where the params and data gets communicated to devices:\n",
+        "        replicated_states, batch_loss = update(replicated_states, batch_x, batch_y)\n",
+        "\n",
+        "        # Note that loss is actually an array of shape [num_devices], with identical\n",
+        "        # entries, because each device returns its copy of the loss, so we need\n",
+        "        # to unreplicate it.\n",
+        "        loss += flax.jax_utils.unreplicate(batch_loss)\n",
+        "\n",
+        "    losses.append(loss)\n",
+        "    print(f\"Step {i:3d}, loss: {loss:.3f}\")\n",
+        "\n",
+        "state = flax.jax_utils.unreplicate(replicated_states)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "0kSGJgigeIZj",
+        "outputId": "503685a3-9d18-41b3-dc55-25750870638d"
+      },
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Step   0, loss: 297723.250\n",
+            "Step   1, loss: 4534.677\n",
+            "Step   2, loss: 3913.025\n",
+            "Step   3, loss: 3867.223\n",
+            "Step   4, loss: 3580.433\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We ignore the first item in `losses`, which represents the initial loss of the randomly-initalized parameter."
+      ],
+      "metadata": {
+        "id": "C-NDm-rKhvIW"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.plot(range(1, num_epochs), losses[1:])\n",
+        "plt.xlabel(\"Epoch\")\n",
+        "plt.ylabel(\"Training Loss\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 297
+        },
+        "id": "BcM1PW9sVorp",
+        "outputId": "a1f324b0-1d23-4a4f-e215-478461d91803"
+      },
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Text(0, 0.5, 'Training Loss')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 16
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEGCAYAAACUzrmNAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXwV5dn/8c+VlUCAsAQRAoKyCbImUtwBNyoqLlRBcXu0WtyoaLU+j7+6tNbWuiLuVougonVF1CoqiAuKCauAYkQQUCCAAcISCFy/PzLYiAnnADmZnOT7fr3mlZn7zDnnOwzkYrb7NndHRERkdxLCDiAiItWfioWIiESkYiEiIhGpWIiISEQqFiIiElFS2AFioWnTpt6mTZuwY4iIxJW8vLzV7p5Z3ms1sli0adOG3NzcsGOIiMQVM1tS0Ws6DSUiIhGpWIiISEQqFiIiEpGKhYiIRKRiISIiEalYiIhIRCoWIiISkYpFGRu2bOOWCfNYt3lb2FFERKoVFYsyvl5VxLhPl3DtC7PYsUPjfIiI7KRiUUav1o24aeDBvLtgFQ9Ozg87johItaFisYsLDm/D6T1bcs+7C5n81aqw44iIVAsqFrswM/56elc6NW/AiOdm8t2aTWFHEhEJnYpFOdJSEnl0WDZmxmXj8ti8dXvYkUREQqViUYHWTepy35AefLliPTe+PAd3XfAWkdpLxWI3+nVsxsjjOvDqrO8Z88nisOOIiIRGxSKCK/q147iDm/GXNxbw+eK1YccREQmFikUECQnGPWf3oFXjulz+zAxWrt8SdiQRkSqnYhGFBnWSeWRYNhuLS7j8mRlsLdkRdiQRkSqlYhGljs3rc+fgbuQt+ZHb35gfdhwRkSpVI8fgjpWTu7Vg9tJCHv/wW7plZXBmdlbYkUREqoSOLPbQDQM60efAxvzvK3P5Yvm6sOOIiFQJFYs9lJSYwOhzetG4Xgq/G5dH4aatYUcSEYk5FYu90DQ9lYeHZbNqfTFXj5/FdvVQKyI1nIrFXurRKoNbB3Vh6sIC7p20MOw4IiIxpWKxD4b2bs2QQ1sxenI+78xbEXYcEZGYUbHYR7ec2oVuWQ0Z+cJsvikoCjuOiEhMqFjsozrJiTw8LJuUpAR+NzaPouKSsCOJiFQ6FYtK0DIjjdFDe/JNQRHXvzhbPdSKSI2jYlFJDm/XlBsGdOLNuSt4/MNFYccREalUKhaV6NKjD+Skrs3521tf8kn+6rDjiIhUGhWLSmRm3Dm4OwdlpnPlczNZXrg57EgiIpVCxaKSpacm8ch52Wwt2cHl4/LYsk1DsopI/FOxiIGDMtO5+6zuzF62jlsmzAs7jojIPot5sTCzRDObaWYTd2kfZWZFZZZTzex5M8s3s8/MrE2Z124M2r8ysxNjnbkynNilOVf2a8f4z5fy3PTvwo4jIrJPquLIYgSwoGyDmeUAjXZZ72LgR3dvB9wL/D1YtzMwBOgCDAAeMrPEWIeuDNcc34GjO2Ry82vzmLW0MOw4IiJ7LabFwsyygIHAE2XaEoF/ANfvsvogYEww/yJwrJlZ0D7e3Yvd/VsgH+gdy9yVJTHBuP/sHjRrkMrwcXmsLioOO5KIyF6J9ZHFfZQWhbLjkF4JTHD3H3ZZtyWwFMDdS4B1QJOy7YFlQdvPmNmlZpZrZrkFBQWVtwX7qFG9FB4Zls3ajVu58tkZlGzXkKwiEn9iVizM7GRglbvnlWlrAfwGeKCyv8/dH3P3HHfPyczMrOyP3yeHtGzIHWd05dNFa7nz7a/CjiMissdiOazqEcCpZnYSUAdoAMwDioH80jNM1DWz/OA6xXKgFbDMzJKAhsCaMu07ZQVtceWMXlnMWlrIY1MX0S2rISd3axF2JBGRqMXsyMLdb3T3LHdvQ+kF6vfdvZG7N3f3NkH7pqBQAEwALgjmBwfre9A+JLhbqi3QHpgeq9yxdNPAzmQf0IjrX5zDwpUbwo4jIhK16vScxT+BJmaWD4wE/gjg7vOAF4D5wH+AK9w9Lp90S0lK4KFze1EvNYnLxuaxfsu2sCOJiETFamIPqTk5OZ6bmxt2jAp9vngtQx/7lL4dm/HYedkkJFjYkUREMLM8d88p77XqdGRRaxzapjE3DTyYdxes5MHJ+WHHERGJSMUiJBcc3obTe7bknncXMuWrVWHHERHZLRWLkJgZfz29K52aN2DE+Fl8t2ZT2JFERCqkYhGitJREHh2Wjbtz2bg8Nm+Ny+v2IlILqFiErHWTutw/tCdfrljP/74yV0Oyiki1pGJRDfTr2IxrjuvAKzOX8/S0JWHHERH5BRWLauLKfu047uBm/HnifD5fvDbsOCIiP6NiUU0kJBj3nN2DVo3rcvkzM1i1fkvYkUREfqJiUY00qJPMI8Oy2VhcwuXPzGBriXqoFZHqQcWimunYvD53Du5G7pIfuf2N+WHHEREBVCyqpZO7teC3R7VlzLQlvDxjWdhxRERULKqrGwZ0os+Bjbnx5bl8sXxd2HFEpJZTsaimkhITGH1OLxrXS+F34/Io3LQ17EgiUoupWFRjTdNTeejcXqxaX8zV42exfYce2BORcKhYVHM9Wzfi1kFdmLqwgPveXRh2HBGppVQs4sDQ3q05O6cVD7yfzzvzVoQdR0RqIRWLOHHroC50y2rItS/MZlFBUdhxRKSWUbGIE3WSE3l4WDbJSQlcNjaPjcUlYUcSkVpExSKOtMxIY/TQnnxTUMT1L85RD7UiUmVULOLM4e2acsOATrwx9wce/3BR2HFEpJZQsYhDlx59ICd1bc7f3vqST/JXhx1HRGoBFYs4ZGbcObg7B2amc+VzM/m+cHPYkUSkhlOxiFPpqUk8el42W0t2MHxcHlu2aUhWEYkdFYs4dlBmOnef1Z3Zy9Zxy4R5YccRkRpMxSLOndilOVf2a8f4z5fy3PTvwo4jIjWUikUNcM3xHTi6QyY3vzaPWUsLw44jIjWQikUNkJhg3H92D5o1SGX4uDxWFxWHHUlEahgVixqiUb0UHhmWzdqNW7nq2ZmUbNeQrCJSeVQsapBDWjbkr6d3ZdqiNdz59ldhxxGRGiQp7ABSuc7MzmL2skIem7qIblkNOblbi7AjiUgNoCOLGuimgZ3JPqAR1784h4UrN4QdR0RqABWLGiglKYGHzu1FvdQkLhubx/ot28KOJCJxLubFwswSzWymmU0Mlp8xs6/M7Asze9LMkoN2M7NRZpZvZnPMrFeZz7jAzL4Opgtinbkm2K9BHR48pxdL125i5POz2aEhWUVkH1TFkcUIYEGZ5WeATkBXIA24JGj/NdA+mC4FHgYws8bAzcCvgN7AzWbWqApyx73ebRtz08CDeXfBSh6akh92HBGJY3tULMwswcwa7MH6WcBA4Imdbe7+pgeA6UBW8NIg4OngpU+BDDPbHzgRmOTua939R2ASMGBPctdmFxzehtN6tODuSQuZ8tWqsOOISJyKWCzM7Fkza2Bm9YAvgPlm9ocoP/8+4HrgFzf9B6efzgP+EzS1BJaWWWVZ0FZRu0TBzLjjjG50at6AEeNn8d2aTWFHEpE4FM2RRWd3Xw+cBrwFtKX0l/xumdnJwCp3z6tglYeAqe7+YbRhI3zfpWaWa2a5BQUFlfGRNUZaSiKPDsvG3fnduDw2b1UPtSKyZ6IpFsnBUcBpwAR33wZEc7X0COBUM1sMjAf6m9k4ADO7GcgERpZZfznQqsxyVtBWUfvPuPtj7p7j7jmZmZlRxKtdWjepy/1De7JgxXr+75W5GpJVRPZINMXiUWAxUA+YamYHAOsjvcndb3T3LHdvAwwB3nf3YWZ2CaXXIYa6e9nTUxOA84O7ovoA69z9B+Bt4AQzaxRc2D4haJM91K9jM645rgMvz1zO09OWhB1HROJIxCe43X0UMKpM0xIz67cP3/kIsASYZmYAL7v7bcCbwElAPrAJuCj4/rVm9mfg8+D9t7n72n34/lrtyn7tmLOskD9PnE+XFg3IadM47EgiEgcs0ukIMxsBPAVsoPSupp7AH939ndjH2zs5OTmem5sbdoxqa/2WbQwa/TFFxSW8cdWRNGtQJ+xIIlINmFmeu+eU91o0p6H+J7jAfQLQiNKL23+rxHxSxRrUSeaRYdkUbSnh8mdmsLVEPdSKyO5FUyws+HkSMNbd55VpkzjVsXl97hzcjdwlP3L7G/PDjiMi1Vw0xSLPzN6htFi8bWb1Kee5CYk/p3RvwW+PasuYaUt4ecaysOOISDUWTRflFwM9gEXuvsnMmhBcfJb4d8OATsxdvo4bX55Lh/3qc0jLhmFHEpFqKOKRRXB7axZwk5ndBRzu7nNinkyqRFJiAqPP6UWjuikMfyaPwk1bw44kItVQNN19/I3SzgDnB9PVZvbXWAeTqtM0PZWHh/Vi5bpirh4/i+3qoVZEdhHNNYuTgOPd/Ul3f5LSTvxOjm0sqWo9WzfillO7MHVhAfe9uzDsOCJSzUTb62xGmXmd1K6hhvZuxdk5rXjg/Xzembci7DgiUo1EUyzuAGaa2b/MbAyQB9we21gSBjPj1kFd6JbVkGtfmM2igqKwI4lINRHNBe7ngD7Ay8BLwGGU9hUlNVCd5EQeHpZNclICl43NY2NxSdiRRKQaiOo0lLv/4O4TgmkF8O8Y55IQtcxI44GhPfmmoIjrX5yjHmpFZK+HVdUT3DXcEe2acsOATrwx9wee+PDbsOOISMj2tljov5q1wKVHH8hJXZtzx1sL+CR/ddhxRCREFT7BbWavU35RMKBJzBJJtWFm3Dm4OwtXFnHlczOZeNWRtMhICzuWiISgwi7KzeyY3b3R3T+ISaJKoC7KK9c3BUUMGv0xB2XW4/nLDqNOcmLYkUQkBnbXRXmFRxbVuRhI1TooM527z+rOZWPzuPX1edxxRrewI4lIFdvbaxZSy5zYpTlX9DuI56YvZfz078KOIyJVTMVCojby+I4c1b4pf3ptHrOWFoYdR0SqkIqFRC0xwRg1pCfNGqQyfFweq4uKw44kIlUkml5nXzezCbtMY81shJlp8OZaplG9FB4Zls3ajVu56tmZlGzXOFgitUE0RxaLgCLg8WBaD2wAOgTLUssc0rIht5/elWmL1vCPt78KO46IVIFoRso73N0PLbP8upl97u6Hmtm8WAWT6m1wdhZzlhXy6NRFdMvKYGC3/cOOJCIxFM2RRbqZtd65EMynB4saVq0Wu2lgZ7IPaMQfXpzNwpUbwo4jIjEUTbG4FvjIzCab2RTgQ+A6M6sHjIllOKneUpISeOjcXtRNSeKysXms37It7EgiEiPRdFH+JtAe+D2lw6t2dPc33H2ju98X64BSve3XoA4PnduLpWs3ce0Ls9mhIVlFaqRob53NBroA3YGzzOz82EWSeNO7bWNuGngwk+av5KEp+WHHEZEYiHiB28zGAgcBs4DtQbMDT8cwl8SZCw5vw6ylhdw9aSGHtGxI347Nwo4kIpUomruhcoDOrhFwZDfMjDvO6MZXK4sYMX4WE686klaN64YdS0QqSTSnob4Amsc6iMS/tJREHh2Wjbtz2dg8Nm/dHvlNIhIXoikWTYH5ZvZ22ae4Yx1M4lPrJnW5f2hPFqxYz/+9MldDsorUENGchrol1iGkZunXsRnXHNeBeyYtpEfrDM4/rE3YkURkH0UsFhrXQvbGlf3aMWdZIbe9Pp/O+zcgp03jsCOJyD6o8DSUmX0U/NxgZuvLTBvMbH3VRZR4lJBg3H1WD7IapTH8mRmsWr8l7Egisg8qLBbufmTws767Nygz1Xf3BtF+gZklmtlMM5sYLLc1s8/MLN/MnjezlKA9NVjOD15vU+YzbgzavzKzE/d2Y6VqNUxL5tHzcijaUsLlz8xga4l6qBWJV1E9lBf8wm9hZq13TnvwHSOABWWW/w7c6+7tgB+Bi4P2i4Efg/Z7g/Uws87AEEofChwAPGRmGgQ6TnRsXp87B3cjd8mP/PXNBZHfICLVUjTjWVwFrAQmAW8E08RoPtzMsoCBwBPBsgH9gReDVcYApwXzg/hvX1MvAscG6w8Cxrt7sbt/C+QDvaP5fqkeTunegkuObMu/PlnMKzOXhR1HRPZCNHdD7ewPas1efP59wPVA/WC5CVDo7iXB8jKgZTDfElgK4O4lZrYuWL8l8GmZzyz7np+Y2aXApQCtW+/JgY9UhT/+uhNffL+OG1+eS4f96tOlRcOwI4nIHojmNNRSYN2efrCZnQyscve8PU61F9z9MXfPcfeczMzMqvhK2QNJiQmMPqcXGWkp/G5cHoWb1Lu9SDyJdqS8KcFF5pE7pyjedwRwqpktBsZTevrpfiDDzHYe0WQBy4P55UArgOD1hsCasu3lvEfiSNP0VB4e1ouV64oZMX4W29VDrUjciKZYfEfp9YoUSk8n7Zx2y91vdPcsd29D6QXq9939XGAyMDhY7QLgtWB+QrBM8Pr7QX9UE4Ahwd1SbSntLn16FLmlGurZuhG3nNqFDxYWcP+7C8OOIyJRiuahvFsr+TtvAMab2V+AmcA/g/Z/AmPNLB9YS2mBwd3nmdkLwHygBLjC3dXpUBwb2rsVs5cWMur9fLpmZXB85/3CjiQiEVhFffeY2X3u/nsze53SLsl/xt1PjXW4vZWTk+O5ublhx5Dd2LJtO2c9Oo1vCzby2pVHcGBmeuQ3iUhMmVmeu+eU99rujizGBj/vqvxIUtvVSU7k4WHZnPLAR1w2No9XrziCeqnR3JwnImHY3RPcecHPD8qbqi6i1FQtM9J4YGhPviko4vqX5qiHWpFqLJqH8tqb2YtmNt/MFu2cqiKc1HxHtGvKDQM68cacH3jiw2/DjiMiFYjmbqingIcpvbjcj9LhVMfFMpTULpcefSAndW3OHW8t4JNvVocdR0TKEU2xSHP39yi9GL7E3W+htAsPkUphZtw5uDsHZqZz1bMz+b5wc9iRRGQX0RSLYjNLAL42syvN7HRAt65IpUpPTeLR87IpLtnB8HF5bNmmu6NFqpNoisUIoC5wNZANDOO/D8+JVJqDMtO5+6zuzF62jltfnxd2HBEpY7fFIugK/Gx3L3L3Ze5+kbuf6e6f7u59InvrxC7NuaLfQTw3fSnjp38XdhwRCexupLyk4EnpI6swjwgjj+/IUe2b8qfX5jFraWHYcUSE3R9Z7Ox/aaaZTTCz88zsjJ1TVYST2ikxwRg1pCfNGqRy+bg81hQVhx1JpNaL5ppFHUp7f+0PnAycEvwUiZlG9VJ4ZFg2azZu5arnZlKyXUOyioRpd/0rNAu6Iv+C0r6hrMxretRWYu6Qlg25/fSuXPfv2Qx9/FPa71efzPRUMuuXmYLlOskaaVcklnZXLBIpvUXWynlNxUKqxODsLFau38Lrs7/nnXkrWLNxK+X1ClK/TtLPikfTcopKs/qpNK6XQlJiVEPPi0gZu+t1doa796riPJVCvc7WXCXbd7B241ZWbSimoKiYgg1lpmB5dbC8objkF+83gyb1UsotJjvnmwXFpmFaMqXDwIvUDnvb66z+lUi1k5SYQLMGdWjWoE7Edbds2/6zIrJrUSnYUMyigo0UFBWzteSX10RSEhNomp5SYVEpXa5DZv1U0lJ0Gkxqtt0Vi2OrLIVIDNRJTqRV47q0alx3t+u5O+u3lJRbTFYH898XbmH2snWsKSqmvNFg01OTflFMflZogqLSJD2FZJ0GkzhUYbFw97VVGUQkLGZGw7RkGqYl067Z7nuy2b7DWbtx626OWLbw5Yr1fPh1Meu3/PI0GEDjeikVXqj/b6FJJSMtmYQEHeBL9aDRZkT2QGKC/fQLPZIt27b/dGSyumhrmaKy5af53CUbWbW+mOJyToMlJdjPr63sWmDKtGngKIk1/Q0TiZE6yYlkNapLVqPIp8GKiss/DbZzedWGLcz7fh2ri7ayvZzzYHVTEss5DfbLItM0PZWUJJ0Gkz2nYiESMjOjfp1k6tdJjjgW+Y4dzo+btv6yoJQpMvmripi2aA2Fm7aV+xkZdZN/fpRSwRFLo7opOg0mP1GxEIkjCQlGk/RUmqSn0qn57tctLtnOmjKnv3aeEitbaGYtLWTV+mI2l9MlfGKC0aReSoVFpWVGGj1aZej24lpCxUKkhkpNSqRFRhotMtIirrtx52mw3RyxfPnDBlYXFVNS5jTYr9o25pZTu3Dw/g1iuSlSDahYiAj1UpOol5pEm6b1drvejh3Ous3bKCgq5tNFa7h30kIGjvqQYX0OYOTxHciom1JFiaWqqViISNQSEoxG9VJoVC+FDvvV59TuLbh30kLGfrqECbO/57oTOjK0d2sSda2jxtFtESKy1zLqpnDroEN4c8RRdGpen5te/YKTH/iIzxatCTuaVDIVCxHZZ52aN+C53/bhoXN7sX7zNs5+7FOuem4m3xduDjuaVBIVCxGpFGbGSV33592RxzDi2Pa8M28Fx979AaPf/5ot5dxtJfFFxUJEKlVaSiLXHN+Bd0ceQ9+Omdz1zkKOv/cD3pm3gop6uZbqT8VCRGKiVeO6PDwsm2cu+RVpyYlcOjaP85+cTv6qDWFHk72gYiEiMXVEu6a8cfVR3HxKZ2YtLWTAfR/y54nzWb+l/CfMpXpSsRCRmEtOTOCiI9oy5bq+/CYniyc//pb+d03hhc+XsqO8Pt+l2lGxEJEq0yQ9lTvO6MaEK46kdeO6XP/SHE5/6GNmfPdj2NEkgpgVCzOrY2bTzWy2mc0zs1uD9mPNbIaZzTKzj8ysXdCeambPm1m+mX1mZm3KfNaNQftXZnZirDKLSNXomtWQl4Yfzn1n9+CHdVs446FPuPaF2azasCXsaFKBWB5ZFAP93b070AMYYGZ9gIeBc929B/AscFOw/sXAj+7eDrgX+DuAmXUGhgBdgAHAQ2amMSxF4pyZcVrPlrx/XV+G9z2ICbOX0/+uD3hs6jflDnMr4YpZsfBSRcFicjB5MO3sdawh8H0wPwgYE8y/CBxrpd1ZDgLGu3uxu38L5AO9Y5VbRKpWemoSNwzoxDvXHMOv2jbmr29+yYD7pjLlq1VhR5MyYnrNwswSzWwWsAqY5O6fAZcAb5rZMuA84G/B6i2BpQDuXgKsA5qUbQ8sC9p2/a5LzSzXzHILCgpitUkiEiNtm9bjnxceylMXHooDFz71OZeM+ZzFqzeGHU2IcbFw9+3B6aYsoLeZHQJcA5zk7lnAU8A9lfRdj7l7jrvnZGZmVsZHikgI+nVqxtu/P5obf92Jad+s4YR7p/L3/3zJxuLyxzSXqlEld0O5eyEwGfg10D04wgB4Hjg8mF8OtAIwsyRKT1GtKdseyAraRKSGSklK4LJjDmLydX05ufv+PDzlG/rfPYVXZy7XU+AhieXdUJlmlhHMpwHHAwuAhmbWIVhtZxvABOCCYH4w8L6X/q2YAAwJ7pZqC7QHpscqt4hUH80a1OGes3rw0vDDaVa/Dr9/fha/eWQaXyxfF3a0WieW41nsD4wJ7lxKAF5w94lm9lvgJTPbAfwI/E+w/j+BsWaWD6yl9A4o3H2emb0AzAdKgCvcXb2SidQi2Qc04rUrjuDFvGX8/T9fcsrojxhyaGuuO6EDTdJTw45XK1hNPKTLycnx3NzcsGOISAys27yNUe99zZhPFlM3JZGRx3dgWJ8DSErUM8b7yszy3D2nvNf0pysicaVhWjL/7+TOvDXiKLplZXDL6/MZOOojPslfHXa0Gk3FQkTiUvv96jP24t48el42G7eWcM4TnzF8XB5L124KO1qNpGIhInHLzDixS3PeHXkM1x7fgclfreK4ez7g3kkL2bxVlzYrk4qFiMS9OsmJXHVse96/ti/Hd96P+9/7muPu+YA35/6gW20riYqFiNQYLTLSGH1OL8Zf2of6dZK4/JkZnPP4Z3y1QgMu7SsVCxGpcfoc2ISJVx3Jn087hAUr1nPSqA+5ZcI81m3SgEt7S8VCRGqkpMQEzutzAJOv7cs5vVvz9LTF9L1rMs9+9h3bNeDSHlOxEJEarVG9FP582iFMvOoo2u9Xn/99ZS6njv6I3MVrw44WV1QsRKRW6NyiAc9f2ocHhvZk7catDH5kGiPGz2TFOg24FA0VCxGpNcyMU7q34L1rj+Gq/u1464sV9L97Cg9Ozqe4RLfa7o6KhYjUOnVTkrj2hI68N/IYjmrflH+8/RUn3DuVd+ev1K22FVCxEJFaq1Xjujx6Xg5jL+5NcmIClzydy4VPfc43BUWR31zLqFiISK13VPtM3hpxFP/v5M7MWPIjJ947lb++uYANW3Sr7U4qFiIiQHJiAhcf2ZbJf+jLmb2yePzDRfS76wNezFvGDt1qq2IhIlJW0/RU/j64G69efgStGqdx3b9nc8bDnzB7aWHY0UKlYiEiUo7urTJ46XeHc/dvurO8cDODHvyYP/x7NgUbisOOFgoVCxGRCiQkGGdmZzH5ur5cdsyBvDprOf3vmsITHy5i2/YdYcerUioWIiIRpKcmceOvD+bt3x9NdptG/OWNBQy4bypTFxaEHa3KqFiIiETpwMx0/nVRb568MIftO5zzn5zOb5/O5bs1NX/AJRULEZE91L/Tfrx9zdHcMKATH+ev5rh7P+Cut79i09aSsKPFjIqFiMheSE1KZHjfg5h8XV8Gdt2f0ZPz6X/XB0yY/X2NfApcxUJEZB/s16AO957dg5eGH0bT+ilc/dxMzn70U+Z9vy7saJVKxUJEpBJkH9CY1644kr+d0ZX8giJOeeAjbnp1Lj9u3Bp2tEqhYiEiUkkSE4whvVsz+dq+XHB4G56bvpS+d03h6WmLKYnzW21VLEREKlnDusncfEoX3hpxFF1aNOBPr83j5Ac+Yto3a8KOttdULEREYqTDfvV55pJf8ciwXmzYUsLQxz/limdnsLxwc9jR9piKhYhIDJkZAw7Zn/euPYZrjuvAewtWcuzdUxj13tds2RY/Ay6pWIiIVIE6yYmMOK49713bl2MP3o97Ji3kuHs+4D9frIiLW21VLEREqlDLjDQePKcXz/22D+mpSfxuXB7n/XM6X6/cEHa03VKxEBEJwWEHNWHiVUdy26AuzF2+jgH3f8htr89n3ebqOeCSioWISEiSEhM4/7A2TL6uL0MObcVTn3xL/7umMH76d2yvZgMuqViIiGr9kzwAAAh6SURBVISscb0Ubj+9K69feSQHZtbjjy/P5bQHPyZvydqwo/1ExUJEpJo4pGVDXrjsMO4f0oOCDcWc+fA0Rj4/i5Xrt4QdLXbFwszqmNl0M5ttZvPM7Nag3czsdjNbaGYLzOzqMu2jzCzfzOaYWa8yn3WBmX0dTBfEKrOISNjMjEE9WvLetcdwZb92TJzzA/3vmsIjH3xDcUl4t9parG7ZMjMD6rl7kZklAx8BI4CDgX7Ahe6+w8yaufsqMzsJuAo4CfgVcL+7/8rMGgO5QA7gQB6Q7e4/VvTdOTk5npubG5PtEhGpSkvWbOQvbyxg0vyVtG1ajz+d3Jl+nZrF5LvMLM/dc8p7LWZHFl6qKFhMDiYHhgO3ufuOYL1VwTqDgKeD930KZJjZ/sCJwCR3XxsUiEnAgFjlFhGpTg5oUo/Hz89hzP/0xgwu+tfnXPTUdBYVFEV+cyWK6TULM0s0s1nAKkp/4X8GHAScbWa5ZvaWmbUPVm8JLC3z9mVBW0Xtu37XpcFn5hYU1J6hDkWkdjimQyb/GXE0Nw08mM8X/8iJ903ljrcWUFRcNQMuxbRYuPt2d+8BZAG9zewQIBXYEhzqPA48WUnf9Zi757h7TmZmZmV8pIhItZKSlMAlRx3I+9cdw2k9WvLoB4vod9cUXp6xjB0xvtW2Su6GcvdCYDKlp4+WAS8HL70CdAvmlwOtyrwtK2irqF1EpFZqVr8O//hNd1694ghaZKQx8oXZDH7kE+YsK4zZd8bybqhMM8sI5tOA44EvgVcpvcANcAywMJifAJwf3BXVB1jn7j8AbwMnmFkjM2sEnBC0iYjUaj1aZfDK8MP5x+BufLd2M4Me/Ji/TJwfk+9KismnltofGGNmiZQWpRfcfaKZfQQ8Y2bXAEXAJcH6b1J6J1Q+sAm4CMDd15rZn4HPg/Vuc/fq86SKiEiIEhKM3+S0YsAhzXng/XyyGqXF5HtidutsmHTrrIjIngvl1lkREak5VCxERCQiFQsREYlIxUJERCJSsRARkYhULEREJCIVCxERiUjFQkREIqqRD+WZWQGwZB8+oimwupLihKmmbAdoW6qjmrIdoG3Z6QB3L7cn1hpZLPaVmeVW9BRjPKkp2wHaluqopmwHaFuiodNQIiISkYqFiIhEpGJRvsfCDlBJasp2gLalOqop2wHaloh0zUJERCLSkYWIiESkYiEiIhHV2mJhZk+a2Soz+6KC183MRplZvpnNMbNeVZ0xGlFsR18zW2dms4LpT1WdMVpm1srMJpvZfDObZ2Yjylmn2u+XKLcjLvaLmdUxs+lmNjvYllvLWSfVzJ4P9slnZtam6pNGFuW2XGhmBWX2yyXlfVZ1YGaJZjbTzCaW81rl7xN3r5UTcDTQC/iigtdPAt4CDOgDfBZ25r3cjr7AxLBzRrkt+wO9gvn6lI7P3jne9kuU2xEX+yX4c04P5pOBz4A+u6xzOfBIMD8EeD7s3PuwLRcCo8POGuX2jASeLe/vUSz2Sa09snD3qcDuxvIeBDztpT4FMsxs/6pJF70otiNuuPsP7j4jmN8ALABa7rJatd8vUW5HXAj+nIuCxeRg2vWumEHAmGD+ReBYM7Mqihi1KLclLphZFjAQeKKCVSp9n9TaYhGFlsDSMsvLiNN/8MBhwaH3W2bWJeww0QgOm3tS+r+/suJqv+xmOyBO9ktwumMWsAqY5O4V7hN3LwHWAU2qNmV0otgWgDODU5wvmlmrKo4YrfuA64EdFbxe6ftExaLmm0Fpfy/dgQeAV0POE5GZpQMvAb939/Vh59lbEbYjbvaLu2939x5AFtDbzA4JO9PeimJbXgfauHs3YBL//d95tWFmJwOr3D2vKr9XxaJiy4Gy/6vICtriiruv33no7e5vAslm1jTkWBUys2RKf8E+4+4vl7NKXOyXSNsRb/sFwN0LgcnAgF1e+mmfmFkS0BBYU7Xp9kxF2+Lua9y9OFh8Asiu6mxROAI41cwWA+OB/mY2bpd1Kn2fqFhUbAJwfnD3TR9gnbv/EHaoPWVmzXeeqzSz3pTu82r5DznI+U9ggbvfU8Fq1X6/RLMd8bJfzCzTzDKC+TTgeODLXVabAFwQzA8G3vfgymp1Es227HL961RKrzdVK+5+o7tnuXsbSi9ev+/uw3ZZrdL3SdK+vDmemdlzlN6R0tTMlgE3U3rBC3d/BHiT0jtv8oFNwEXhJN29KLZjMDDczEqAzcCQ6vgPOXAEcB4wNzivDPC/QGuIq/0SzXbEy37ZHxhjZomUFrQX3H2imd0G5Lr7BEoL41gzy6f0Zosh4cXdrWi25WozOxUooXRbLgwt7R6K9T5Rdx8iIhKRTkOJiEhEKhYiIhKRioWIiESkYiEiIhGpWIiISEQqFiJ7ycy2l+mddJaZ/bESP7uNVdCTsEgYau1zFiKVYHPQdYRIjacjC5FKZmaLzexOM5sbjJ/QLmhvY2bvB53UvWdmrYP2/czslaBTwdlmdnjwUYlm9ngw9sI7wVPHIqFQsRDZe2m7nIY6u8xr69y9KzCa0h5CobTDwDFBJ3XPAKOC9lHAB0Gngr2AeUF7e+BBd+8CFAJnxnh7RCqkJ7hF9pKZFbl7ejnti4H+7r4o6FBwhbs3MbPVwP7uvi1o/8Hdm5pZAZBVpgO7nV2bT3L39sHyDUCyu/8l9lsm8ks6shCJDa9gfk8Ul5nfjq4xSohULERi4+wyP6cF85/w3w7dzgU+DObfA4bDT4PzNKyqkCLR0v9URPZeWpleZQH+4+47b59tZGZzKD06GBq0XQU8ZWZ/AAr4b4+5I4DHzOxiSo8ghgPVqtt1EV2zEKlkwTWLHHdfHXYWkcqi01AiIhKRjixERCQiHVmIiEhEKhYiIhKRioWIiESkYiEiIhGpWIiISET/H4Dw8VFXgTAnAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Evaluation\n",
+        "\n",
+        "We can evaluate the model on the test set as usual. The performance is not bad given that we only trained for 5 epoches."
+      ],
+      "metadata": {
+        "id": "umMcmhQcS8As"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def evaluate(state, xs):\n",
+        "    logits = CNN().apply({'params': state.params}, xs)\n",
+        "    prediction = jnp.argmax(logits, -1)\n",
+        "    return prediction"
+      ],
+      "metadata": {
+        "id": "HVFD-RGsLR3X"
+      },
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "test_x, test_y = get_datasets('test')\n",
+        "print(evaluate(state, test_x[:10, :]))\n",
+        "print(test_y[:10])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "23_1SfaCTbbx",
+        "outputId": "5527d321-7cd8-4857-fd94-339d7657b498"
+      },
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "[4 4 9 9 5 1 0 5 7 4]\n",
+            "[4 4 9 7 5 1 0 5 7 4]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "np.mean(evaluate(state, test_x) == test_y)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XNye7YOFURMK",
+        "outputId": "57eb502f-9b4e-460e-cad1-669629492487"
+      },
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.8086, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 19
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

<!-- Please refer to https://github.com/probml/pyprobml/blob/master/CONTRIBUTING.md before opening this PR -->

### Colab link

<!-- Add colab link that redirects to your notebook -->
<!-- 

For example, if your notebook is : 

https://github.com/codeboy5/probml-notebooks/blob/add-densenet-jax/notebooks-d2l/densenet_jax.ipynb  

Then colab notebook link is:

https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-densenet-jax/notebooks-d2l/densenet_jax.ipynb 

-->

https://colab.research.google.com/drive/1fa05RZZnDW5KOlaFaZbgMSidYm0CXfC7?usp=sharing

### Issue 

<!-- Link the issue you are solving -->

https://github.com/probml/pyprobml/issues/686

<!-- If the issue is from this repo, include directly with issue number -->
<!-- For example: 

#12

-->

<!-- If the issue is from another repo, you can include it using the regular linking mechanism -->
<!-- For example:

[Issue title](Issue link) 

-->

## Checklist:

- [X] Performed a self-review of the code
- [X] Tested on Google Colab.

## Potential problems/Important remarks

Since writing JAX requires a completely different mindset from that of PyTorch, translating the notebook work-by-word would inevitably lead to JAX code with a PyTorch "accent". To avoid that, I created an idiomatic JAX/Flax implementation of multi-device training from scratch. It borrows some code from the official [Parallel Evaluation in JAX](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html) notebook (which trains a linear regression model), and follows roughly the same narration as [the original D2L notebook](https://github.com/probml/probml-notebooks/blob/main/notebooks-d2l/multi_gpu_training_torch.ipynb).

<!-- If you have any important remarks for the reviewers to look at closer,  you can write them in detail here.  -->
