### PR TITLE
Put back `layer_norm_jax.ipynb`

### DIFF
--- a/notebooks/layer_norm_jax.ipynb
+++ b/notebooks/layer_norm_jax.ipynb
@@ -1,0 +1,155 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "layer-norm-jax.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q flax"
+      ],
+      "metadata": {
+        "id": "b_qFXPuEPCKk",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "0fe29674-af5e-4277-9681-dce06ea569d9"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[?25l\r\u001b[K     |█▉                              | 10 kB 23.8 MB/s eta 0:00:01\r\u001b[K     |███▋                            | 20 kB 24.2 MB/s eta 0:00:01\r\u001b[K     |█████▍                          | 30 kB 12.5 MB/s eta 0:00:01\r\u001b[K     |███████▏                        | 40 kB 10.4 MB/s eta 0:00:01\r\u001b[K     |█████████                       | 51 kB 4.5 MB/s eta 0:00:01\r\u001b[K     |██████████▊                     | 61 kB 5.4 MB/s eta 0:00:01\r\u001b[K     |████████████▌                   | 71 kB 6.0 MB/s eta 0:00:01\r\u001b[K     |██████████████▎                 | 81 kB 4.3 MB/s eta 0:00:01\r\u001b[K     |████████████████                | 92 kB 4.8 MB/s eta 0:00:01\r\u001b[K     |█████████████████▉              | 102 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |███████████████████▋            | 112 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▍          | 122 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |███████████████████████▏        | 133 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████       | 143 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▊     | 153 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▌   | 163 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▎ | 174 kB 5.3 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 184 kB 5.3 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 140 kB 64.5 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 72 kB 646 kB/s \n",
+            "\u001b[?25h"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pxxCjM4AIsZP"
+      },
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "from flax import linen as nn"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OcFY2bZeImQI",
+        "outputId": "88ca947c-d827-49b5-bc72-af544642a046"
+      },
+      "source": [
+        "# batch size 3, feature size 2\n",
+        "np.random.seed(42)\n",
+        "X = np.random.normal(size=(2, 3))\n",
+        "\n",
+        "print('batch norm')\n",
+        "mu_batch = np.mean(X, axis=0)\n",
+        "sigma_batch = np.std(X, axis=0)\n",
+        "XBN = (X-mu_batch)/sigma_batch\n",
+        "print(XBN)\n",
+        "\n",
+        "print('layer norm')\n",
+        "mu_layer = np.expand_dims(np.mean(X, axis=1), axis=1)\n",
+        "sigma_layer = np.expand_dims(np.std(X, axis=1), axis=1)\n",
+        "XLN = (X-mu_layer)/sigma_layer\n",
+        "print(XLN)"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "batch norm\n",
+            "[[-1.  1.  1.]\n",
+            " [ 1. -1. -1.]]\n",
+            "layer norm\n",
+            "[[ 0.47376014 -1.39085732  0.91709718]\n",
+            " [ 1.41421356 -0.70711669 -0.70709687]]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "6p9f1kSyJbuT",
+        "outputId": "e69ec5a1-b554-4d20-8f4d-a95665437165"
+      },
+      "source": [
+        "X = jnp.float32(X)\n",
+        "\n",
+        "rng = jax.random.PRNGKey(42)\n",
+        "bn_rng, ln_rng = jax.random.split(rng)\n",
+        "\n",
+        "print('batch norm')\n",
+        "bn = nn.BatchNorm(use_running_average=False, epsilon=1e-6)\n",
+        "bn_params = bn.init(bn_rng, X)\n",
+        "XBN_t, _ = bn.apply(bn_params, X, mutable=['batch_stats'])\n",
+        "print(XBN_t)\n",
+        "assert(np.allclose(np.array(XBN_t), XBN, atol=1e-3))\n",
+        "\n",
+        "print('layer norm')\n",
+        "ln = nn.LayerNorm()\n",
+        "ln_params = ln.init(ln_rng, X)\n",
+        "XLN_t = ln.apply(ln_params, X)\n",
+        "print(XLN_t)\n",
+        "assert(np.allclose(np.array(XLN_t), XLN, atol=1e-3))"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "batch norm\n",
+            "[[-0.99999815  0.99978346  0.99999744]\n",
+            " [ 0.99999815 -0.9997831  -0.9999975 ]]\n",
+            "layer norm\n",
+            "[[ 0.473758   -1.3908514   0.9170933 ]\n",
+            " [ 1.4142125  -0.70711625 -0.7070964 ]]\n"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

<!-- Please refer to https://github.com/probml/pyprobml/blob/master/CONTRIBUTING.md before opening this PR -->

### Colab link

https://colab.research.google.com/drive/1GxljkZPiJF4fDDExrzyaTIxXATDl4byF?usp=sharing

### Issue 

<!-- Link the issue you are solving -->

<!-- If the issue is from this repo, include directly with issue number -->
<!-- For example: 

#12

-->

<!-- If the issue is from another repo, you can include it using the regular linking mechanism -->
<!-- For example:


-->

https://github.com/probml/probml-notebooks/pull/56
https://github.com/probml/probml-notebooks/pull/58
https://github.com/probml/pyprobml/issues/718
https://github.com/probml/pyprobml/issues/745

## Checklist:

- [X] Performed a self-review of the code
- [X] Tested on Google Colab.

## Potential problems/Important remarks

This file was originally added in https://github.com/probml/probml-notebooks/pull/56 to address https://github.com/probml/pyprobml/issues/718, but it was accidentally removed in https://github.com/probml/probml-notebooks/pull/58. It was brought to our attention again in https://github.com/probml/pyprobml/issues/745, which prompts this PR to put it back.

Tangentially, I cleaned up the notebook a little bit by fixing the filename and removing the unnecessary `import`s.