### PR TITLE
Converted `bert_torch.ipynb` to `bert_jax.ipynb`.

### DIFF
--- a/notebooks-d2l/bert_jax.ipynb
+++ b/notebooks-d2l/bert_jax.ipynb
@@ -1,0 +1,2056 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-bert-jax/notebooks-d2l/bert_jax.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cd49d6d4",
+      "metadata": {
+        "id": "cd49d6d4"
+      },
+      "source": [
+        "# BERT\n",
+        "\n",
+        "We show how to implement BERT from scratch.\n",
+        "Based on sec 14.8 of http://d2l.ai/chapter_natural-language-processing-pretraining/bert.html\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "67915239",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "67915239",
+        "outputId": "7c71a968-d618-41f8-e32e-1a13cc537d5c"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[?25l\r\u001b[K     |█▉                              | 10 kB 31.0 MB/s eta 0:00:01\r\u001b[K     |███▋                            | 20 kB 37.7 MB/s eta 0:00:01\r\u001b[K     |█████▍                          | 30 kB 41.1 MB/s eta 0:00:01\r\u001b[K     |███████▏                        | 40 kB 27.5 MB/s eta 0:00:01\r\u001b[K     |█████████                       | 51 kB 22.1 MB/s eta 0:00:01\r\u001b[K     |██████████▊                     | 61 kB 25.2 MB/s eta 0:00:01\r\u001b[K     |████████████▌                   | 71 kB 25.2 MB/s eta 0:00:01\r\u001b[K     |██████████████▎                 | 81 kB 24.6 MB/s eta 0:00:01\r\u001b[K     |████████████████                | 92 kB 26.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████▉              | 102 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |███████████████████▋            | 112 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▍          | 122 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |███████████████████████▏        | 133 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████       | 143 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▊     | 153 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▌   | 163 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▎ | 174 kB 28.7 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 184 kB 28.7 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 136 kB 71.4 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 72 kB 943 kB/s \n",
+            "\u001b[?25h"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install -q flax"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 107,
+      "id": "8aa33797",
+      "metadata": {
+        "id": "8aa33797",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "ca7e5d1a-8c41-49c7-8e4f-046ba17190d8"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "mkdir: cannot create directory ‘figures’: File exists\n"
+          ]
+        }
+      ],
+      "source": [
+        "import jax\n",
+        "import jax.numpy as jnp                # JAX NumPy\n",
+        "\n",
+        "from flax import linen as nn           # The Linen API\n",
+        "from flax.training import train_state  # Useful dataclass to keep train state\n",
+        "from flax.core.frozen_dict import FrozenDict\n",
+        "from flax.core import freeze, unfreeze\n",
+        "import torch\n",
+        "from torch.utils import data           # For data\n",
+        "\n",
+        "import numpy as np                     # Ordinary NumPy\n",
+        "import optax                           # Optimizers\n",
+        "\n",
+        "import collections\n",
+        "import re\n",
+        "import random\n",
+        "import os\n",
+        "import requests\n",
+        "import zipfile\n",
+        "import tarfile\n",
+        "import hashlib\n",
+        "import time\n",
+        "import json\n",
+        "import multiprocessing\n",
+        "from typing import Any, Callable, Sequence, Tuple\n",
+        "from functools import partial\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import pandas as pd\n",
+        "import math\n",
+        "from IPython import display \n",
+        "\n",
+        "rng = jax.random.PRNGKey(0)\n",
+        "!mkdir figures # for saving plots\n",
+        "ModuleDef = Any"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cf0844b3",
+      "metadata": {
+        "id": "cf0844b3"
+      },
+      "source": [
+        "# Data\n",
+        "\n",
+        "We pretrain on wikitext 2.\n",
+        "This is  smaller than other corpora, so it trains in reasonable time. It retains the original punctuation, making it suitable for next sentence prediction.\n",
+        "\n",
+        "Based on sec 14.9 of\n",
+        "http://d2l.ai/chapter_natural-language-processing-pretraining/bert-dataset.html\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "151b98d2",
+      "metadata": {
+        "id": "151b98d2"
+      },
+      "outputs": [],
+      "source": [
+        "DATA_HUB = dict()\n",
+        "DATA_HUB['wikitext-2'] = (\n",
+        "    'https://s3.amazonaws.com/research.metamind.io/wikitext/'\n",
+        "    'wikitext-2-v1.zip', '3c914d17d80b1459be871a5039ac23e752a53cbe')\n",
+        "\n",
+        "def _read_wiki(data_dir):\n",
+        "    file_name = os.path.join(data_dir, 'wiki.train.tokens')\n",
+        "    with open(file_name, 'r') as f:\n",
+        "        lines = f.readlines()\n",
+        "    # Uppercase letters are converted to lowercase ones\n",
+        "    paragraphs = [\n",
+        "        line.strip().lower().split(' . ') for line in lines\n",
+        "        if len(line.split(' . ')) >= 2]\n",
+        "    random.shuffle(paragraphs)\n",
+        "    return paragraphs"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a8d78ad5",
+      "metadata": {
+        "id": "a8d78ad5"
+      },
+      "source": [
+        "## Next sentence prediciton"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "d8ad71cc",
+      "metadata": {
+        "id": "d8ad71cc"
+      },
+      "outputs": [],
+      "source": [
+        "def _get_next_sentence(sentence, next_sentence, paragraphs):\n",
+        "    if random.random() < 0.5:\n",
+        "        is_next = True\n",
+        "    else:\n",
+        "        # `paragraphs` is a list of lists of lists\n",
+        "        next_sentence = random.choice(random.choice(paragraphs))\n",
+        "        is_next = False\n",
+        "    return sentence, next_sentence, is_next"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "f8de9a8e",
+      "metadata": {
+        "id": "f8de9a8e"
+      },
+      "outputs": [],
+      "source": [
+        "def get_tokens_and_segments(tokens_a, tokens_b=None):\n",
+        "    tokens = ['<cls>'] + tokens_a + ['<sep>']\n",
+        "    # 0 and 1 are marking segment A and B, respectively\n",
+        "    segments = [0] * (len(tokens_a) + 2)\n",
+        "    if tokens_b is not None:\n",
+        "        tokens += tokens_b + ['<sep>']\n",
+        "        segments += [1] * (len(tokens_b) + 1)\n",
+        "    return tokens, segments\n",
+        "\n",
+        "def _get_nsp_data_from_paragraph(paragraph, paragraphs, vocab, max_len):\n",
+        "    nsp_data_from_paragraph = []\n",
+        "    for i in range(len(paragraph) - 1):\n",
+        "        tokens_a, tokens_b, is_next = _get_next_sentence(\n",
+        "            paragraph[i], paragraph[i + 1], paragraphs)\n",
+        "        # Consider 1 '<cls>' token and 2 '<sep>' tokens\n",
+        "        if len(tokens_a) + len(tokens_b) + 3 > max_len:\n",
+        "            continue\n",
+        "        tokens, segments = get_tokens_and_segments(tokens_a, tokens_b)\n",
+        "        nsp_data_from_paragraph.append((tokens, segments, is_next))\n",
+        "    return nsp_data_from_paragraph"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2ce6d5c3",
+      "metadata": {
+        "id": "2ce6d5c3"
+      },
+      "source": [
+        "## Masked language model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "9a120c86",
+      "metadata": {
+        "id": "9a120c86"
+      },
+      "outputs": [],
+      "source": [
+        "def _replace_mlm_tokens(tokens, candidate_pred_positions, num_mlm_preds,\n",
+        "                        vocab):\n",
+        "    # Make a new copy of tokens for the input of a masked language model,\n",
+        "    # where the input may contain replaced '<mask>' or random tokens\n",
+        "    mlm_input_tokens = [token for token in tokens]\n",
+        "    pred_positions_and_labels = []\n",
+        "    # Shuffle for getting 15% random tokens for prediction in the masked\n",
+        "    # language modeling task\n",
+        "    random.shuffle(candidate_pred_positions)\n",
+        "    for mlm_pred_position in candidate_pred_positions:\n",
+        "        if len(pred_positions_and_labels) >= num_mlm_preds:\n",
+        "            break\n",
+        "        masked_token = None\n",
+        "        # 80% of the time: replace the word with the '<mask>' token\n",
+        "        if random.random() < 0.8:\n",
+        "            masked_token = '<mask>'\n",
+        "        else:\n",
+        "            # 10% of the time: keep the word unchanged\n",
+        "            if random.random() < 0.5:\n",
+        "                masked_token = tokens[mlm_pred_position]\n",
+        "            # 10% of the time: replace the word with a random word\n",
+        "            else:\n",
+        "                masked_token = random.randint(0, len(vocab) - 1)\n",
+        "        mlm_input_tokens[mlm_pred_position] = masked_token\n",
+        "        pred_positions_and_labels.append(\n",
+        "            (mlm_pred_position, tokens[mlm_pred_position]))\n",
+        "    return mlm_input_tokens, pred_positions_and_labels"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "c2090540",
+      "metadata": {
+        "id": "c2090540"
+      },
+      "outputs": [],
+      "source": [
+        "def _get_mlm_data_from_tokens(tokens, vocab):\n",
+        "    candidate_pred_positions = []\n",
+        "    # `tokens` is a list of strings\n",
+        "    for i, token in enumerate(tokens):\n",
+        "        # Special tokens are not predicted in the masked language modeling\n",
+        "        # task\n",
+        "        if token in ['<cls>', '<sep>']:\n",
+        "            continue\n",
+        "        candidate_pred_positions.append(i)\n",
+        "    # 15% of random tokens are predicted in the masked language modeling task\n",
+        "    num_mlm_preds = max(1, round(len(tokens) * 0.15))\n",
+        "    mlm_input_tokens, pred_positions_and_labels = _replace_mlm_tokens(\n",
+        "        tokens, candidate_pred_positions, num_mlm_preds, vocab)\n",
+        "    pred_positions_and_labels = sorted(pred_positions_and_labels,\n",
+        "                                       key=lambda x: x[0])\n",
+        "    pred_positions = [v[0] for v in pred_positions_and_labels]\n",
+        "    mlm_pred_labels = [v[1] for v in pred_positions_and_labels]\n",
+        "    return vocab[mlm_input_tokens], pred_positions, vocab[mlm_pred_labels]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4b67e46c",
+      "metadata": {
+        "id": "4b67e46c"
+      },
+      "source": [
+        "## Padding"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "36e7608d",
+      "metadata": {
+        "id": "36e7608d"
+      },
+      "outputs": [],
+      "source": [
+        "def _pad_bert_inputs(examples, max_len, vocab):\n",
+        "    max_num_mlm_preds = round(max_len * 0.15)\n",
+        "    all_token_ids, all_segments, valid_lens, = [], [], []\n",
+        "    all_pred_positions, all_mlm_weights, all_mlm_labels = [], [], []\n",
+        "    nsp_labels = []\n",
+        "    for (token_ids, pred_positions, mlm_pred_label_ids, segments,\n",
+        "         is_next) in examples:\n",
+        "        all_token_ids.append(\n",
+        "            torch.tensor(\n",
+        "                token_ids + [vocab['<pad>']] * (max_len - len(token_ids)),\n",
+        "                dtype=torch.long))\n",
+        "        all_segments.append(\n",
+        "            torch.tensor(segments + [0] * (max_len - len(segments)),\n",
+        "                         dtype=torch.long))\n",
+        "        # `valid_lens` excludes count of '<pad>' tokens\n",
+        "        valid_lens.append(torch.tensor(len(token_ids), dtype=torch.float32))\n",
+        "        all_pred_positions.append(\n",
+        "            torch.tensor(\n",
+        "                pred_positions + [0] *\n",
+        "                (max_num_mlm_preds - len(pred_positions)), dtype=torch.long))\n",
+        "        # Predictions of padded tokens will be filtered out in the loss via\n",
+        "        # multiplication of 0 weights\n",
+        "        all_mlm_weights.append(\n",
+        "            torch.tensor([1.0] * len(mlm_pred_label_ids) + [0.0] *\n",
+        "                         (max_num_mlm_preds - len(pred_positions)),\n",
+        "                         dtype=torch.float32))\n",
+        "        all_mlm_labels.append(\n",
+        "            torch.tensor(\n",
+        "                mlm_pred_label_ids + [0] *\n",
+        "                (max_num_mlm_preds - len(mlm_pred_label_ids)),\n",
+        "                dtype=torch.long))\n",
+        "        nsp_labels.append(torch.tensor(is_next, dtype=torch.long))\n",
+        "    return (all_token_ids, all_segments, valid_lens, all_pred_positions,\n",
+        "            all_mlm_weights, all_mlm_labels, nsp_labels)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3e75ebbd",
+      "metadata": {
+        "id": "3e75ebbd"
+      },
+      "source": [
+        "## Putting it altogether"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "d0f45e8f",
+      "metadata": {
+        "id": "d0f45e8f"
+      },
+      "outputs": [],
+      "source": [
+        "def tokenize(lines, token='word'):\n",
+        "    \"\"\"Split text lines into word or character tokens.\"\"\"\n",
+        "    if token == 'word':\n",
+        "        return [line.split() for line in lines]\n",
+        "    elif token == 'char':\n",
+        "        return [list(line) for line in lines]\n",
+        "    else:\n",
+        "        print('ERROR: unknown token type: ' + token)\n",
+        "\n",
+        "class Vocab:  \n",
+        "    \"\"\"Vocabulary for text.\"\"\"\n",
+        "    def __init__(self, tokens=None, min_freq=0, reserved_tokens=None):\n",
+        "        if tokens is None:\n",
+        "            tokens = []\n",
+        "        if reserved_tokens is None:\n",
+        "            reserved_tokens = []\n",
+        "        # Sort according to frequencies\n",
+        "        counter = count_corpus(tokens)\n",
+        "        self.token_freqs = sorted(counter.items(), key=lambda x: x[1],\n",
+        "                                  reverse=True)\n",
+        "        # The index for the unknown token is 0\n",
+        "        self.unk, uniq_tokens = 0, ['<unk>'] + reserved_tokens\n",
+        "        uniq_tokens += [\n",
+        "            token for token, freq in self.token_freqs\n",
+        "            if freq >= min_freq and token not in uniq_tokens]\n",
+        "        self.idx_to_token, self.token_to_idx = [], dict()\n",
+        "        for token in uniq_tokens:\n",
+        "            self.idx_to_token.append(token)\n",
+        "            self.token_to_idx[token] = len(self.idx_to_token) - 1\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.idx_to_token)\n",
+        "\n",
+        "    def __getitem__(self, tokens):\n",
+        "        if not isinstance(tokens, (list, tuple)):\n",
+        "            return self.token_to_idx.get(tokens, self.unk)\n",
+        "        return [self.__getitem__(token) for token in tokens]\n",
+        "\n",
+        "    def to_tokens(self, indices):\n",
+        "        if not isinstance(indices, (list, tuple)):\n",
+        "            return self.idx_to_token[indices]\n",
+        "        return [self.idx_to_token[index] for index in indices]\n",
+        "\n",
+        "def count_corpus(tokens):  \n",
+        "    \"\"\"Count token frequencies.\"\"\"\n",
+        "    # Here `tokens` is a 1D list or 2D list\n",
+        "    if len(tokens) == 0 or isinstance(tokens[0], list):\n",
+        "        # Flatten a list of token lists into a list of tokens\n",
+        "        tokens = [token for line in tokens for token in line]\n",
+        "    return collections.Counter(tokens)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "9f5921de",
+      "metadata": {
+        "id": "9f5921de"
+      },
+      "outputs": [],
+      "source": [
+        "class _WikiTextDataset(torch.utils.data.Dataset):\n",
+        "    def __init__(self, paragraphs, max_len):\n",
+        "        # Input `paragraphs[i]` is a list of sentence strings representing a\n",
+        "        # paragraph; while output `paragraphs[i]` is a list of sentences\n",
+        "        # representing a paragraph, where each sentence is a list of tokens\n",
+        "        paragraphs = [\n",
+        "            tokenize(paragraph, token='word') for paragraph in paragraphs]\n",
+        "        sentences = [\n",
+        "            sentence for paragraph in paragraphs for sentence in paragraph]\n",
+        "        self.vocab = Vocab(\n",
+        "            sentences, min_freq=5,\n",
+        "            reserved_tokens=['<pad>', '<mask>', '<cls>', '<sep>'])\n",
+        "        # Get data for the next sentence prediction task\n",
+        "        examples = []\n",
+        "        for paragraph in paragraphs:\n",
+        "            examples.extend(\n",
+        "                _get_nsp_data_from_paragraph(paragraph, paragraphs,\n",
+        "                                             self.vocab, max_len))\n",
+        "        # Get data for the masked language model task\n",
+        "        examples = [(_get_mlm_data_from_tokens(tokens, self.vocab) +\n",
+        "                     (segments, is_next))\n",
+        "                    for tokens, segments, is_next in examples]\n",
+        "        # Pad inputs\n",
+        "        (self.all_token_ids, self.all_segments, self.valid_lens,\n",
+        "         self.all_pred_positions, self.all_mlm_weights, self.all_mlm_labels,\n",
+        "         self.nsp_labels) = _pad_bert_inputs(examples, max_len, self.vocab)\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        return (self.all_token_ids[idx], self.all_segments[idx],\n",
+        "                self.valid_lens[idx], self.all_pred_positions[idx],\n",
+        "                self.all_mlm_weights[idx], self.all_mlm_labels[idx],\n",
+        "                self.nsp_labels[idx])\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.all_token_ids)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "8ab55081",
+      "metadata": {
+        "id": "8ab55081"
+      },
+      "outputs": [],
+      "source": [
+        "# Required functions for downloading data\n",
+        "\n",
+        "def download(name, cache_dir=os.path.join('..', 'data')):\n",
+        "    \"\"\"Download a file inserted into DATA_HUB, return the local filename.\"\"\"\n",
+        "    assert name in DATA_HUB, f\"{name} does not exist in {DATA_HUB}.\"\n",
+        "    url, sha1_hash = DATA_HUB[name]\n",
+        "    os.makedirs(cache_dir, exist_ok=True)\n",
+        "    fname = os.path.join(cache_dir, url.split('/')[-1])\n",
+        "    if os.path.exists(fname):\n",
+        "        sha1 = hashlib.sha1()\n",
+        "        with open(fname, 'rb') as f:\n",
+        "            while True:\n",
+        "                data = f.read(1048576)\n",
+        "                if not data:\n",
+        "                    break\n",
+        "                sha1.update(data)\n",
+        "        if sha1.hexdigest() == sha1_hash:\n",
+        "            return fname  # Hit cache\n",
+        "    print(f'Downloading {fname} from {url}...')\n",
+        "    r = requests.get(url, stream=True, verify=True)\n",
+        "    with open(fname, 'wb') as f:\n",
+        "        f.write(r.content)\n",
+        "    return fname\n",
+        "\n",
+        "def download_extract(name, folder=None):\n",
+        "    \"\"\"Download and extract a zip/tar file.\"\"\"\n",
+        "    fname = download(name)\n",
+        "    base_dir = os.path.dirname(fname)\n",
+        "    data_dir, ext = os.path.splitext(fname)\n",
+        "    if ext == '.zip':\n",
+        "        fp = zipfile.ZipFile(fname, 'r')\n",
+        "    elif ext in ('.tar', '.gz'):\n",
+        "        fp = tarfile.open(fname, 'r')\n",
+        "    else:\n",
+        "        assert False, 'Only zip/tar files can be extracted.'\n",
+        "    fp.extractall(base_dir)\n",
+        "    return os.path.join(base_dir, folder) if folder else data_dir"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "id": "6c2a2467",
+      "metadata": {
+        "id": "6c2a2467"
+      },
+      "outputs": [],
+      "source": [
+        "def load_data_wiki(batch_size, max_len):\n",
+        "    num_workers = 4\n",
+        "    data_dir = download_extract('wikitext-2', 'wikitext-2')\n",
+        "    paragraphs = _read_wiki(data_dir)\n",
+        "    train_set = _WikiTextDataset(paragraphs, max_len)\n",
+        "    train_iter = torch.utils.data.DataLoader(train_set, batch_size,\n",
+        "                                             shuffle=True,\n",
+        "                                             num_workers=num_workers)\n",
+        "    return train_iter, train_set.vocab"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "97e40835",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "97e40835",
+        "outputId": "b7011a52-094a-4d9c-e8ee-b1ebade102d3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading ../data/wikitext-2-v1.zip from https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip...\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/torch/utils/data/dataloader.py:481: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
+            "  cpuset_checked))\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([512, 64]) torch.Size([512, 64]) torch.Size([512]) torch.Size([512, 10]) torch.Size([512, 10]) torch.Size([512, 10]) torch.Size([512])\n"
+          ]
+        }
+      ],
+      "source": [
+        "batch_size, max_len = 512, 64\n",
+        "train_iter, vocab = load_data_wiki(batch_size, max_len)\n",
+        "\n",
+        "for (tokens_X, segments_X, valid_lens_x, pred_positions_X, mlm_weights_X,\n",
+        "     mlm_Y, nsp_y) in train_iter:\n",
+        "    print(tokens_X.shape, segments_X.shape, valid_lens_x.shape,\n",
+        "          pred_positions_X.shape, mlm_weights_X.shape, mlm_Y.shape,\n",
+        "          nsp_y.shape)\n",
+        "    break"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8cf1d579",
+      "metadata": {
+        "id": "8cf1d579"
+      },
+      "source": [
+        "# Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "18650387",
+      "metadata": {
+        "id": "18650387"
+      },
+      "source": [
+        "## Encoder"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "id": "8e1582b7",
+      "metadata": {
+        "id": "8e1582b7"
+      },
+      "outputs": [],
+      "source": [
+        "def get_tokens_and_segments(tokens_a, tokens_b=None):\n",
+        "    tokens = ['<cls>'] + tokens_a + ['<sep>']\n",
+        "    # 0 and 1 are marking segment A and B, respectively\n",
+        "    segments = [0] * (len(tokens_a) + 2)\n",
+        "    if tokens_b is not None:\n",
+        "        tokens += tokens_b + ['<sep>']\n",
+        "        segments += [1] * (len(tokens_b) + 1)\n",
+        "    return tokens, segments"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "id": "9fd8862c",
+      "metadata": {
+        "id": "9fd8862c"
+      },
+      "outputs": [],
+      "source": [
+        "class DotProductAttention(nn.Module):\n",
+        "    \"\"\"Scaled dot product attention.\"\"\"\n",
+        "    dropout_rate: float\n",
+        "    \n",
+        "    # Shape of `queries`: (`batch_size`, no. of queries, `d`)\n",
+        "    # Shape of `keys`: (`batch_size`, no. of key-value pairs, `d`)\n",
+        "    # Shape of `values`: (`batch_size`, no. of key-value pairs, value\n",
+        "    # dimension)\n",
+        "    # Shape of `valid_lens`: (`batch_size`,) or (`batch_size`, no. of queries)\n",
+        "    @nn.compact\n",
+        "    def __call__(self, queries, keys, values, train, valid_lens=None):\n",
+        "        d = queries.shape[-1]\n",
+        "        scores = queries@(keys.swapaxes(1, 2)) / math.sqrt(d)\n",
+        "        attention_weights = masked_softmax(scores, valid_lens)\n",
+        "        dropout_layer = nn.Dropout(self.dropout_rate, deterministic=not train)\n",
+        "        return dropout_layer(attention_weights)@values\n",
+        "\n",
+        "    \n",
+        "class MultiHeadAttention(nn.Module):\n",
+        "    num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    dropout: float\n",
+        "    bias: bool = False\n",
+        "        \n",
+        "    @nn.compact\n",
+        "    def __call__(self, queries, keys, values, valid_lens, train):\n",
+        "        # Shape of `queries`, `keys`, or `values`:\n",
+        "        # (`batch_size`, no. of queries or key-value pairs, `num_hiddens`)\n",
+        "        # Shape of `valid_lens`:\n",
+        "        # (`batch_size`,) or (`batch_size`, no. of queries)\n",
+        "        # After transposing, shape of output `queries`, `keys`, or `values`:\n",
+        "        # (`batch_size` * `num_heads`, no. of queries or key-value pairs,\n",
+        "        # `num_hiddens` / `num_heads`)\n",
+        "        queries = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias, name=\"W_q\")(queries), self.num_heads)\n",
+        "        keys = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias, name=\"W_k\")(keys), self.num_heads)\n",
+        "        values = transpose_qkv(nn.Dense(self.num_hiddens, use_bias=self.bias, name=\"W_v\")(values), self.num_heads)\n",
+        "        \n",
+        "        if valid_lens is not None:\n",
+        "            # On axis 0, copy the first item (scalar or vector) for\n",
+        "            # `num_heads` times, then copy the next item, and so on\n",
+        "            valid_lens = jnp.repeat(valid_lens, self.num_heads, axis=0)\n",
+        "            \n",
+        "        # Shape of `output`: (`batch_size` * `num_heads`, no. of queries,\n",
+        "        # `num_hiddens` / `num_heads`)\n",
+        "        output = DotProductAttention(self.dropout)(queries, keys, values, train, valid_lens)\n",
+        "        \n",
+        "        # Shape of `output_concat`:\n",
+        "        # (`batch_size`, no. of queries, `num_hiddens`)\n",
+        "        output_concat = transpose_output(output, self.num_heads)\n",
+        "        return nn.Dense(self.num_hiddens, use_bias=self.bias, name=\"W_o\")(output_concat)\n",
+        "\n",
+        "    \n",
+        "class PositionWiseFFN(nn.Module):\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    ffn_num_outputs: int\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.dense1 = nn.Dense(self.ffn_num_hiddens)\n",
+        "        self.relu = nn.relu\n",
+        "        self.dense2 = nn.Dense(self.ffn_num_outputs)\n",
+        "\n",
+        "    def __call__(self, inputs):\n",
+        "        return self.dense2(self.relu(self.dense1(inputs)))\n",
+        "\n",
+        "    \n",
+        "class AddNorm(nn.Module):\n",
+        "    dropout_rate: int\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.dropout = nn.Dropout(self.dropout_rate)\n",
+        "        self.ln = nn.LayerNorm()\n",
+        "\n",
+        "    def __call__(self, X, Y, train):\n",
+        "        return self.ln(self.dropout(Y, deterministic = not train) + X)\n",
+        "\n",
+        "\n",
+        "class EncoderBlock(nn.Module):\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    dropout_rate: float\n",
+        "    use_bias: bool = False\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.attention = MultiHeadAttention(self.num_hiddens, self.num_heads, self.dropout_rate, self.use_bias)\n",
+        "        self.addnorm1 = AddNorm(self.dropout_rate)\n",
+        "        self.ffn = PositionWiseFFN(self.ffn_num_input, self.ffn_num_hiddens, self.num_hiddens)\n",
+        "        self.addnorm2 = AddNorm(self.dropout_rate)\n",
+        "\n",
+        "    def __call__(self, X, valid_lens, train):\n",
+        "        output = self.attention(X, X, X, valid_lens, train)\n",
+        "        Y = self.addnorm1(X, output, train)\n",
+        "        return self.addnorm2(Y, self.ffn(Y), train)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "af07008e",
+      "metadata": {
+        "id": "af07008e"
+      },
+      "outputs": [],
+      "source": [
+        "class BERTEncoder(nn.Module):\n",
+        "    vocab_size: int\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    num_layers: int\n",
+        "    dropout: float\n",
+        "    max_len: int = 1000\n",
+        "    \n",
+        "    def setup(self):\n",
+        "        self.token_embedding = nn.Embed(self.vocab_size, self.num_hiddens, name=\"token_embedding\")\n",
+        "        self.segment_embedding = nn.Embed(2, self.num_hiddens, name=\"segment_embedding\")\n",
+        "        self.blks = [\n",
+        "            EncoderBlock(self.num_hiddens, self.ffn_num_input, self.ffn_num_hiddens, \n",
+        "                         self.num_heads, self.dropout, True) for _ in range(self.num_layers)]\n",
+        "        # In BERT, positional embeddings are learnable, thus we create a\n",
+        "        # parameter of positional embeddings that are long enough\n",
+        "        pos_embed_shape = (1, self.max_len, self.num_hiddens)\n",
+        "        self.pos_embedding =  self.param('embedding', nn.initializers.normal(), pos_embed_shape)\n",
+        "        \n",
+        "    def __call__(self, tokens, segments, valid_lens, train=True):\n",
+        "        # Shape of `X` remains unchanged in the following code snippet:\n",
+        "        # (batch size, max sequence length, `num_hiddens`)\n",
+        "        X = self.token_embedding(tokens) + self.segment_embedding(segments)\n",
+        "        X = X + self.pos_embedding[:, :X.shape[1], :]\n",
+        "        for i, blk in enumerate(self.blks):\n",
+        "            X = blk(X, valid_lens, train)\n",
+        "        return X"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "id": "5505fd09",
+      "metadata": {
+        "id": "5505fd09"
+      },
+      "outputs": [],
+      "source": [
+        "def masked_softmax(X, valid_lens):\n",
+        "    \"\"\"Perform softmax operation by masking elements on the last axis.\"\"\"\n",
+        "    # `X`: 3D tensor, `valid_lens`: 1D or 2D tensor\n",
+        "    if valid_lens is None:\n",
+        "        return nn.softmax(X, axis=-1)\n",
+        "    else:\n",
+        "        shape = X.shape\n",
+        "        if valid_lens.ndim == 1:\n",
+        "            valid_lens = jnp.repeat(valid_lens, shape[1])\n",
+        "        else:\n",
+        "            valid_lens = valid_lens.reshape(-1)\n",
+        "        # On the last axis, replace masked elements with a very large negative\n",
+        "        # value, whose exponentiation outputs 0\n",
+        "        X = sequence_mask(X.reshape(-1, shape[-1]), valid_lens, value=-1e6)\n",
+        "        return nn.softmax(X.reshape(shape), axis=-1)\n",
+        "\n",
+        "def sequence_mask(X, valid_len, value=0):\n",
+        "    \"\"\"Mask irrelevant entries in sequences.\"\"\"\n",
+        "    maxlen = X.shape[1]\n",
+        "    mask = jnp.arange((maxlen), dtype=jnp.float32)[None, :] < valid_len[:, None]\n",
+        "    X = jnp.where(~mask, value, X)\n",
+        "    return X\n",
+        "\n",
+        "def transpose_qkv(X, num_heads):\n",
+        "    # Shape of input `X`:\n",
+        "    # (`batch_size`, no. of queries or key-value pairs, `num_hiddens`).\n",
+        "    # Shape of output `X`:\n",
+        "    # (`batch_size`, no. of queries or key-value pairs, `num_heads`,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    X = X.reshape((X.shape[0], X.shape[1], num_heads, -1))\n",
+        "\n",
+        "    # Shape of output `X`:\n",
+        "    # (`batch_size`, `num_heads`, no. of queries or key-value pairs,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    X = jnp.transpose(X, (0, 2, 1, 3))\n",
+        "    \n",
+        "    # Shape of `output`:\n",
+        "    # (`batch_size` * `num_heads`, no. of queries or key-value pairs,\n",
+        "    # `num_hiddens` / `num_heads`)\n",
+        "    return X.reshape((-1, X.shape[2], X.shape[3]))\n",
+        "\n",
+        "\n",
+        "def transpose_output(X, num_heads):\n",
+        "    \"\"\"Reverse the operation of `transpose_qkv`\"\"\"\n",
+        "    X = X.reshape((-1, num_heads, X.shape[1], X.shape[2]))\n",
+        "    X = jnp.transpose(X, (0, 2, 1, 3))\n",
+        "    return X.reshape((X.shape[0], X.shape[1], -1))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "id": "3b952afd",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "3b952afd",
+        "outputId": "d7d24e73-1c5c-4fa3-b1bf-38a2650ae1da"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(2, 8, 768)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 18
+        }
+      ],
+      "source": [
+        "vocab_size, num_hiddens, ffn_num_hiddens, num_heads = 10000, 768, 1024, 4\n",
+        "norm_shape, ffn_num_input, num_layers, dropout = [768], 768, 2, 0.2\n",
+        "\n",
+        "encoder = BERTEncoder(vocab_size, num_hiddens, ffn_num_input, ffn_num_hiddens, num_heads, num_layers, dropout)\n",
+        "\n",
+        "rng, i_rng = jax.random.split(rng)\n",
+        "tokens = jax.random.randint(i_rng, (2, 8), 0, vocab_size)\n",
+        "segments = jnp.array([[0, 0, 0, 0, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1]])\n",
+        "\n",
+        "rng, i_rng = jax.random.split(rng)\n",
+        "params = encoder.init(i_rng, tokens, segments, None, False)\n",
+        "encoded_X = encoder.apply(params, tokens, segments, None, False)\n",
+        "encoded_X.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4a29774b",
+      "metadata": {
+        "id": "4a29774b"
+      },
+      "source": [
+        "## Loss"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "id": "3e3d0326",
+      "metadata": {
+        "id": "3e3d0326"
+      },
+      "outputs": [],
+      "source": [
+        "class MaskLM(nn.Module):\n",
+        "    vocab_size: int\n",
+        "    num_hiddens: int\n",
+        "\n",
+        "    @nn.compact\n",
+        "    def __call__(self, X, pred_positions):\n",
+        "        num_pred_positions = pred_positions.shape[1]\n",
+        "        pred_positions = pred_positions.reshape(-1)\n",
+        "        batch_size = X.shape[0]\n",
+        "        batch_idx = jnp.arange(0, batch_size)\n",
+        "        # Suppose that `batch_size` = 2, `num_pred_positions` = 3, then\n",
+        "        # `batch_idx` is `torch.tensor([0, 0, 0, 1, 1, 1])`\n",
+        "        batch_idx = jnp.repeat(batch_idx, num_pred_positions)\n",
+        "        masked_X = X[batch_idx, pred_positions]\n",
+        "        masked_X = masked_X.reshape((batch_size, num_pred_positions, -1))\n",
+        "        # MLP Layer\n",
+        "        mlm_Y_hat_ = nn.Dense(self.num_hiddens)(masked_X)\n",
+        "        mlm_Y_hat_ = nn.relu(mlm_Y_hat_)\n",
+        "        mlm_Y_hat_ = nn.LayerNorm(1e-5)(mlm_Y_hat_)\n",
+        "        mlm_Y_hat  = nn.Dense(self.vocab_size)(mlm_Y_hat_)\n",
+        "        return mlm_Y_hat"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "id": "237c7cae",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "237c7cae",
+        "outputId": "556b5b62-beb0-474c-d789-9195d27fef4f"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(2, 3, 10000)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 20
+        }
+      ],
+      "source": [
+        "mlm = MaskLM(vocab_size, num_hiddens)\n",
+        "mlm_positions = jnp.array([[1, 5, 2], [6, 1, 5]])\n",
+        "rng, i_rng = jax.random.split(rng)\n",
+        "params = mlm.init(i_rng, encoded_X, mlm_positions)\n",
+        "mlm_Y_hat = mlm.apply(params, encoded_X, mlm_positions)\n",
+        "mlm_Y_hat.shape"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "id": "d067f0dc",
+      "metadata": {
+        "id": "d067f0dc"
+      },
+      "outputs": [],
+      "source": [
+        "class NextSentencePred(nn.Module):\n",
+        "    \n",
+        "    @nn.compact\n",
+        "    def __call__(self, X):\n",
+        "        # `X` shape: (batch size, `num_hiddens`)\n",
+        "        Y = nn.Dense(2)(X)\n",
+        "        return Y"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "id": "9a97a361",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9a97a361",
+        "outputId": "9fc19304-3e4b-4130-dde2-cc4f2958565d"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(2, 2)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
+      ],
+      "source": [
+        "encoded_X = jnp.reshape(encoded_X, (encoded_X.shape[0], -1))\n",
+        "# input_shape for NSP: (batch size, `num_hiddens`)\n",
+        "nsp = NextSentencePred()\n",
+        "rng, i_rng = jax.random.split(rng)\n",
+        "params = nsp.init(i_rng, encoded_X)\n",
+        "nsp_Y_hat = nsp.apply(params, encoded_X)\n",
+        "nsp_Y_hat.shape"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "id": "f2d91207",
+      "metadata": {
+        "id": "f2d91207"
+      },
+      "outputs": [],
+      "source": [
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2b1fb5e2",
+      "metadata": {
+        "id": "2b1fb5e2"
+      },
+      "source": [
+        "## Putting it altogether"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "id": "bb640e6b",
+      "metadata": {
+        "id": "bb640e6b"
+      },
+      "outputs": [],
+      "source": [
+        "class BERTModel(nn.Module):\n",
+        "    vocab_size: int\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    num_layers: int\n",
+        "    dropout: float\n",
+        "    maxlen: int = 1000\n",
+        "    \n",
+        "    def setup(self):\n",
+        "        self.encoder = BERTEncoder(self.vocab_size, self.num_hiddens, self.ffn_num_input, self.ffn_num_hiddens, \n",
+        "                                   self.num_heads, self.num_layers, self.dropout, self.maxlen)\n",
+        "        self.mlm = MaskLM(self.vocab_size, self.num_hiddens)\n",
+        "        self.nsp = NextSentencePred()\n",
+        "    \n",
+        "    @nn.compact\n",
+        "    def __call__(self, tokens, segments, valid_lens=None, pred_positions=None, train=True):\n",
+        "        encoded_X = self.encoder(tokens, segments, valid_lens, train)\n",
+        "        # mlm_Y_hat = self.mlm(encoded_X, pred_positions)\n",
+        "        if pred_positions is not None:\n",
+        "            mlm_Y_hat = self.mlm(encoded_X, pred_positions)\n",
+        "        else:\n",
+        "            mlm_Y_hat = None\n",
+        "        # The hidden layer of the MLP classifier for next sentence prediction.\n",
+        "        # 0 is the index of the '<cls>' token\n",
+        "        nsp_Y_hat_ = nn.Dense(self.num_hiddens, name=\"hidden\")(encoded_X[:, 0, :])\n",
+        "        nsp_Y_hat_ = nn.tanh(nsp_Y_hat_)\n",
+        "        nsp_Y_hat = self.nsp(nsp_Y_hat_)\n",
+        "        return encoded_X, mlm_Y_hat, nsp_Y_hat"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f1aa8082",
+      "metadata": {
+        "id": "f1aa8082"
+      },
+      "source": [
+        "# Pre-training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "id": "f52d30f8",
+      "metadata": {
+        "id": "f52d30f8"
+      },
+      "outputs": [],
+      "source": [
+        "class Animator:\n",
+        "    \"\"\"For plotting data in animation.\"\"\"\n",
+        "    def __init__(self, xlabel=None, ylabel=None, legend=None, xlim=None,\n",
+        "                 ylim=None, xscale='linear', yscale='linear',\n",
+        "                 fmts=('-', 'm--', 'g-.', 'r:'), nrows=1, ncols=1,\n",
+        "                 figsize=(3.5, 2.5)):\n",
+        "        # Incrementally plot multiple lines\n",
+        "        if legend is None:\n",
+        "            legend = []\n",
+        "        display.set_matplotlib_formats('svg')\n",
+        "        self.fig, self.axes = plt.subplots(nrows, ncols, figsize=figsize)\n",
+        "        if nrows * ncols == 1:\n",
+        "            self.axes = [self.axes,]\n",
+        "        # Use a lambda function to capture arguments\n",
+        "        self.config_axes = lambda: set_axes(self.axes[\n",
+        "            0], xlabel, ylabel, xlim, ylim, xscale, yscale, legend)\n",
+        "        self.X, self.Y, self.fmts = None, None, fmts\n",
+        "\n",
+        "    def add(self, x, y):\n",
+        "        # Add multiple data points into the figure\n",
+        "        if not hasattr(y, \"__len__\"):\n",
+        "            y = [y]\n",
+        "        n = len(y)\n",
+        "        if not hasattr(x, \"__len__\"):\n",
+        "            x = [x] * n\n",
+        "        if not self.X:\n",
+        "            self.X = [[] for _ in range(n)]\n",
+        "        if not self.Y:\n",
+        "            self.Y = [[] for _ in range(n)]\n",
+        "        for i, (a, b) in enumerate(zip(x, y)):\n",
+        "            if a is not None and b is not None:\n",
+        "                self.X[i].append(a)\n",
+        "                self.Y[i].append(b)\n",
+        "        self.axes[0].cla()\n",
+        "        for x, y, fmt in zip(self.X, self.Y, self.fmts):\n",
+        "            self.axes[0].plot(x, y, fmt)\n",
+        "        self.config_axes()\n",
+        "        display.display(self.fig)\n",
+        "        display.clear_output(wait=True)\n",
+        "\n",
+        "class Timer:\n",
+        "    \"\"\"Record multiple running times.\"\"\"\n",
+        "    def __init__(self):\n",
+        "        self.times = []\n",
+        "        self.start()\n",
+        "\n",
+        "    def start(self):\n",
+        "        \"\"\"Start the timer.\"\"\"\n",
+        "        self.tik = time.time()\n",
+        "\n",
+        "    def stop(self):\n",
+        "        \"\"\"Stop the timer and record the time in a list.\"\"\"\n",
+        "        self.times.append(time.time() - self.tik)\n",
+        "        return self.times[-1]\n",
+        "\n",
+        "    def avg(self):\n",
+        "        \"\"\"Return the average time.\"\"\"\n",
+        "        return sum(self.times) / len(self.times)\n",
+        "\n",
+        "    def sum(self):\n",
+        "        \"\"\"Return the sum of time.\"\"\"\n",
+        "        return sum(self.times)\n",
+        "\n",
+        "    def cumsum(self):\n",
+        "        \"\"\"Return the accumulated time.\"\"\"\n",
+        "        return np.array(self.times).cumsum().tolist()\n",
+        "\n",
+        "class Accumulator:\n",
+        "    \"\"\"For accumulating sums over `n` variables.\"\"\"\n",
+        "    def __init__(self, n):\n",
+        "        self.data = [0.0] * n\n",
+        "\n",
+        "    def add(self, *args):\n",
+        "        self.data = [a + float(b) for a, b in zip(self.data, args)]\n",
+        "\n",
+        "    def reset(self):\n",
+        "        self.data = [0.0] * len(self.data)\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        return self.data[idx]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "id": "84031393",
+      "metadata": {
+        "id": "84031393"
+      },
+      "outputs": [],
+      "source": [
+        "def set_axes(axes, xlabel, ylabel, xlim, ylim, xscale, yscale, legend):\n",
+        "    \"\"\"Set the axes for matplotlib.\"\"\"\n",
+        "    axes.set_xlabel(xlabel)\n",
+        "    axes.set_ylabel(ylabel)\n",
+        "    axes.set_xscale(xscale)\n",
+        "    axes.set_yscale(yscale)\n",
+        "    axes.set_xlim(xlim)\n",
+        "    axes.set_ylim(ylim)\n",
+        "    if legend:\n",
+        "        axes.legend(legend)\n",
+        "    axes.grid()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "id": "810ff9eb",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "810ff9eb",
+        "outputId": "32f16fe4-7980-4144-fab7-dfe99681aac9"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/torch/utils/data/dataloader.py:481: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
+            "  cpuset_checked))\n"
+          ]
+        }
+      ],
+      "source": [
+        "batch_size, max_len = 512, 64\n",
+        "train_iter, vocab = load_data_wiki(batch_size, max_len)\n",
+        "\n",
+        "Transformer = partial(BERTModel, vocab_size=len(vocab), num_hiddens=128, ffn_num_input=128, ffn_num_hiddens=256,\n",
+        "                                num_heads=2, num_layers=2, dropout=0.2)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "id": "0443ac0d",
+      "metadata": {
+        "id": "0443ac0d"
+      },
+      "outputs": [],
+      "source": [
+        "def cross_entropy_loss(logits, labels) -> float:\n",
+        "    one_hot = jax.nn.one_hot(labels, num_classes=logits.shape[1])\n",
+        "    loss = optax.softmax_cross_entropy(logits=logits, labels=one_hot)\n",
+        "    return loss\n",
+        "\n",
+        "def compute_metrics(logits, labels):\n",
+        "    \"\"\"Computes metrics and returns them.\"\"\"\n",
+        "    loss = cross_entropy_loss(logits, labels)\n",
+        "    metrics = {\n",
+        "        'loss': loss\n",
+        "    }\n",
+        "    return metrics"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "id": "69188d65",
+      "metadata": {
+        "id": "69188d65"
+      },
+      "outputs": [],
+      "source": [
+        "def get_initial_params(model, rng):\n",
+        "    \"\"\"Returns the initial parameters of a bert model.\"\"\"\n",
+        "    rng, i_rng = jax.random.split(rng)\n",
+        "    #! tokens, segments\n",
+        "    tokens = jnp.ones((512, 64), dtype=jnp.int32)\n",
+        "    segments = jnp.ones((512, 64), dtype=jnp.int32)\n",
+        "    positions = jnp.ones((512, 10), dtype=jnp.int32)\n",
+        "    rng, init_rng = jax.random.split(rng)\n",
+        "    variables = model.init(\n",
+        "        init_rng,\n",
+        "        tokens, segments,\n",
+        "        None, positions, False)\n",
+        "    return variables['params']\n",
+        "\n",
+        "def get_train_state(Model ,rng, lr) -> train_state.TrainState:\n",
+        "    \"\"\"Returns a train state.\"\"\"\n",
+        "    model = Model()\n",
+        "    params = get_initial_params(model, rng)\n",
+        "    tx = optax.adam(lr)\n",
+        "    return train_state.TrainState.create(\n",
+        "        apply_fn=model.apply, params=params, tx=tx)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "id": "84ecba1d",
+      "metadata": {
+        "id": "84ecba1d"
+      },
+      "outputs": [],
+      "source": [
+        "def train_step(state: train_state.TrainState, vocab_size, tokens_X, segments_X, valid_lens_x, pred_positions_X,\n",
+        "              mlm_weights_X, mlm_Y, nsp_y, dropout_rng):\n",
+        "    \n",
+        "    \n",
+        "    \"\"\"Trains one step.\"\"\"\n",
+        "    def loss_fn(params):\n",
+        "        # Forward pass\n",
+        "        _, mlm_Y_hat, nsp_Y_hat = state.apply_fn({'params': params}, tokens_X, segments_X, valid_lens_x.reshape(-1),\n",
+        "                                                 pred_positions_X, True, rngs={'dropout': dropout_rng})\n",
+        "        # Compute masked language model loss\n",
+        "        mlm_l = cross_entropy_loss(mlm_Y_hat.reshape(-1, vocab_size), mlm_Y.reshape(-1))\n",
+        "        mlm_weights_X.reshape((-1, 1))\n",
+        "        mlm_l = mlm_l.sum() / (mlm_weights_X.sum() + 1e-8)\n",
+        "        # Compute next sentence prediction loss\n",
+        "        nsp_l = cross_entropy_loss(nsp_Y_hat, nsp_y).mean()\n",
+        "        l = mlm_l + nsp_l\n",
+        "        return l, (mlm_l, nsp_l)\n",
+        "    \n",
+        "    grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
+        "    (l, (mlm_l, nsp_l)), grads = grad_fn(state.params)\n",
+        "    state = state.apply_gradients(grads=grads)\n",
+        "    \n",
+        "    return mlm_l, nsp_l, l, state"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "id": "7adc4b5e",
+      "metadata": {
+        "id": "7adc4b5e"
+      },
+      "outputs": [],
+      "source": [
+        "def train_bert(Model, train_iter, lr, num_steps, vocab_size):\n",
+        "    \n",
+        "    key = jax.random.PRNGKey(314)\n",
+        "    state = get_train_state(Model, key, lr)\n",
+        "    \n",
+        "    step, timer = 0, Timer()\n",
+        "    animator = Animator(xlabel='step', ylabel='loss', xlim=[1, num_steps],\n",
+        "                            legend=['mlm', 'nsp'])\n",
+        "    # Sum of masked language modeling losses, sum of next sentence prediction\n",
+        "    # losses, no. of sentence pairs, count\n",
+        "    metric = Accumulator(4)\n",
+        "    num_steps_reached = False\n",
+        "    while step < num_steps and not num_steps_reached:\n",
+        "        for tokens_X, segments_X, valid_lens_x, pred_positions_X,\\\n",
+        "            mlm_weights_X, mlm_Y, nsp_y in train_iter:\n",
+        "            key, dropout_rng = jax.random.split(key)\n",
+        "            tokens_X = jnp.array(tokens_X)\n",
+        "            segments_X = jnp.array(segments_X)\n",
+        "            valid_lens_x = jnp.array(valid_lens_x)\n",
+        "            pred_positions_X = jnp.array(pred_positions_X)\n",
+        "            mlm_weights_X = jnp.array(mlm_weights_X)\n",
+        "            mlm_Y = jnp.array(mlm_Y)\n",
+        "            nsp_y = jnp.array(nsp_y)\n",
+        "            timer.start()\n",
+        "            mlm_l, nsp_l, l, state = train_step(state, vocab_size, tokens_X, segments_X, valid_lens_x, \n",
+        "                                                pred_positions_X, mlm_weights_X, mlm_Y, nsp_y, dropout_rng)\n",
+        "            metric.add(mlm_l, nsp_l, tokens_X.shape[0], 1)\n",
+        "            timer.stop()\n",
+        "            animator.add(step + 1,\n",
+        "                         (metric[0] / metric[3], metric[1] / metric[3]))\n",
+        "            step += 1\n",
+        "            if step == num_steps:\n",
+        "                num_steps_reached = True\n",
+        "                break\n",
+        "    device = jax.default_backend()\n",
+        "    print(f'MLM loss {metric[0] / metric[3]:.3f}, '\n",
+        "          f'NSP loss {metric[1] / metric[3]:.3f}')\n",
+        "    print(f'{metric[2] / timer.sum():.1f} sentence pairs/sec on '\n",
+        "          f'{str(device)}')\n",
+        "    \n",
+        "    return state"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "id": "a62cebd5",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 297
+        },
+        "id": "a62cebd5",
+        "outputId": "33f2cbe2-0118-44c5-ef86-bba4d822f107"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "MLM loss 7.850, NSP loss 0.748\n",
+            "453.8 sentence pairs/sec on gpu\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 252x180 with 1 Axes>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"180.65625pt\" version=\"1.1\" viewBox=\"0 0 249.465625 180.65625\" width=\"249.465625pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 180.65625 \nL 249.465625 180.65625 \nL 249.465625 0 \nL 0 0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 40.603125 143.1 \nL 235.903125 143.1 \nL 235.903125 7.2 \nL 40.603125 7.2 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 76.474554 143.1 \nL 76.474554 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"m13b32ba077\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"76.474554\" xlink:href=\"#m13b32ba077\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 10 -->\n      <defs>\n       <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(70.112054 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 116.331696 143.1 \nL 116.331696 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"116.331696\" xlink:href=\"#m13b32ba077\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 20 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(109.969196 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 156.188839 143.1 \nL 156.188839 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"156.188839\" xlink:href=\"#m13b32ba077\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 30 -->\n      <defs>\n       <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n      </defs>\n      <g transform=\"translate(149.826339 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-51\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 196.045982 143.1 \nL 196.045982 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"196.045982\" xlink:href=\"#m13b32ba077\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 40 -->\n      <defs>\n       <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n      </defs>\n      <g transform=\"translate(189.683482 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 235.903125 143.1 \nL 235.903125 7.2 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"235.903125\" xlink:href=\"#m13b32ba077\" y=\"143.1\"/>\n      </g>\n     </g>\n     <g id=\"text_5\">\n      <!-- 50 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(229.540625 157.698438)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_6\">\n     <!-- step -->\n     <defs>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n     </defs>\n     <g transform=\"translate(127.4375 171.376563)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"52.099609\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"91.308594\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"152.832031\" xlink:href=\"#DejaVuSans-112\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_11\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 40.603125 101.047247 \nL 235.903125 101.047247 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"mf8e4ed65cd\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"40.603125\" xlink:href=\"#mf8e4ed65cd\" y=\"101.047247\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 5 -->\n      <g transform=\"translate(27.240625 104.846466)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_13\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 40.603125 58.864203 \nL 235.903125 58.864203 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"40.603125\" xlink:href=\"#mf8e4ed65cd\" y=\"58.864203\"/>\n      </g>\n     </g>\n     <g id=\"text_8\">\n      <!-- 10 -->\n      <g transform=\"translate(20.878125 62.663421)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_15\">\n      <path clip-path=\"url(#p4ee0f03581)\" d=\"M 40.603125 16.681158 \nL 235.903125 16.681158 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_16\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"40.603125\" xlink:href=\"#mf8e4ed65cd\" y=\"16.681158\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 15 -->\n      <g transform=\"translate(20.878125 20.480377)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_10\">\n     <!-- loss -->\n     <defs>\n      <path d=\"M 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 0 \nL 9.421875 0 \nz\n\" id=\"DejaVuSans-108\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n     </defs>\n     <g transform=\"translate(14.798437 84.807812)rotate(-90)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"27.783203\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"88.964844\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"141.064453\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_17\">\n    <path clip-path=\"url(#p4ee0f03581)\" d=\"M 40.603125 13.377273 \nL 44.588839 27.215712 \nL 48.574554 34.73065 \nL 52.560268 40.660161 \nL 56.545982 45.297682 \nL 60.531696 48.949554 \nL 64.517411 51.89589 \nL 68.503125 54.420549 \nL 72.488839 56.661103 \nL 76.474554 58.491799 \nL 80.460268 60.105224 \nL 84.445982 61.379052 \nL 88.431696 62.518555 \nL 92.417411 63.502941 \nL 96.403125 64.382667 \nL 100.388839 65.187908 \nL 104.374554 65.823461 \nL 108.360268 66.469023 \nL 112.345982 67.050903 \nL 116.331696 67.707455 \nL 120.317411 68.363328 \nL 124.303125 68.967387 \nL 128.288839 69.511927 \nL 132.274554 70.050847 \nL 136.260268 70.524511 \nL 140.245982 71.005227 \nL 144.231696 71.43079 \nL 148.217411 71.841736 \nL 152.203125 72.228789 \nL 156.188839 72.599673 \nL 160.174554 72.927559 \nL 164.160268 73.263775 \nL 168.145982 73.553922 \nL 172.131696 73.857868 \nL 176.117411 74.147959 \nL 180.103125 74.420534 \nL 184.088839 74.666246 \nL 188.074554 74.900155 \nL 192.060268 75.112592 \nL 196.045982 75.334212 \nL 200.031696 75.528177 \nL 204.017411 75.726075 \nL 208.003125 75.905745 \nL 211.988839 76.071348 \nL 215.974554 76.250532 \nL 219.960268 76.415711 \nL 223.945982 76.567168 \nL 227.931696 76.71527 \nL 231.917411 76.866581 \nL 235.903125 77.002152 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"line2d_18\">\n    <path clip-path=\"url(#p4ee0f03581)\" d=\"M 40.603125 136.784636 \nL 44.588839 132.379544 \nL 48.574554 131.892372 \nL 52.560268 133.169562 \nL 56.545982 133.766454 \nL 60.531696 134.253163 \nL 64.517411 134.680023 \nL 68.503125 134.961273 \nL 72.488839 135.135763 \nL 76.474554 135.34177 \nL 80.460268 135.526943 \nL 84.445982 135.668233 \nL 88.431696 135.77921 \nL 92.417411 135.88212 \nL 96.403125 135.974072 \nL 100.388839 136.060777 \nL 104.374554 136.134451 \nL 108.360268 136.192039 \nL 112.345982 136.244582 \nL 116.331696 136.298885 \nL 120.317411 136.346617 \nL 124.303125 136.389303 \nL 128.288839 136.431574 \nL 132.274554 136.470433 \nL 136.260268 136.50256 \nL 140.245982 136.5287 \nL 144.231696 136.557892 \nL 148.217411 136.587235 \nL 152.203125 136.613088 \nL 156.188839 136.635913 \nL 160.174554 136.657348 \nL 164.160268 136.677749 \nL 168.145982 136.698815 \nL 172.131696 136.717241 \nL 176.117411 136.735807 \nL 180.103125 136.751943 \nL 184.088839 136.769325 \nL 188.074554 136.78521 \nL 192.060268 136.799536 \nL 196.045982 136.814369 \nL 200.031696 136.826065 \nL 204.017411 136.83914 \nL 208.003125 136.850777 \nL 211.988839 136.863107 \nL 215.974554 136.874447 \nL 219.960268 136.884588 \nL 223.945982 136.895584 \nL 227.931696 136.90558 \nL 231.917411 136.914684 \nL 235.903125 136.922727 \n\" style=\"fill:none;stroke:#bf00bf;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 40.603125 143.1 \nL 40.603125 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 235.903125 143.1 \nL 235.903125 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 40.603125 143.1 \nL 235.903125 143.1 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 40.603125 7.2 \nL 235.903125 7.2 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"legend_1\">\n    <g id=\"patch_7\">\n     <path d=\"M 174.64375 44.55625 \nL 228.903125 44.55625 \nQ 230.903125 44.55625 230.903125 42.55625 \nL 230.903125 14.2 \nQ 230.903125 12.2 228.903125 12.2 \nL 174.64375 12.2 \nQ 172.64375 12.2 172.64375 14.2 \nL 172.64375 42.55625 \nQ 172.64375 44.55625 174.64375 44.55625 \nz\n\" style=\"fill:#ffffff;opacity:0.8;stroke:#cccccc;stroke-linejoin:miter;\"/>\n    </g>\n    <g id=\"line2d_19\">\n     <path d=\"M 176.64375 20.298437 \nL 196.64375 20.298437 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_20\"/>\n    <g id=\"text_11\">\n     <!-- mlm -->\n     <defs>\n      <path d=\"M 52 44.1875 \nQ 55.375 50.25 60.0625 53.125 \nQ 64.75 56 71.09375 56 \nQ 79.640625 56 84.28125 50.015625 \nQ 88.921875 44.046875 88.921875 33.015625 \nL 88.921875 0 \nL 79.890625 0 \nL 79.890625 32.71875 \nQ 79.890625 40.578125 77.09375 44.375 \nQ 74.3125 48.1875 68.609375 48.1875 \nQ 61.625 48.1875 57.5625 43.546875 \nQ 53.515625 38.921875 53.515625 30.90625 \nL 53.515625 0 \nL 44.484375 0 \nL 44.484375 32.71875 \nQ 44.484375 40.625 41.703125 44.40625 \nQ 38.921875 48.1875 33.109375 48.1875 \nQ 26.21875 48.1875 22.15625 43.53125 \nQ 18.109375 38.875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.1875 51.21875 25.484375 53.609375 \nQ 29.78125 56 35.6875 56 \nQ 41.65625 56 45.828125 52.96875 \nQ 50 49.953125 52 44.1875 \nz\n\" id=\"DejaVuSans-109\"/>\n     </defs>\n     <g transform=\"translate(204.64375 23.798437)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-109\"/>\n      <use x=\"97.412109\" xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"125.195312\" xlink:href=\"#DejaVuSans-109\"/>\n     </g>\n    </g>\n    <g id=\"line2d_21\">\n     <path d=\"M 176.64375 34.976562 \nL 196.64375 34.976562 \n\" style=\"fill:none;stroke:#bf00bf;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_22\"/>\n    <g id=\"text_12\">\n     <!-- nsp -->\n     <defs>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n     </defs>\n     <g transform=\"translate(204.64375 38.476562)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"63.378906\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"115.478516\" xlink:href=\"#DejaVuSans-112\"/>\n     </g>\n    </g>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p4ee0f03581\">\n   <rect height=\"135.9\" width=\"195.3\" x=\"40.603125\" y=\"7.2\"/>\n  </clipPath>\n </defs>\n</svg>\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "nsteps, lr = 50, 5e-3\n",
+        "bert_train_state = train_bert(Transformer, train_iter, lr, nsteps, len(vocab))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Extracting the output encoding"
+      ],
+      "metadata": {
+        "id": "_hBuKwTJxtRT"
+      },
+      "id": "_hBuKwTJxtRT"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "id": "707ffdef",
+      "metadata": {
+        "id": "707ffdef"
+      },
+      "outputs": [],
+      "source": [
+        "def get_bert_encoding(state, tokens_a, tokens_b=None):\n",
+        "    tokens, segments = get_tokens_and_segments(tokens_a, tokens_b)\n",
+        "    token_ids = jnp.expand_dims(jnp.array(vocab[tokens]), 0)\n",
+        "    segments = jnp.expand_dims(jnp.array(segments), 0) \n",
+        "    valid_len = jnp.expand_dims(jnp.array(len(tokens)), 0)\n",
+        "    encoded_X, _, _ = state.apply_fn({'params': state.params}, token_ids, segments, valid_len, None, False)\n",
+        "    return encoded_X"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Encoding of 1 sentnence. \n",
+        "tokens_a = ['a', 'crane', 'is', 'flying']\n",
+        "encoded_text = get_bert_encoding(bert_train_state, tokens_a)\n",
+        "# Tokens: '<cls>', 'a', 'crane', 'is', 'flying', '<sep>'\n",
+        "encoded_text_cls = encoded_text[:, 0, :] # cls is token 0\n",
+        "encoded_text_crane = encoded_text[:, 2, :]\n",
+        "encoded_text.shape, encoded_text_cls.shape"
+      ],
+      "metadata": {
+        "id": "J6dPbIH-xuAb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e7b38b0e-96e3-4528-e2bd-1859815a20d0"
+      },
+      "id": "J6dPbIH-xuAb",
+      "execution_count": 34,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "((1, 6, 128), (1, 128))"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 34
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Pre-trained model"
+      ],
+      "metadata": {
+        "id": "p2f92Nj1DZaI"
+      },
+      "id": "p2f92Nj1DZaI"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'\n",
+        "DATA_HUB['bert.base'] = (DATA_URL + 'bert.base.torch.zip',\n",
+        "                             '225d66f04cae318b841a13d32af3acc165f253ac')\n",
+        "DATA_HUB['bert.small'] = (DATA_URL + 'bert.small.torch.zip',\n",
+        "                              'c72329e68a732bef0452e4b96a1c341c8910f81f')"
+      ],
+      "metadata": {
+        "id": "4rXER3MYO9en"
+      },
+      "id": "4rXER3MYO9en",
+      "execution_count": 56,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Function To Convert Pytorch Weights To Flax.\n",
+        "def load_params_from_torch(pretrained_model):\n",
+        "\n",
+        "    data_dir = download_extract(pretrained_model)\n",
+        "\n",
+        "    pt_params = torch.load(os.path.join(data_dir, 'pretrained.params'))\n",
+        "    jax_params = {}\n",
+        "\n",
+        "    # mapping between PyTorch BERT and JAX model.\n",
+        "    # Embeddings\n",
+        "    pt_key_to_jax_key = [\n",
+        "        # Encoder.\n",
+        "        ('encoder.pos_embedding', 'encoder.embedding', 0),\n",
+        "        ('encoder.token_embedding.weight', 'encoder.token_embedding.embedding', 0),\n",
+        "        ('encoder.segment_embedding.weight', 'encoder.segment_embedding.embedding', 0),\n",
+        "        # Encoder Block 0.\n",
+        "        ('encoder.blks.0.attention.W_q.weight', 'encoder.blks_0.attention.W_q.kernel', 1),\n",
+        "        ('encoder.blks.0.attention.W_q.bias', 'encoder.blks_0.attention.W_q.bias', -1),\n",
+        "        ('encoder.blks.0.attention.W_k.weight', 'encoder.blks_0.attention.W_k.kernel', 1),\n",
+        "        ('encoder.blks.0.attention.W_k.bias', 'encoder.blks_0.attention.W_k.bias', -1),\n",
+        "        ('encoder.blks.0.attention.W_v.weight', 'encoder.blks_0.attention.W_v.kernel', 1),\n",
+        "        ('encoder.blks.0.attention.W_v.bias', 'encoder.blks_0.attention.W_v.bias', -1),\n",
+        "        ('encoder.blks.0.attention.W_o.weight', 'encoder.blks_0.attention.W_o.kernel', 1),\n",
+        "        ('encoder.blks.0.attention.W_o.bias', 'encoder.blks_0.attention.W_o.bias', -1),\n",
+        "        ('encoder.blks.0.addnorm1.ln.weight', 'encoder.blks_0.addnorm1.ln.scale', -1),\n",
+        "        ('encoder.blks.0.addnorm1.ln.bias', 'encoder.blks_0.addnorm1.ln.bias', -1),\n",
+        "        ('encoder.blks.0.ffn.dense1.weight', 'encoder.blks_0.ffn.dense1.kernel', 1),\n",
+        "        ('encoder.blks.0.ffn.dense1.bias', 'encoder.blks_0.ffn.dense1.bias', -1),\n",
+        "        ('encoder.blks.0.ffn.dense2.weight', 'encoder.blks_0.ffn.dense2.kernel', 1),\n",
+        "        ('encoder.blks.0.ffn.dense2.bias', 'encoder.blks_0.ffn.dense2.bias', -1),\n",
+        "        ('encoder.blks.0.addnorm2.ln.weight', 'encoder.blks_0.addnorm2.ln.scale', -1),\n",
+        "        ('encoder.blks.0.addnorm2.ln.bias', 'encoder.blks_0.addnorm2.ln.bias', -1),\n",
+        "        # Encoder Block 1.\n",
+        "        ('encoder.blks.1.attention.W_q.weight', 'encoder.blks_1.attention.W_q.kernel', 1),\n",
+        "        ('encoder.blks.1.attention.W_q.bias', 'encoder.blks_1.attention.W_q.bias', -1),\n",
+        "        ('encoder.blks.1.attention.W_k.weight', 'encoder.blks_1.attention.W_k.kernel', 1),\n",
+        "        ('encoder.blks.1.attention.W_k.bias', 'encoder.blks_1.attention.W_k.bias', -1),\n",
+        "        ('encoder.blks.1.attention.W_v.weight', 'encoder.blks_1.attention.W_v.kernel', 1),\n",
+        "        ('encoder.blks.1.attention.W_v.bias', 'encoder.blks_1.attention.W_v.bias', -1),\n",
+        "        ('encoder.blks.1.attention.W_o.weight', 'encoder.blks_1.attention.W_o.kernel', 1),\n",
+        "        ('encoder.blks.1.attention.W_o.bias', 'encoder.blks_1.attention.W_o.bias', -1),\n",
+        "        ('encoder.blks.1.addnorm1.ln.weight', 'encoder.blks_1.addnorm1.ln.scale', -1),\n",
+        "        ('encoder.blks.1.addnorm1.ln.bias', 'encoder.blks_1.addnorm1.ln.bias', -1),\n",
+        "        ('encoder.blks.1.ffn.dense1.weight', 'encoder.blks_1.ffn.dense1.kernel', 1),\n",
+        "        ('encoder.blks.1.ffn.dense1.bias', 'encoder.blks_1.ffn.dense1.bias', -1),\n",
+        "        ('encoder.blks.1.ffn.dense2.weight', 'encoder.blks_1.ffn.dense2.kernel', 1),\n",
+        "        ('encoder.blks.1.ffn.dense2.bias', 'encoder.blks_1.ffn.dense2.bias', -1),\n",
+        "        ('encoder.blks.1.addnorm2.ln.weight', 'encoder.blks_1.addnorm2.ln.scale', -1),\n",
+        "        ('encoder.blks.1.addnorm2.ln.bias', 'encoder.blks_1.addnorm2.ln.bias', -1),\n",
+        "        # Hidden.\n",
+        "        ('hidden.0.weight', 'hidden.kernel', 1),\n",
+        "        ('hidden.0.bias', 'hidden.bias', -1),\n",
+        "        # MLM\n",
+        "        ('mlm.mlp.0.weight', 'mlm.Dense_0.kernel', 1),\n",
+        "        ('mlm.mlp.0.bias', 'mlm.Dense_0.bias', -1),\n",
+        "        ('mlm.mlp.2.weight', 'mlm.LayerNorm_0.scale', -1),\n",
+        "        ('mlm.mlp.2.bias', 'mlm.LayerNorm_0.bias', -1),\n",
+        "        ('mlm.mlp.3.weight', 'mlm.Dense_1.kernel', 1),\n",
+        "        ('mlm.mlp.3.bias', 'mlm.Dense_1.bias', -1),\n",
+        "        # NSP\n",
+        "        ('nsp.output.weight', 'nsp.Dense_0.kernel', 1),\n",
+        "        ('nsp.output.bias', 'nsp.Dense_0.bias', -1)\n",
+        "    ]\n",
+        "\n",
+        "    for pt_name, jax_name, id in pt_key_to_jax_key:\n",
+        "        val = pt_params[pt_name]\n",
+        "        if (id == 1):\n",
+        "            val = val.T\n",
+        "        val = np.asarray(val)\n",
+        "        jax_params[jax_name] = val\n",
+        "        \n",
+        "        # convert flat param dict into nested dict using `/` as delimeter\n",
+        "        outer_dict = {}\n",
+        "        for key, val in jax_params.items():\n",
+        "            tokens = key.split('.')\n",
+        "            inner_dict = outer_dict\n",
+        "            # each token except the very last should add a layer to the nested dict\n",
+        "            for token in tokens[:-1]:\n",
+        "                if token not in inner_dict:\n",
+        "                    inner_dict[token] = {}\n",
+        "                inner_dict = inner_dict[token]\n",
+        "            inner_dict[tokens[-1]] = val\n",
+        "    \n",
+        "    params = jax.tree_map(jnp.asarray, outer_dict)\n",
+        "    flax_params = {'params': params}\n",
+        "\n",
+        "    return flax_params"
+      ],
+      "metadata": {
+        "id": "LnMCw29-xmQO"
+      },
+      "id": "LnMCw29-xmQO",
+      "execution_count": 60,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def load_pretrain_vocab(pretrained_model):\n",
+        "    data_dir = download_extract(pretrained_model)\n",
+        "    # Define an empty vocabulary to load the predefined vocabulary\n",
+        "    vocab = Vocab()\n",
+        "    vocab.idx_to_token = json.load(open(os.path.join(data_dir, 'vocab.json')))\n",
+        "    vocab.token_to_idx = {\n",
+        "        token: idx for idx, token in enumerate(vocab.idx_to_token)}\n",
+        "    \n",
+        "    return vocab"
+      ],
+      "metadata": {
+        "id": "p0YMqUD8rSRc"
+      },
+      "id": "p0YMqUD8rSRc",
+      "execution_count": 58,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "vocab = load_pretrain_vocab('bert.small')"
+      ],
+      "metadata": {
+        "id": "1bB0CuitrSOc"
+      },
+      "id": "1bB0CuitrSOc",
+      "execution_count": 59,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Fine tuning"
+      ],
+      "metadata": {
+        "id": "wZw1UWpDEaDH"
+      },
+      "id": "wZw1UWpDEaDH"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We use the stanford natural language inference dataset, as in this [colab](https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/entailment_attention_mlp_torch.ipynb)"
+      ],
+      "metadata": {
+        "id": "XvQnZfHbEeP4"
+      },
+      "id": "XvQnZfHbEeP4"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class SNLIBERTDataset(torch.utils.data.Dataset):\n",
+        "    def __init__(self, dataset, max_len, vocab=None):\n",
+        "        all_premise_hypothesis_tokens = [[\n",
+        "            p_tokens, h_tokens] for p_tokens, h_tokens in zip(*[\n",
+        "                tokenize([s.lower() for s in sentences])\n",
+        "                for sentences in dataset[:2]])]\n",
+        "\n",
+        "        self.labels = torch.tensor(dataset[2])\n",
+        "        self.vocab = vocab\n",
+        "        self.max_len = max_len\n",
+        "        (self.all_token_ids, self.all_segments,\n",
+        "         self.valid_lens) = self._preprocess(all_premise_hypothesis_tokens)\n",
+        "        print('read ' + str(len(self.all_token_ids)) + ' examples')\n",
+        "\n",
+        "    def _preprocess(self, all_premise_hypothesis_tokens):\n",
+        "        pool = multiprocessing.Pool(4)  # Use 4 worker processes\n",
+        "        out = pool.map(self._mp_worker, all_premise_hypothesis_tokens)\n",
+        "        all_token_ids = [token_ids for token_ids, segments, valid_len in out]\n",
+        "        all_segments = [segments for token_ids, segments, valid_len in out]\n",
+        "        valid_lens = [valid_len for token_ids, segments, valid_len in out]\n",
+        "        return (torch.tensor(all_token_ids, dtype=torch.long),\n",
+        "                torch.tensor(all_segments,\n",
+        "                             dtype=torch.long), torch.tensor(valid_lens))\n",
+        "\n",
+        "    def _mp_worker(self, premise_hypothesis_tokens):\n",
+        "        p_tokens, h_tokens = premise_hypothesis_tokens\n",
+        "        self._truncate_pair_of_tokens(p_tokens, h_tokens)\n",
+        "        tokens, segments = get_tokens_and_segments(p_tokens, h_tokens)\n",
+        "        token_ids = self.vocab[tokens] + [self.vocab['<pad>']] \\\n",
+        "                             * (self.max_len - len(tokens))\n",
+        "        segments = segments + [0] * (self.max_len - len(segments))\n",
+        "        valid_len = len(tokens)\n",
+        "        return token_ids, segments, valid_len\n",
+        "\n",
+        "    def _truncate_pair_of_tokens(self, p_tokens, h_tokens):\n",
+        "        # Reserve slots for '<CLS>', '<SEP>', and '<SEP>' tokens for the BERT\n",
+        "        # input\n",
+        "        while len(p_tokens) + len(h_tokens) > self.max_len - 3:\n",
+        "            if len(p_tokens) > len(h_tokens):\n",
+        "                p_tokens.pop()\n",
+        "            else:\n",
+        "                h_tokens.pop()\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        return (self.all_token_ids[idx], self.all_segments[idx],\n",
+        "                self.valid_lens[idx]), self.labels[idx]\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.all_token_ids)"
+      ],
+      "metadata": {
+        "id": "oe-QBJ9rEcox"
+      },
+      "id": "oe-QBJ9rEcox",
+      "execution_count": 46,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def read_snli(data_dir, is_train):\n",
+        "    \"\"\"Read the SNLI dataset into premises, hypotheses, and labels.\"\"\"\n",
+        "    def extract_text(s):\n",
+        "        # Remove information that will not be used by us\n",
+        "        s = re.sub('\\\\(', '', s)\n",
+        "        s = re.sub('\\\\)', '', s)\n",
+        "        # Substitute two or more consecutive whitespace with space\n",
+        "        s = re.sub('\\\\s{2,}', ' ', s)\n",
+        "        return s.strip()\n",
+        "\n",
+        "    label_set = {'entailment': 0, 'contradiction': 1, 'neutral': 2}\n",
+        "    file_name = os.path.join(\n",
+        "        data_dir, 'snli_1.0_train.txt' if is_train else 'snli_1.0_test.txt')\n",
+        "    with open(file_name, 'r') as f:\n",
+        "        rows = [row.split('\\t') for row in f.readlines()[1:]]\n",
+        "    premises = [extract_text(row[1]) for row in rows if row[0] in label_set]\n",
+        "    hypotheses = [extract_text(row[2]) for row in rows if row[0] in label_set]\n",
+        "    labels = [label_set[row[0]] for row in rows if row[0] in label_set]\n",
+        "    return premises, hypotheses, labels"
+      ],
+      "metadata": {
+        "id": "wJz2r_47FW5X"
+      },
+      "id": "wJz2r_47FW5X",
+      "execution_count": 47,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "DATA_HUB['SNLI'] = ('https://nlp.stanford.edu/projects/snli/snli_1.0.zip',\n",
+        "                        '9fcde07509c7e87ec61c640c1b2753d9041758e4')"
+      ],
+      "metadata": {
+        "id": "58q8_wSiFjqw"
+      },
+      "id": "58q8_wSiFjqw",
+      "execution_count": 50,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Reduce `batch_size` if there is an out of memory error. \n",
+        "#In the original BERT model, `max_len` = 512\n",
+        "#batch_size, max_len, num_workers = 512, 128, 4\n",
+        "batch_size, max_len, num_workers = 256, 128, 4\n",
+        "data_dir = download_extract('SNLI')\n",
+        "train_set = SNLIBERTDataset(read_snli(data_dir, True), max_len, vocab)\n",
+        "test_set = SNLIBERTDataset(read_snli(data_dir, False), max_len, vocab)\n",
+        "train_iter = torch.utils.data.DataLoader(train_set, batch_size, shuffle=True,\n",
+        "                                         num_workers=num_workers)\n",
+        "test_iter = torch.utils.data.DataLoader(test_set, batch_size,\n",
+        "                                        num_workers=num_workers)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_N5StXvTFki2",
+        "outputId": "4c6edb7f-7dc9-40c9-b2f5-be1f0ba89f72"
+      },
+      "id": "_N5StXvTFki2",
+      "execution_count": 51,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "read 549367 examples\n",
+            "read 9824 examples\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/torch/utils/data/dataloader.py:481: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
+            "  cpuset_checked))\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class BERTClassifier(nn.Module):\n",
+        "    vocab_size: int\n",
+        "    num_hiddens: int\n",
+        "    ffn_num_input: int\n",
+        "    ffn_num_hiddens: int\n",
+        "    num_heads: int\n",
+        "    num_layers: int\n",
+        "    dropout: float\n",
+        "    maxlen: int\n",
+        "\n",
+        "    def setup(self):\n",
+        "        self.encoder = BERTEncoder(self.vocab_size, self.num_hiddens, self.ffn_num_input, self.ffn_num_hiddens, \n",
+        "                                   self.num_heads, self.num_layers, self.dropout, self.maxlen)\n",
+        "        self.output = nn.Dense(3)\n",
+        "    \n",
+        "    @nn.compact\n",
+        "    def __call__(self, inputs, train=True):\n",
+        "        tokens_X, segments_X, valid_lens_x = inputs\n",
+        "        encoded_X = self.encoder(tokens_X, segments_X, valid_lens_x, train)\n",
+        "        # Hidden Layer\n",
+        "        hidden_X = nn.Dense(self.num_hiddens, name=\"hidden\")(encoded_X[:, 0, :])\n",
+        "        hidden_X = nn.tanh(hidden_X)\n",
+        "        # Output Layer\n",
+        "        return self.output(hidden_X)"
+      ],
+      "metadata": {
+        "id": "LjMsCxpPFmUq"
+      },
+      "id": "LjMsCxpPFmUq",
+      "execution_count": 108,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Transformer = partial(BERTClassifier, vocab_size=len(vocab), num_hiddens=256, ffn_num_input=256, ffn_num_hiddens=512,\n",
+        "                                num_heads=4, num_layers=2, dropout=0.2, maxlen=512)"
+      ],
+      "metadata": {
+        "id": "krwwg_qBLf9s"
+      },
+      "id": "krwwg_qBLf9s",
+      "execution_count": 109,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def cross_entropy_loss(logits, labels) -> float:\n",
+        "    one_hot = jax.nn.one_hot(labels, num_classes=3)\n",
+        "    loss = optax.softmax_cross_entropy(logits=logits, labels=one_hot)\n",
+        "    return loss.sum()\n",
+        "\n",
+        "def compute_metrics(logits, labels):\n",
+        "    \"\"\"Computes metrics and returns them.\"\"\"\n",
+        "    loss = cross_entropy_loss(logits, labels)\n",
+        "    accuracy = jnp.sum(jnp.argmax(logits, -1) == labels)\n",
+        "    metrics = {\n",
+        "        'loss': loss,\n",
+        "        'accuracy': accuracy,\n",
+        "    }\n",
+        "    return metrics\n",
+        "\n",
+        "def evaluate_accuracy(state: train_state.TrainState, data_iter):\n",
+        "    \"\"\"Compute the accuracy for a model on a dataset using a GPU.\"\"\"\n",
+        "    # No. of correct predictions, no. of predictions\n",
+        "    metric = Accumulator(2)\n",
+        "    for X, y in data_iter:\n",
+        "        X = [jnp.array(x) for x in X]\n",
+        "        y = jnp.array(y)\n",
+        "        logits = state.apply_fn({'params': state.params}, X, False)\n",
+        "        accuracy = jnp.sum(jnp.argmax(logits, -1) == y)\n",
+        "        metric.add(accuracy, y.size)\n",
+        "    return metric[0] / metric[1]"
+      ],
+      "metadata": {
+        "id": "PBPuoULnN8lq"
+      },
+      "id": "PBPuoULnN8lq",
+      "execution_count": 123,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_initial_params(model, rng):\n",
+        "    \"\"\"Returns the initial parameters of a bert model.\"\"\"\n",
+        "    #! tokens, segments, valid_lens\n",
+        "    tokens = jnp.ones((256, 128), dtype=jnp.int32)\n",
+        "    segments = jnp.ones((256, 128), dtype=jnp.int32)\n",
+        "    valid_lens = jnp.ones((256,), dtype=jnp.int32)\n",
+        "    features = [tokens, segments, valid_lens]\n",
+        "    rng, init_rng = jax.random.split(rng)\n",
+        "    variables = model.init(\n",
+        "        init_rng,features, False)\n",
+        "    return variables['params']\n",
+        "\n",
+        "def get_train_state(Model ,rng, lr) -> train_state.TrainState:\n",
+        "    \"\"\"Returns a train state.\"\"\"\n",
+        "    model = Model()\n",
+        "    params = get_initial_params(model, rng)\n",
+        "    pretrained_params = load_params_from_torch('bert.small')['params']\n",
+        "\n",
+        "    # Load the Pretrained Params into Initiated Params.\n",
+        "    params = unfreeze(params)\n",
+        "    params['encoder'] = pretrained_params['encoder']\n",
+        "    params['hidden']  = pretrained_params['hidden']\n",
+        "    params = freeze(params)\n",
+        "\n",
+        "    tx = optax.adam(lr)\n",
+        "    \n",
+        "    return train_state.TrainState.create(\n",
+        "        apply_fn=model.apply, params=params, tx=tx)"
+      ],
+      "metadata": {
+        "id": "l-FQVlaOUryT"
+      },
+      "id": "l-FQVlaOUryT",
+      "execution_count": 122,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(state: train_state.TrainState, features, labels, dropout_rng):\n",
+        "\n",
+        "    \"\"\"Trains one step.\"\"\"\n",
+        "    def loss_fn(params):\n",
+        "        logits = state.apply_fn({'params': params}, features, True, rngs={'dropout': dropout_rng})\n",
+        "        loss = cross_entropy_loss(logits, labels)\n",
+        "        return loss, logits\n",
+        "    \n",
+        "    grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
+        "    (_, logits), grads = grad_fn(state.params)\n",
+        "    state = state.apply_gradients(grads=grads)\n",
+        "    metrics = compute_metrics(logits, labels)\n",
+        "\n",
+        "    return state, metrics\n"
+      ],
+      "metadata": {
+        "id": "CBX0a8GqUz2T"
+      },
+      "id": "CBX0a8GqUz2T",
+      "execution_count": 124,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def train_bert_classifier(Model, train_iter, test_iter, num_epochs, lr):\n",
+        "\n",
+        "    key = jax.random.PRNGKey(42)\n",
+        "    state = get_train_state(Model, key, lr)\n",
+        "\n",
+        "    timer, num_batches = Timer(), len(train_iter)\n",
+        "    animator = Animator(xlabel='epoch', xlim=[1, num_epochs], ylim=[0, 1],\n",
+        "                            legend=['train loss', 'train acc', 'test acc'])\n",
+        "    \n",
+        "    for epoch in range(num_epochs):\n",
+        "        # Store training_loss, training_accuracy, num_examples, num_features\n",
+        "        metric = Accumulator(4)\n",
+        "        for i, (features, labels) in enumerate(train_iter):\n",
+        "            features = [jnp.array(x) for x in features]\n",
+        "            labels = jnp.array(labels)\n",
+        "            timer.start()\n",
+        "            state, metrics = train_step(state, features, labels, key)\n",
+        "            l = metrics['loss']\n",
+        "            acc = metrics['accuracy']\n",
+        "            metric.add(l, acc, labels.shape[0], labels.size)\n",
+        "            timer.stop()\n",
+        "            if (i + 1) % (num_batches // 5) == 0 or i == num_batches - 1:\n",
+        "                animator.add(\n",
+        "                    epoch + (i + 1) / num_batches,\n",
+        "                    (metric[0] / metric[2], metric[1] / metric[3], None))\n",
+        "        # Calculate Test Accuracy\n",
+        "        test_acc = evaluate_accuracy(state, test_iter)    \n",
+        "        animator.add(epoch + 1, (None, None, test_acc))\n",
+        "    device = jax.default_backend()\n",
+        "    print(f'loss {metric[0] / metric[2]:.3f}, train acc '\n",
+        "          f'{metric[1] / metric[3]:.3f}, test acc {test_acc:.3f}')\n",
+        "    print(f'{metric[2] * num_epochs / timer.sum():.1f} examples/sec on '\n",
+        "          f'{str(device)}')\n",
+        "    return state"
+      ],
+      "metadata": {
+        "id": "mxD9JVfkXIwB"
+      },
+      "id": "mxD9JVfkXIwB",
+      "execution_count": 129,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "lr, num_epochs = 0.001, 4\n",
+        "final_state = train_bert_classifier(Transformer, train_iter, test_iter, num_epochs, lr)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 302
+        },
+        "id": "HfPULmdfYGLo",
+        "outputId": "b1a21abf-909e-4d41-c551-b0e1960a1155"
+      },
+      "id": "HfPULmdfYGLo",
+      "execution_count": 130,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "loss 0.636, train acc 0.736, test acc 0.740\n",
+            "1882.5 examples/sec on gpu\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 252x180 with 1 Axes>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Created with matplotlib (https://matplotlib.org/) -->\n<svg height=\"184.455469pt\" version=\"1.1\" viewBox=\"0 0 240.554687 184.455469\" width=\"240.554687pt\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n <defs>\n  <style type=\"text/css\">\n*{stroke-linecap:butt;stroke-linejoin:round;}\n  </style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 184.455469 \nL 240.554687 184.455469 \nL 240.554687 -0 \nL 0 -0 \nz\n\" style=\"fill:none;\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 30.103125 146.899219 \nL 225.403125 146.899219 \nL 225.403125 10.999219 \nL 30.103125 10.999219 \nz\n\" style=\"fill:#ffffff;\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 146.899219 \nL 30.103125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path d=\"M 0 0 \nL 0 3.5 \n\" id=\"me6ebe8fbda\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 1.0 -->\n      <defs>\n       <path d=\"M 12.40625 8.296875 \nL 28.515625 8.296875 \nL 28.515625 63.921875 \nL 10.984375 60.40625 \nL 10.984375 69.390625 \nL 28.421875 72.90625 \nL 38.28125 72.90625 \nL 38.28125 8.296875 \nL 54.390625 8.296875 \nL 54.390625 0 \nL 12.40625 0 \nz\n\" id=\"DejaVuSans-49\"/>\n       <path d=\"M 10.6875 12.40625 \nL 21 12.40625 \nL 21 0 \nL 10.6875 0 \nz\n\" id=\"DejaVuSans-46\"/>\n       <path d=\"M 31.78125 66.40625 \nQ 24.171875 66.40625 20.328125 58.90625 \nQ 16.5 51.421875 16.5 36.375 \nQ 16.5 21.390625 20.328125 13.890625 \nQ 24.171875 6.390625 31.78125 6.390625 \nQ 39.453125 6.390625 43.28125 13.890625 \nQ 47.125 21.390625 47.125 36.375 \nQ 47.125 51.421875 43.28125 58.90625 \nQ 39.453125 66.40625 31.78125 66.40625 \nz\nM 31.78125 74.21875 \nQ 44.046875 74.21875 50.515625 64.515625 \nQ 56.984375 54.828125 56.984375 36.375 \nQ 56.984375 17.96875 50.515625 8.265625 \nQ 44.046875 -1.421875 31.78125 -1.421875 \nQ 19.53125 -1.421875 13.0625 8.265625 \nQ 6.59375 17.96875 6.59375 36.375 \nQ 6.59375 54.828125 13.0625 64.515625 \nQ 19.53125 74.21875 31.78125 74.21875 \nz\n\" id=\"DejaVuSans-48\"/>\n      </defs>\n      <g transform=\"translate(22.151563 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 62.653125 146.899219 \nL 62.653125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"62.653125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 1.5 -->\n      <defs>\n       <path d=\"M 10.796875 72.90625 \nL 49.515625 72.90625 \nL 49.515625 64.59375 \nL 19.828125 64.59375 \nL 19.828125 46.734375 \nQ 21.96875 47.46875 24.109375 47.828125 \nQ 26.265625 48.1875 28.421875 48.1875 \nQ 40.625 48.1875 47.75 41.5 \nQ 54.890625 34.8125 54.890625 23.390625 \nQ 54.890625 11.625 47.5625 5.09375 \nQ 40.234375 -1.421875 26.90625 -1.421875 \nQ 22.3125 -1.421875 17.546875 -0.640625 \nQ 12.796875 0.140625 7.71875 1.703125 \nL 7.71875 11.625 \nQ 12.109375 9.234375 16.796875 8.0625 \nQ 21.484375 6.890625 26.703125 6.890625 \nQ 35.15625 6.890625 40.078125 11.328125 \nQ 45.015625 15.765625 45.015625 23.390625 \nQ 45.015625 31 40.078125 35.4375 \nQ 35.15625 39.890625 26.703125 39.890625 \nQ 22.75 39.890625 18.8125 39.015625 \nQ 14.890625 38.140625 10.796875 36.28125 \nz\n\" id=\"DejaVuSans-53\"/>\n      </defs>\n      <g transform=\"translate(54.701563 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 95.203125 146.899219 \nL 95.203125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"95.203125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 2.0 -->\n      <defs>\n       <path d=\"M 19.1875 8.296875 \nL 53.609375 8.296875 \nL 53.609375 0 \nL 7.328125 0 \nL 7.328125 8.296875 \nQ 12.9375 14.109375 22.625 23.890625 \nQ 32.328125 33.6875 34.8125 36.53125 \nQ 39.546875 41.84375 41.421875 45.53125 \nQ 43.3125 49.21875 43.3125 52.78125 \nQ 43.3125 58.59375 39.234375 62.25 \nQ 35.15625 65.921875 28.609375 65.921875 \nQ 23.96875 65.921875 18.8125 64.3125 \nQ 13.671875 62.703125 7.8125 59.421875 \nL 7.8125 69.390625 \nQ 13.765625 71.78125 18.9375 73 \nQ 24.125 74.21875 28.421875 74.21875 \nQ 39.75 74.21875 46.484375 68.546875 \nQ 53.21875 62.890625 53.21875 53.421875 \nQ 53.21875 48.921875 51.53125 44.890625 \nQ 49.859375 40.875 45.40625 35.40625 \nQ 44.1875 33.984375 37.640625 27.21875 \nQ 31.109375 20.453125 19.1875 8.296875 \nz\n\" id=\"DejaVuSans-50\"/>\n      </defs>\n      <g transform=\"translate(87.251563 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 127.753125 146.899219 \nL 127.753125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"127.753125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 2.5 -->\n      <g transform=\"translate(119.801563 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-50\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 160.303125 146.899219 \nL 160.303125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"160.303125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_5\">\n      <!-- 3.0 -->\n      <defs>\n       <path d=\"M 40.578125 39.3125 \nQ 47.65625 37.796875 51.625 33 \nQ 55.609375 28.21875 55.609375 21.1875 \nQ 55.609375 10.40625 48.1875 4.484375 \nQ 40.765625 -1.421875 27.09375 -1.421875 \nQ 22.515625 -1.421875 17.65625 -0.515625 \nQ 12.796875 0.390625 7.625 2.203125 \nL 7.625 11.71875 \nQ 11.71875 9.328125 16.59375 8.109375 \nQ 21.484375 6.890625 26.8125 6.890625 \nQ 36.078125 6.890625 40.9375 10.546875 \nQ 45.796875 14.203125 45.796875 21.1875 \nQ 45.796875 27.640625 41.28125 31.265625 \nQ 36.765625 34.90625 28.71875 34.90625 \nL 20.21875 34.90625 \nL 20.21875 43.015625 \nL 29.109375 43.015625 \nQ 36.375 43.015625 40.234375 45.921875 \nQ 44.09375 48.828125 44.09375 54.296875 \nQ 44.09375 59.90625 40.109375 62.90625 \nQ 36.140625 65.921875 28.71875 65.921875 \nQ 24.65625 65.921875 20.015625 65.03125 \nQ 15.375 64.15625 9.8125 62.3125 \nL 9.8125 71.09375 \nQ 15.4375 72.65625 20.34375 73.4375 \nQ 25.25 74.21875 29.59375 74.21875 \nQ 40.828125 74.21875 47.359375 69.109375 \nQ 53.90625 64.015625 53.90625 55.328125 \nQ 53.90625 49.265625 50.4375 45.09375 \nQ 46.96875 40.921875 40.578125 39.3125 \nz\n\" id=\"DejaVuSans-51\"/>\n      </defs>\n      <g transform=\"translate(152.351562 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-51\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_6\">\n     <g id=\"line2d_11\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 192.853125 146.899219 \nL 192.853125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"192.853125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_6\">\n      <!-- 3.5 -->\n      <g transform=\"translate(184.901562 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-51\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-53\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_7\">\n     <g id=\"line2d_13\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 225.403125 146.899219 \nL 225.403125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"225.403125\" xlink:href=\"#me6ebe8fbda\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 4.0 -->\n      <defs>\n       <path d=\"M 37.796875 64.3125 \nL 12.890625 25.390625 \nL 37.796875 25.390625 \nz\nM 35.203125 72.90625 \nL 47.609375 72.90625 \nL 47.609375 25.390625 \nL 58.015625 25.390625 \nL 58.015625 17.1875 \nL 47.609375 17.1875 \nL 47.609375 0 \nL 37.796875 0 \nL 37.796875 17.1875 \nL 4.890625 17.1875 \nL 4.890625 26.703125 \nz\n\" id=\"DejaVuSans-52\"/>\n      </defs>\n      <g transform=\"translate(217.451562 161.497656)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-52\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_8\">\n     <!-- epoch -->\n     <defs>\n      <path d=\"M 56.203125 29.59375 \nL 56.203125 25.203125 \nL 14.890625 25.203125 \nQ 15.484375 15.921875 20.484375 11.0625 \nQ 25.484375 6.203125 34.421875 6.203125 \nQ 39.59375 6.203125 44.453125 7.46875 \nQ 49.3125 8.734375 54.109375 11.28125 \nL 54.109375 2.78125 \nQ 49.265625 0.734375 44.1875 -0.34375 \nQ 39.109375 -1.421875 33.890625 -1.421875 \nQ 20.796875 -1.421875 13.15625 6.1875 \nQ 5.515625 13.8125 5.515625 26.8125 \nQ 5.515625 40.234375 12.765625 48.109375 \nQ 20.015625 56 32.328125 56 \nQ 43.359375 56 49.78125 48.890625 \nQ 56.203125 41.796875 56.203125 29.59375 \nz\nM 47.21875 32.234375 \nQ 47.125 39.59375 43.09375 43.984375 \nQ 39.0625 48.390625 32.421875 48.390625 \nQ 24.90625 48.390625 20.390625 44.140625 \nQ 15.875 39.890625 15.1875 32.171875 \nz\n\" id=\"DejaVuSans-101\"/>\n      <path d=\"M 18.109375 8.203125 \nL 18.109375 -20.796875 \nL 9.078125 -20.796875 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.390625 \nQ 20.953125 51.265625 25.265625 53.625 \nQ 29.59375 56 35.59375 56 \nQ 45.5625 56 51.78125 48.09375 \nQ 58.015625 40.1875 58.015625 27.296875 \nQ 58.015625 14.40625 51.78125 6.484375 \nQ 45.5625 -1.421875 35.59375 -1.421875 \nQ 29.59375 -1.421875 25.265625 0.953125 \nQ 20.953125 3.328125 18.109375 8.203125 \nz\nM 48.6875 27.296875 \nQ 48.6875 37.203125 44.609375 42.84375 \nQ 40.53125 48.484375 33.40625 48.484375 \nQ 26.265625 48.484375 22.1875 42.84375 \nQ 18.109375 37.203125 18.109375 27.296875 \nQ 18.109375 17.390625 22.1875 11.75 \nQ 26.265625 6.109375 33.40625 6.109375 \nQ 40.53125 6.109375 44.609375 11.75 \nQ 48.6875 17.390625 48.6875 27.296875 \nz\n\" id=\"DejaVuSans-112\"/>\n      <path d=\"M 30.609375 48.390625 \nQ 23.390625 48.390625 19.1875 42.75 \nQ 14.984375 37.109375 14.984375 27.296875 \nQ 14.984375 17.484375 19.15625 11.84375 \nQ 23.34375 6.203125 30.609375 6.203125 \nQ 37.796875 6.203125 41.984375 11.859375 \nQ 46.1875 17.53125 46.1875 27.296875 \nQ 46.1875 37.015625 41.984375 42.703125 \nQ 37.796875 48.390625 30.609375 48.390625 \nz\nM 30.609375 56 \nQ 42.328125 56 49.015625 48.375 \nQ 55.71875 40.765625 55.71875 27.296875 \nQ 55.71875 13.875 49.015625 6.21875 \nQ 42.328125 -1.421875 30.609375 -1.421875 \nQ 18.84375 -1.421875 12.171875 6.21875 \nQ 5.515625 13.875 5.515625 27.296875 \nQ 5.515625 40.765625 12.171875 48.375 \nQ 18.84375 56 30.609375 56 \nz\n\" id=\"DejaVuSans-111\"/>\n      <path d=\"M 48.78125 52.59375 \nL 48.78125 44.1875 \nQ 44.96875 46.296875 41.140625 47.34375 \nQ 37.3125 48.390625 33.40625 48.390625 \nQ 24.65625 48.390625 19.8125 42.84375 \nQ 14.984375 37.3125 14.984375 27.296875 \nQ 14.984375 17.28125 19.8125 11.734375 \nQ 24.65625 6.203125 33.40625 6.203125 \nQ 37.3125 6.203125 41.140625 7.25 \nQ 44.96875 8.296875 48.78125 10.40625 \nL 48.78125 2.09375 \nQ 45.015625 0.34375 40.984375 -0.53125 \nQ 36.96875 -1.421875 32.421875 -1.421875 \nQ 20.0625 -1.421875 12.78125 6.34375 \nQ 5.515625 14.109375 5.515625 27.296875 \nQ 5.515625 40.671875 12.859375 48.328125 \nQ 20.21875 56 33.015625 56 \nQ 37.15625 56 41.109375 55.140625 \nQ 45.0625 54.296875 48.78125 52.59375 \nz\n\" id=\"DejaVuSans-99\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 75.984375 \nL 18.109375 75.984375 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-104\"/>\n     </defs>\n     <g transform=\"translate(112.525 175.175781)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"61.523438\" xlink:href=\"#DejaVuSans-112\"/>\n      <use x=\"125\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"186.181641\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"241.162109\" xlink:href=\"#DejaVuSans-104\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_15\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 146.899219 \nL 225.403125 146.899219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_16\">\n      <defs>\n       <path d=\"M 0 0 \nL -3.5 0 \n\" id=\"m2f55b0d2a4\" style=\"stroke:#000000;stroke-width:0.8;\"/>\n      </defs>\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#m2f55b0d2a4\" y=\"146.899219\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 0.0 -->\n      <g transform=\"translate(7.2 150.698437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_17\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 119.719219 \nL 225.403125 119.719219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_18\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#m2f55b0d2a4\" y=\"119.719219\"/>\n      </g>\n     </g>\n     <g id=\"text_10\">\n      <!-- 0.2 -->\n      <g transform=\"translate(7.2 123.518437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-50\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_19\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 92.539219 \nL 225.403125 92.539219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_20\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#m2f55b0d2a4\" y=\"92.539219\"/>\n      </g>\n     </g>\n     <g id=\"text_11\">\n      <!-- 0.4 -->\n      <g transform=\"translate(7.2 96.338437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-52\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_4\">\n     <g id=\"line2d_21\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 65.359219 \nL 225.403125 65.359219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_22\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#m2f55b0d2a4\" y=\"65.359219\"/>\n      </g>\n     </g>\n     <g id=\"text_12\">\n      <!-- 0.6 -->\n      <defs>\n       <path d=\"M 33.015625 40.375 \nQ 26.375 40.375 22.484375 35.828125 \nQ 18.609375 31.296875 18.609375 23.390625 \nQ 18.609375 15.53125 22.484375 10.953125 \nQ 26.375 6.390625 33.015625 6.390625 \nQ 39.65625 6.390625 43.53125 10.953125 \nQ 47.40625 15.53125 47.40625 23.390625 \nQ 47.40625 31.296875 43.53125 35.828125 \nQ 39.65625 40.375 33.015625 40.375 \nz\nM 52.59375 71.296875 \nL 52.59375 62.3125 \nQ 48.875 64.0625 45.09375 64.984375 \nQ 41.3125 65.921875 37.59375 65.921875 \nQ 27.828125 65.921875 22.671875 59.328125 \nQ 17.53125 52.734375 16.796875 39.40625 \nQ 19.671875 43.65625 24.015625 45.921875 \nQ 28.375 48.1875 33.59375 48.1875 \nQ 44.578125 48.1875 50.953125 41.515625 \nQ 57.328125 34.859375 57.328125 23.390625 \nQ 57.328125 12.15625 50.6875 5.359375 \nQ 44.046875 -1.421875 33.015625 -1.421875 \nQ 20.359375 -1.421875 13.671875 8.265625 \nQ 6.984375 17.96875 6.984375 36.375 \nQ 6.984375 53.65625 15.1875 63.9375 \nQ 23.390625 74.21875 37.203125 74.21875 \nQ 40.921875 74.21875 44.703125 73.484375 \nQ 48.484375 72.75 52.59375 71.296875 \nz\n\" id=\"DejaVuSans-54\"/>\n      </defs>\n      <g transform=\"translate(7.2 69.158437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-54\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_5\">\n     <g id=\"line2d_23\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 38.179219 \nL 225.403125 38.179219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_24\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#m2f55b0d2a4\" y=\"38.179219\"/>\n      </g>\n     </g>\n     <g id=\"text_13\">\n      <!-- 0.8 -->\n      <defs>\n       <path d=\"M 31.78125 34.625 \nQ 24.75 34.625 20.71875 30.859375 \nQ 16.703125 27.09375 16.703125 20.515625 \nQ 16.703125 13.921875 20.71875 10.15625 \nQ 24.75 6.390625 31.78125 6.390625 \nQ 38.8125 6.390625 42.859375 10.171875 \nQ 46.921875 13.96875 46.921875 20.515625 \nQ 46.921875 27.09375 42.890625 30.859375 \nQ 38.875 34.625 31.78125 34.625 \nz\nM 21.921875 38.8125 \nQ 15.578125 40.375 12.03125 44.71875 \nQ 8.5 49.078125 8.5 55.328125 \nQ 8.5 64.0625 14.71875 69.140625 \nQ 20.953125 74.21875 31.78125 74.21875 \nQ 42.671875 74.21875 48.875 69.140625 \nQ 55.078125 64.0625 55.078125 55.328125 \nQ 55.078125 49.078125 51.53125 44.71875 \nQ 48 40.375 41.703125 38.8125 \nQ 48.828125 37.15625 52.796875 32.3125 \nQ 56.78125 27.484375 56.78125 20.515625 \nQ 56.78125 9.90625 50.3125 4.234375 \nQ 43.84375 -1.421875 31.78125 -1.421875 \nQ 19.734375 -1.421875 13.25 4.234375 \nQ 6.78125 9.90625 6.78125 20.515625 \nQ 6.78125 27.484375 10.78125 32.3125 \nQ 14.796875 37.15625 21.921875 38.8125 \nz\nM 18.3125 54.390625 \nQ 18.3125 48.734375 21.84375 45.5625 \nQ 25.390625 42.390625 31.78125 42.390625 \nQ 38.140625 42.390625 41.71875 45.5625 \nQ 45.3125 48.734375 45.3125 54.390625 \nQ 45.3125 60.0625 41.71875 63.234375 \nQ 38.140625 66.40625 31.78125 66.40625 \nQ 25.390625 66.40625 21.84375 63.234375 \nQ 18.3125 60.0625 18.3125 54.390625 \nz\n\" id=\"DejaVuSans-56\"/>\n      </defs>\n      <g transform=\"translate(7.2 41.978437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-48\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-56\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_6\">\n     <g id=\"line2d_25\">\n      <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 10.999219 \nL 225.403125 10.999219 \n\" style=\"fill:none;stroke:#b0b0b0;stroke-linecap:square;stroke-width:0.8;\"/>\n     </g>\n     <g id=\"line2d_26\">\n      <g>\n       <use style=\"stroke:#000000;stroke-width:0.8;\" x=\"30.103125\" xlink:href=\"#m2f55b0d2a4\" y=\"10.999219\"/>\n      </g>\n     </g>\n     <g id=\"text_14\">\n      <!-- 1.0 -->\n      <g transform=\"translate(7.2 14.798437)scale(0.1 -0.1)\">\n       <use xlink:href=\"#DejaVuSans-49\"/>\n       <use x=\"63.623047\" xlink:href=\"#DejaVuSans-46\"/>\n       <use x=\"95.410156\" xlink:href=\"#DejaVuSans-48\"/>\n      </g>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_27\">\n    <path clip-path=\"url(#p6c06884a66)\" d=\"M -1 26.817797 \nL 4.044924 28.15165 \nL 17.058857 30.271608 \nL 30.072789 32.036614 \nL 30.103125 32.043556 \nL 43.117058 44.820878 \nL 56.130991 44.68202 \nL 69.144924 45.238268 \nL 82.158857 45.812355 \nL 95.172789 46.371742 \nL 95.203125 46.370703 \nL 108.217058 54.264136 \nL 121.230991 54.230707 \nL 134.244924 54.209106 \nL 147.258857 54.450177 \nL 160.272789 54.65182 \nL 160.303125 54.655557 \nL 173.317058 60.094602 \nL 186.330991 60.156103 \nL 199.344924 60.507151 \nL 212.358857 60.403079 \nL 225.372789 60.460935 \nL 225.403125 60.461652 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"line2d_28\">\n    <path clip-path=\"url(#p6c06884a66)\" d=\"M -1 66.817309 \nL 4.044924 65.974719 \nL 17.058857 64.67665 \nL 30.072789 63.508017 \nL 30.103125 63.503704 \nL 43.117058 55.369905 \nL 56.130991 55.39651 \nL 69.144924 55.084883 \nL 82.158857 54.733555 \nL 95.172789 54.375998 \nL 95.203125 54.373812 \nL 108.217058 49.948705 \nL 121.230991 49.947468 \nL 134.244924 49.941281 \nL 147.258857 49.754119 \nL 160.272789 49.654196 \nL 160.303125 49.653143 \nL 173.317058 47.138492 \nL 186.330991 47.044447 \nL 199.344924 46.909566 \nL 212.358857 46.938027 \nL 225.372789 46.843735 \nL 225.403125 46.843203 \n\" style=\"fill:none;stroke:#bf00bf;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"line2d_29\">\n    <path clip-path=\"url(#p6c06884a66)\" d=\"M 30.103125 55.94416 \nL 95.203125 51.323781 \nL 160.303125 48.197417 \nL 225.403125 46.316065 \n\" style=\"fill:none;stroke:#008000;stroke-dasharray:9.6,2.4,1.5,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 30.103125 146.899219 \nL 30.103125 10.999219 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 225.403125 146.899219 \nL 225.403125 10.999219 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 30.103125 146.899219 \nL 225.403125 146.899219 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 30.103125 10.999219 \nL 225.403125 10.999219 \n\" style=\"fill:none;stroke:#000000;stroke-linecap:square;stroke-linejoin:miter;stroke-width:0.8;\"/>\n   </g>\n   <g id=\"legend_1\">\n    <g id=\"patch_7\">\n     <path d=\"M 37.103125 141.899219 \nL 114.871875 141.899219 \nQ 116.871875 141.899219 116.871875 139.899219 \nL 116.871875 96.864844 \nQ 116.871875 94.864844 114.871875 94.864844 \nL 37.103125 94.864844 \nQ 35.103125 94.864844 35.103125 96.864844 \nL 35.103125 139.899219 \nQ 35.103125 141.899219 37.103125 141.899219 \nz\n\" style=\"fill:#ffffff;opacity:0.8;stroke:#cccccc;stroke-linejoin:miter;\"/>\n    </g>\n    <g id=\"line2d_30\">\n     <path d=\"M 39.103125 102.963281 \nL 59.103125 102.963281 \n\" style=\"fill:none;stroke:#1f77b4;stroke-linecap:square;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_31\"/>\n    <g id=\"text_15\">\n     <!-- train loss -->\n     <defs>\n      <path d=\"M 18.3125 70.21875 \nL 18.3125 54.6875 \nL 36.8125 54.6875 \nL 36.8125 47.703125 \nL 18.3125 47.703125 \nL 18.3125 18.015625 \nQ 18.3125 11.328125 20.140625 9.421875 \nQ 21.96875 7.515625 27.59375 7.515625 \nL 36.8125 7.515625 \nL 36.8125 0 \nL 27.59375 0 \nQ 17.1875 0 13.234375 3.875 \nQ 9.28125 7.765625 9.28125 18.015625 \nL 9.28125 47.703125 \nL 2.6875 47.703125 \nL 2.6875 54.6875 \nL 9.28125 54.6875 \nL 9.28125 70.21875 \nz\n\" id=\"DejaVuSans-116\"/>\n      <path d=\"M 41.109375 46.296875 \nQ 39.59375 47.171875 37.8125 47.578125 \nQ 36.03125 48 33.890625 48 \nQ 26.265625 48 22.1875 43.046875 \nQ 18.109375 38.09375 18.109375 28.8125 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 20.953125 51.171875 25.484375 53.578125 \nQ 30.03125 56 36.53125 56 \nQ 37.453125 56 38.578125 55.875 \nQ 39.703125 55.765625 41.0625 55.515625 \nz\n\" id=\"DejaVuSans-114\"/>\n      <path d=\"M 34.28125 27.484375 \nQ 23.390625 27.484375 19.1875 25 \nQ 14.984375 22.515625 14.984375 16.5 \nQ 14.984375 11.71875 18.140625 8.90625 \nQ 21.296875 6.109375 26.703125 6.109375 \nQ 34.1875 6.109375 38.703125 11.40625 \nQ 43.21875 16.703125 43.21875 25.484375 \nL 43.21875 27.484375 \nz\nM 52.203125 31.203125 \nL 52.203125 0 \nL 43.21875 0 \nL 43.21875 8.296875 \nQ 40.140625 3.328125 35.546875 0.953125 \nQ 30.953125 -1.421875 24.3125 -1.421875 \nQ 15.921875 -1.421875 10.953125 3.296875 \nQ 6 8.015625 6 15.921875 \nQ 6 25.140625 12.171875 29.828125 \nQ 18.359375 34.515625 30.609375 34.515625 \nL 43.21875 34.515625 \nL 43.21875 35.40625 \nQ 43.21875 41.609375 39.140625 45 \nQ 35.0625 48.390625 27.6875 48.390625 \nQ 23 48.390625 18.546875 47.265625 \nQ 14.109375 46.140625 10.015625 43.890625 \nL 10.015625 52.203125 \nQ 14.9375 54.109375 19.578125 55.046875 \nQ 24.21875 56 28.609375 56 \nQ 40.484375 56 46.34375 49.84375 \nQ 52.203125 43.703125 52.203125 31.203125 \nz\n\" id=\"DejaVuSans-97\"/>\n      <path d=\"M 9.421875 54.6875 \nL 18.40625 54.6875 \nL 18.40625 0 \nL 9.421875 0 \nz\nM 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 64.59375 \nL 9.421875 64.59375 \nz\n\" id=\"DejaVuSans-105\"/>\n      <path d=\"M 54.890625 33.015625 \nL 54.890625 0 \nL 45.90625 0 \nL 45.90625 32.71875 \nQ 45.90625 40.484375 42.875 44.328125 \nQ 39.84375 48.1875 33.796875 48.1875 \nQ 26.515625 48.1875 22.3125 43.546875 \nQ 18.109375 38.921875 18.109375 30.90625 \nL 18.109375 0 \nL 9.078125 0 \nL 9.078125 54.6875 \nL 18.109375 54.6875 \nL 18.109375 46.1875 \nQ 21.34375 51.125 25.703125 53.5625 \nQ 30.078125 56 35.796875 56 \nQ 45.21875 56 50.046875 50.171875 \nQ 54.890625 44.34375 54.890625 33.015625 \nz\n\" id=\"DejaVuSans-110\"/>\n      <path id=\"DejaVuSans-32\"/>\n      <path d=\"M 9.421875 75.984375 \nL 18.40625 75.984375 \nL 18.40625 0 \nL 9.421875 0 \nz\n\" id=\"DejaVuSans-108\"/>\n      <path d=\"M 44.28125 53.078125 \nL 44.28125 44.578125 \nQ 40.484375 46.53125 36.375 47.5 \nQ 32.28125 48.484375 27.875 48.484375 \nQ 21.1875 48.484375 17.84375 46.4375 \nQ 14.5 44.390625 14.5 40.28125 \nQ 14.5 37.15625 16.890625 35.375 \nQ 19.28125 33.59375 26.515625 31.984375 \nL 29.59375 31.296875 \nQ 39.15625 29.25 43.1875 25.515625 \nQ 47.21875 21.78125 47.21875 15.09375 \nQ 47.21875 7.46875 41.1875 3.015625 \nQ 35.15625 -1.421875 24.609375 -1.421875 \nQ 20.21875 -1.421875 15.453125 -0.5625 \nQ 10.6875 0.296875 5.421875 2 \nL 5.421875 11.28125 \nQ 10.40625 8.6875 15.234375 7.390625 \nQ 20.0625 6.109375 24.8125 6.109375 \nQ 31.15625 6.109375 34.5625 8.28125 \nQ 37.984375 10.453125 37.984375 14.40625 \nQ 37.984375 18.0625 35.515625 20.015625 \nQ 33.0625 21.96875 24.703125 23.78125 \nL 21.578125 24.515625 \nQ 13.234375 26.265625 9.515625 29.90625 \nQ 5.8125 33.546875 5.8125 39.890625 \nQ 5.8125 47.609375 11.28125 51.796875 \nQ 16.75 56 26.8125 56 \nQ 31.78125 56 36.171875 55.265625 \nQ 40.578125 54.546875 44.28125 53.078125 \nz\n\" id=\"DejaVuSans-115\"/>\n     </defs>\n     <g transform=\"translate(67.103125 106.463281)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"80.322266\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"141.601562\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"169.384766\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"232.763672\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"264.550781\" xlink:href=\"#DejaVuSans-108\"/>\n      <use x=\"292.333984\" xlink:href=\"#DejaVuSans-111\"/>\n      <use x=\"353.515625\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"405.615234\" xlink:href=\"#DejaVuSans-115\"/>\n     </g>\n    </g>\n    <g id=\"line2d_32\">\n     <path d=\"M 39.103125 117.641406 \nL 59.103125 117.641406 \n\" style=\"fill:none;stroke:#bf00bf;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_33\"/>\n    <g id=\"text_16\">\n     <!-- train acc -->\n     <g transform=\"translate(67.103125 121.141406)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-114\"/>\n      <use x=\"80.322266\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"141.601562\" xlink:href=\"#DejaVuSans-105\"/>\n      <use x=\"169.384766\" xlink:href=\"#DejaVuSans-110\"/>\n      <use x=\"232.763672\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"264.550781\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"325.830078\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"380.810547\" xlink:href=\"#DejaVuSans-99\"/>\n     </g>\n    </g>\n    <g id=\"line2d_34\">\n     <path d=\"M 39.103125 132.319531 \nL 59.103125 132.319531 \n\" style=\"fill:none;stroke:#008000;stroke-dasharray:9.6,2.4,1.5,2.4;stroke-dashoffset:0;stroke-width:1.5;\"/>\n    </g>\n    <g id=\"line2d_35\"/>\n    <g id=\"text_17\">\n     <!-- test acc -->\n     <g transform=\"translate(67.103125 135.819531)scale(0.1 -0.1)\">\n      <use xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"39.208984\" xlink:href=\"#DejaVuSans-101\"/>\n      <use x=\"100.732422\" xlink:href=\"#DejaVuSans-115\"/>\n      <use x=\"152.832031\" xlink:href=\"#DejaVuSans-116\"/>\n      <use x=\"192.041016\" xlink:href=\"#DejaVuSans-32\"/>\n      <use x=\"223.828125\" xlink:href=\"#DejaVuSans-97\"/>\n      <use x=\"285.107422\" xlink:href=\"#DejaVuSans-99\"/>\n      <use x=\"340.087891\" xlink:href=\"#DejaVuSans-99\"/>\n     </g>\n    </g>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p6c06884a66\">\n   <rect height=\"135.9\" width=\"195.3\" x=\"30.103125\" y=\"10.999219\"/>\n  </clipPath>\n </defs>\n</svg>\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.7"
+    },
+    "varInspector": {
+      "cols": {
+        "lenName": 16,
+        "lenType": 16,
+        "lenVar": 40
+      },
+      "kernels_config": {
+        "python": {
+          "delete_cmd_postfix": "",
+          "delete_cmd_prefix": "del ",
+          "library": "var_list.py",
+          "varRefreshCmd": "print(var_dic_list())"
+        },
+        "r": {
+          "delete_cmd_postfix": ") ",
+          "delete_cmd_prefix": "rm(",
+          "library": "var_list.r",
+          "varRefreshCmd": "cat(var_dic_list()) "
+        }
+      },
+      "types_to_exclude": [
+        "module",
+        "function",
+        "builtin_function_or_method",
+        "instance",
+        "_Feature"
+      ],
+      "window_display": false
+    },
+    "colab": {
+      "name": "bert_jax.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "include_colab_link": true
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description

Converted `bert_torch.ipynb` to `bert_jax.ipynb`

### Colab link

https://colab.research.google.com/github/codeboy5/probml-notebooks/blob/add-bert-jax/notebooks-d2l/bert_jax.ipynb

### Issue 

[convert pytorch d2l.ai demos to JAX](https://github.com/probml/pyprobml/issues/686)

## Checklist:

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

## Potential problems/Important remarks

<!-- If you have any important remarks for the reviewers to look at closer,  you can write them in detail here.  -->

Some of the code has been imported directly from `transformers_jax.ipynb`. Major changes are made due to differences with bert model and the requirement to load pre-trained weights from torch.

Can you review this code ? @gerdm @murphyk 