### PR TITLE
Add `text_preproc_jax.ipynb`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__
 develop-eggs/ 
 dist/ 
 downloads/ 
+data/
 eggs/ 
 .eggs/ 
 lib/ 

--- a/notebooks/text_preproc_jax.ipynb
+++ b/notebooks/text_preproc_jax.ipynb
@@ -1,0 +1,1447 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/text_preproc_jax.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Yn51eYujm5S1"
+   },
+   "source": [
+    "# Text preprocessing\n",
+    "\n",
+    "We discuss how to convert a sequence of words or characters into numeric form, which can then be fed into an ML model.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "ysx0t0REm4r0"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import math\n",
+    "\n",
+    "import torch\n",
+    "from torch.utils import data\n",
+    "\n",
+    "if not os.path.exists(\"figures\"):\n",
+    "    os.makedirs(\"figures\")  # for saving plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "V6Jbluorndzr"
+   },
+   "outputs": [],
+   "source": [
+    "import collections\n",
+    "import re\n",
+    "import random\n",
+    "import os\n",
+    "import requests\n",
+    "import zipfile\n",
+    "import hashlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Required functions for downloading data\n",
+    "\n",
+    "def download(name, cache_dir=os.path.join('..', 'data')):\n",
+    "    \"\"\"Download a file inserted into DATA_HUB, return the local filename.\"\"\"\n",
+    "    assert name in DATA_HUB, f\"{name} does not exist in {DATA_HUB}.\"\n",
+    "    url, sha1_hash = DATA_HUB[name]\n",
+    "    os.makedirs(cache_dir, exist_ok=True)\n",
+    "    fname = os.path.join(cache_dir, url.split('/')[-1])\n",
+    "    if os.path.exists(fname):\n",
+    "        sha1 = hashlib.sha1()\n",
+    "        with open(fname, 'rb') as f:\n",
+    "            while True:\n",
+    "                data = f.read(1048576)\n",
+    "                if not data:\n",
+    "                    break\n",
+    "                sha1.update(data)\n",
+    "        if sha1.hexdigest() == sha1_hash:\n",
+    "            return fname  # Hit cache\n",
+    "    print(f'Downloading {fname} from {url}...')\n",
+    "    r = requests.get(url, stream=True, verify=True)\n",
+    "    with open(fname, 'wb') as f:\n",
+    "        f.write(r.content)\n",
+    "    return fname\n",
+    "\n",
+    "def download_extract(name, folder=None):\n",
+    "    \"\"\"Download and extract a zip/tar file.\"\"\"\n",
+    "    fname = download(name)\n",
+    "    base_dir = os.path.dirname(fname)\n",
+    "    data_dir, ext = os.path.splitext(fname)\n",
+    "    if ext == '.zip':\n",
+    "        fp = zipfile.ZipFile(fname, 'r')\n",
+    "    elif ext in ('.tar', '.gz'):\n",
+    "        fp = tarfile.open(fname, 'r')\n",
+    "    else:\n",
+    "        assert False, 'Only zip/tar files can be extracted.'\n",
+    "    fp.extractall(base_dir)\n",
+    "    return os.path.join(base_dir, folder) if folder else data_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e9vbpUMwTRY1"
+   },
+   "source": [
+    "# Basics\n",
+    "\n",
+    "This section is based on sec 8.2 of http://d2l.ai/chapter_recurrent-neural-networks/text-preprocessing.html\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RMrGxkRNnOx_"
+   },
+   "source": [
+    "## Data\n",
+    "\n",
+    "As a simple example, we use the book \"The Time Machine\" by H G Wells, since it is short (30k words) and public domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "D7OJT7o8nDQN",
+    "outputId": "2dd7e687-6b9a-48d2-ab49-e1bb5b64d41b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number of lines: 3221\n"
+     ]
+    }
+   ],
+   "source": [
+    "DATA_HUB = dict()\n",
+    "DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'\n",
+    "\n",
+    "DATA_HUB['time_machine'] = (DATA_URL + 'timemachine.txt',\n",
+    "                                '090b5e7e70c295757f55df93cb0a180b9691891a')\n",
+    "\n",
+    "def read_time_machine():  \n",
+    "    \"\"\"Load the time machine dataset into a list of text lines.\"\"\"\n",
+    "    with open(download('time_machine'), 'r') as f:\n",
+    "        lines = f.readlines()\n",
+    "    return [re.sub('[^A-Za-z]+', ' ', line).strip().lower() for line in lines]\n",
+    "\n",
+    "lines = read_time_machine()\n",
+    "print(f'number of lines: {len(lines)}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "uCsuaurvnlK8",
+    "outputId": "8dcf484e-8f45-4748-cc93-c2a2ada427d2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 the time machine by h g wells\n",
+      "1 \n",
+      "2 \n",
+      "3 \n",
+      "4 \n",
+      "5 i\n",
+      "6 \n",
+      "7 \n",
+      "8 the time traveller for so it will be convenient to speak of him\n",
+      "9 was expounding a recondite matter to us his grey eyes shone and\n",
+      "10 twinkled and his usually pale face was flushed and animated the\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(11):\n",
+    "  print(i, lines[i])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "btVyl4dItGVT",
+    "outputId": "6b67aec4-4c26-43f7-ea6e-0c7fd1440f55"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total num characters  170580\n",
+      "total num words  32775\n"
+     ]
+    }
+   ],
+   "source": [
+    "nchars = 0\n",
+    "nwords = 0\n",
+    "for i in range(len(lines)):\n",
+    "  nchars += len(lines[i])\n",
+    "  words = lines[i].split()\n",
+    "  nwords += len(words)\n",
+    "print('total num characters ', nchars)\n",
+    "print('total num words ', nwords)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KKBbwDcKnwsA"
+   },
+   "source": [
+    "## Tokenization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "X32lM-XvnxhC",
+    "outputId": "4783ff38-b282-4b0e-fc59-996f6ec0d6a6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['the', 'time', 'machine', 'by', 'h', 'g', 'wells']\n",
+      "[]\n",
+      "[]\n",
+      "[]\n",
+      "[]\n",
+      "['i']\n",
+      "[]\n",
+      "[]\n",
+      "['the', 'time', 'traveller', 'for', 'so', 'it', 'will', 'be', 'convenient', 'to', 'speak', 'of', 'him']\n",
+      "['was', 'expounding', 'a', 'recondite', 'matter', 'to', 'us', 'his', 'grey', 'eyes', 'shone', 'and']\n",
+      "['twinkled', 'and', 'his', 'usually', 'pale', 'face', 'was', 'flushed', 'and', 'animated', 'the']\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tokenize(lines, token='word'):  \n",
+    "    \"\"\"Split text lines into word or character tokens.\"\"\"\n",
+    "    if token == 'word':\n",
+    "        return [line.split() for line in lines]\n",
+    "    elif token == 'char':\n",
+    "        return [list(line) for line in lines]\n",
+    "    else:\n",
+    "        print('ERROR: unknown token type: ' + token)\n",
+    "\n",
+    "tokens = tokenize(lines)\n",
+    "for i in range(11):\n",
+    "    print(tokens[i])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X-Tbg9jjn8XN"
+   },
+   "source": [
+    "## Vocabulary\n",
+    "\n",
+    "We map each word to a unique integer id, sorted by decreasing frequency.\n",
+    "We reserve the special id of 0 for the \"unknown word\".\n",
+    "We also allow for a list of reserved tokens, such as “pad\" for padding, \"bos\" to present the beginning for a sequence, and “eos” for the end of a sequence.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "8ZOLrVNon9dk"
+   },
+   "outputs": [],
+   "source": [
+    "class Vocab:  \n",
+    "    \"\"\"Vocabulary for text.\"\"\"\n",
+    "    def __init__(self, tokens=None, min_freq=0, reserved_tokens=None):\n",
+    "        if tokens is None:\n",
+    "            tokens = []\n",
+    "        if reserved_tokens is None:\n",
+    "            reserved_tokens = []\n",
+    "        # Sort according to frequencies\n",
+    "        counter = count_corpus(tokens)\n",
+    "        self.token_freqs = sorted(counter.items(), key=lambda x: x[1],\n",
+    "                                  reverse=True)\n",
+    "        # The index for the unknown token is 0\n",
+    "        self.unk, uniq_tokens = 0, ['<unk>'] + reserved_tokens\n",
+    "        uniq_tokens += [\n",
+    "            token for token, freq in self.token_freqs\n",
+    "            if freq >= min_freq and token not in uniq_tokens]\n",
+    "        self.idx_to_token, self.token_to_idx = [], dict()\n",
+    "        for token in uniq_tokens:\n",
+    "            self.idx_to_token.append(token)\n",
+    "            self.token_to_idx[token] = len(self.idx_to_token) - 1\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return len(self.idx_to_token)\n",
+    "\n",
+    "    def __getitem__(self, tokens):\n",
+    "        if not isinstance(tokens, (list, tuple)):\n",
+    "            return self.token_to_idx.get(tokens, self.unk)\n",
+    "        return [self.__getitem__(token) for token in tokens]\n",
+    "\n",
+    "    def to_tokens(self, indices):\n",
+    "        if not isinstance(indices, (list, tuple)):\n",
+    "            return self.idx_to_token[indices]\n",
+    "        return [self.idx_to_token[index] for index in indices]\n",
+    "\n",
+    "def count_corpus(tokens):  \n",
+    "    \"\"\"Count token frequencies.\"\"\"\n",
+    "    # Here `tokens` is a 1D list or 2D list\n",
+    "    if len(tokens) == 0 or isinstance(tokens[0], list):\n",
+    "        # Flatten a list of token lists into a list of tokens\n",
+    "        tokens = [token for line in tokens for token in line]\n",
+    "    return collections.Counter(tokens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "CV0rTlaqoSNE"
+   },
+   "source": [
+    "Here are the top 10 words (and their codes) in our corpus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "tYmbCwY6oUFB",
+    "outputId": "31a05a85-5113-4db8-aacf-f944f2c576f8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('<unk>', 0), ('the', 1), ('i', 2), ('and', 3), ('of', 4), ('a', 5), ('to', 6), ('was', 7), ('in', 8), ('that', 9)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "vocab = Vocab(tokens)\n",
+    "print(list(vocab.token_to_idx.items())[:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sKXJQdbXoiqT"
+   },
+   "source": [
+    "Here is a tokenization of a few sentences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jd73-1zzoUWo",
+    "outputId": "f2e7dbda-4053-4773-d385-686f6c549144"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "words: ['the', 'time', 'machine', 'by', 'h', 'g', 'wells']\n",
+      "indices: [1, 19, 50, 40, 2183, 2184, 400]\n",
+      "words: ['twinkled', 'and', 'his', 'usually', 'pale', 'face', 'was', 'flushed', 'and', 'animated', 'the']\n",
+      "indices: [2186, 3, 25, 1044, 362, 113, 7, 1421, 3, 1045, 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in [0, 10]:\n",
+    "    print('words:', tokens[i])\n",
+    "    print('indices:', vocab[tokens[i]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-6LsXchMop3u"
+   },
+   "source": [
+    "## Putting it altogether\n",
+    "\n",
+    "We tokenize the corpus at the character level, and return the sequence of integers, as well as the corresponding Vocab object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "1BywQ9iUoq_D"
+   },
+   "outputs": [],
+   "source": [
+    "def load_corpus_time_machine(max_tokens=-1): \n",
+    "    \"\"\"Return token indices and the vocabulary of the time machine dataset.\"\"\"\n",
+    "    lines = read_time_machine()\n",
+    "    tokens = tokenize(lines, 'char')\n",
+    "    vocab = Vocab(tokens)\n",
+    "    # Since each text line in the time machine dataset is not necessarily a\n",
+    "    # sentence or a paragraph, flatten all the text lines into a single list\n",
+    "    corpus = [vocab[token] for line in tokens for token in line]\n",
+    "    if max_tokens > 0:\n",
+    "        corpus = corpus[:max_tokens]\n",
+    "    return corpus, vocab\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "oQzX4Am8osdh",
+    "outputId": "53318718-5dba-4574-8f7d-3de538584c0d"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(170580, 28)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "corpus, vocab = load_corpus_time_machine()\n",
+    "len(corpus), len(vocab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "IgDxt_PRovAb",
+    "outputId": "7aaffeaa-0b08-4796-bce7-e3ef6fe9cc58"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3, 9, 2, 1, 3, 5, 13, 2, 1, 13, 4, 15, 9, 5, 6, 2, 1, 21, 19, 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(corpus[:20])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "egONc6CRowLa",
+    "outputId": "030047c5-7199-4000-9e0c-39ba75275fd6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('<unk>', 0), (' ', 1), ('e', 2), ('t', 3), ('a', 4), ('i', 5), ('n', 6), ('o', 7), ('s', 8), ('h', 9)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(list(vocab.token_to_idx.items())[:10])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9xKwPjAAozaX",
+    "outputId": "68c7959c-7bfe-42a1-f324-b9b4a1a90113"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['t', 'h', 'e', ' ', 't', 'i', 'm', 'e', ' ', 'm', 'a', 'c', 'h', 'i', 'n', 'e', ' ', 'b', 'y', ' ']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print([vocab.idx_to_token[i] for i in corpus[:20]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X3fLUodCZebY"
+   },
+   "source": [
+    "## One-hot encodings\n",
+    "\n",
+    "We can convert a sequence of N integers into a N*V one-hot matrix, where V is the vocabulary size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Qk21iCFhZj89",
+    "outputId": "b5323706-52f8-459b-b382-70acbf54ba26"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3 9 2]\n",
+      "(3, 28)\n",
+      "[[0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "  0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "  0. 0. 0. 0.]\n",
+      " [0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "  0. 0. 0. 0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = jnp.array(corpus[:3])\n",
+    "print(x)\n",
+    "X = jax.nn.one_hot(x, len(vocab))\n",
+    "print(X.shape)\n",
+    "print(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8vO99OOSuYhX"
+   },
+   "source": [
+    "# Language modeling\n",
+    "\n",
+    "When fitting language models, we often need to chop up a long sequence into a set of short sequences, which may be overlapping, as shown below, where we extract subsequences of length $n=5$. \n",
+    "\n",
+    "<img src=\"https://github.com/probml/pyprobml/blob/master/images/timemachine-5gram.png?raw=true\">\n",
+    "\n",
+    "Below we show how to do this.\n",
+    "\n",
+    "This section is based on sec 8.3.4 of\n",
+    "http://d2l.ai/chapter_recurrent-neural-networks/language-models-and-dataset.html#reading-long-sequence-data\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Vert2-4qw5K7"
+   },
+   "source": [
+    "## Random ordering"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_rARqDyZuvlu"
+   },
+   "source": [
+    "To increase variety of the data, we can start the extraction at a random offset. We can thus create a random sequence data iterator, as follows.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "id": "meuw3vkjpL22"
+   },
+   "outputs": [],
+   "source": [
+    "def seq_data_iter_random(corpus, batch_size, num_steps):  \n",
+    "    \"\"\"Generate a minibatch of subsequences using random sampling.\"\"\"\n",
+    "    # Start with a random offset (inclusive of `num_steps - 1`) to partition a\n",
+    "    # sequence\n",
+    "    corpus = corpus[random.randint(0, num_steps - 1):]\n",
+    "    # Subtract 1 since we need to account for labels\n",
+    "    num_subseqs = (len(corpus) - 1) // num_steps\n",
+    "    # The starting indices for subsequences of length `num_steps`\n",
+    "    initial_indices = list(range(0, num_subseqs * num_steps, num_steps))\n",
+    "    # In random sampling, the subsequences from two adjacent random\n",
+    "    # minibatches during iteration are not necessarily adjacent on the\n",
+    "    # original sequence\n",
+    "    random.shuffle(initial_indices)\n",
+    "\n",
+    "    def data(pos):\n",
+    "        # Return a sequence of length `num_steps` starting from `pos`\n",
+    "        return corpus[pos:pos + num_steps]\n",
+    "\n",
+    "    num_batches = num_subseqs // batch_size\n",
+    "    for i in range(0, batch_size * num_batches, batch_size):\n",
+    "        # Here, `initial_indices` contains randomized starting indices for\n",
+    "        # subsequences\n",
+    "        initial_indices_per_batch = initial_indices[i:i + batch_size]\n",
+    "        X = [data(j) for j in initial_indices_per_batch]\n",
+    "        Y = [data(j + 1) for j in initial_indices_per_batch]\n",
+    "        yield jnp.array(X), jnp.array(Y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "71kdus7mvMFQ"
+   },
+   "source": [
+    "For example, let us generate a sequence 0,1,..,34, and then extract subsequences of length 5. Each minibatch will have 2 such subsequences, starting at random offsets. There is no ordering between the subsequences, either within or across minibatches. There are $\\lfloor (35-1)/5 \\rfloor = 6$ such subsequences, so the iterator will generate 3 minibatches, each of size 2.\n",
+    "\n",
+    "For language modeling tasks, we define $X$ to be the first $n-1$ tokens, and $Y$ to be the $n$'th token, which is the one to be predicted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "x8GXyqOgvOI7",
+    "outputId": "efc1667a-624e-461c-a72c-c9d8ac244f81"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "batch:  0\n",
+      "X:  [[18 19 20 21 22]\n",
+      " [ 8  9 10 11 12]] \n",
+      "Y: [[19 20 21 22 23]\n",
+      " [ 9 10 11 12 13]]\n",
+      "batch:  1\n",
+      "X:  [[23 24 25 26 27]\n",
+      " [ 3  4  5  6  7]] \n",
+      "Y: [[24 25 26 27 28]\n",
+      " [ 4  5  6  7  8]]\n",
+      "batch:  2\n",
+      "X:  [[28 29 30 31 32]\n",
+      " [13 14 15 16 17]] \n",
+      "Y: [[29 30 31 32 33]\n",
+      " [14 15 16 17 18]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_seq = list(range(35))\n",
+    "b = 0\n",
+    "for X, Y in seq_data_iter_random(my_seq, batch_size=2, num_steps=5):\n",
+    "    print('batch: ', b)\n",
+    "    print('X: ', X, '\\nY:', Y)\n",
+    "    b += 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wdg490Gow7la"
+   },
+   "source": [
+    "## Sequential ordering"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "55ECVkQLwL8K"
+   },
+   "source": [
+    "We can also require that the $i$'th subsequence in minibatch $b$ follows the $i$'th subsequence in minibatch $b-1$. This is useful when training RNNs, since when the model encounters batch $b$, the hidden state of the model will already be initialized by the last token in sequence $i$ of batch $b-1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "id": "r3uVV7lYwCdv"
+   },
+   "outputs": [],
+   "source": [
+    "def seq_data_iter_sequential(corpus, batch_size, num_steps):  \n",
+    "    \"\"\"Generate a minibatch of subsequences using sequential partitioning.\"\"\"\n",
+    "    # Start with a random offset to partition a sequence\n",
+    "    offset = random.randint(0, num_steps)\n",
+    "    num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size\n",
+    "    Xs = jnp.array(corpus[offset:offset + num_tokens])\n",
+    "    Ys = jnp.array(corpus[offset + 1:offset + 1 + num_tokens])\n",
+    "    Xs, Ys = Xs.reshape(batch_size, -1), Ys.reshape(batch_size, -1)\n",
+    "    num_batches = Xs.shape[1] // num_steps\n",
+    "    for i in range(0, num_steps * num_batches, num_steps):\n",
+    "        X = Xs[:, i:i + num_steps]\n",
+    "        Y = Ys[:, i:i + num_steps]\n",
+    "        yield X, Y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KGRIkFvXwZX6"
+   },
+   "source": [
+    "Below we give an example. We see that the first subsequence in batch 1\n",
+    "is [0,1,2,3,4], and the first subsequence in batch 2 is [5,6,7,8,9], as desired."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "aLQzm2qrwY0m",
+    "outputId": "27a0f0e7-46db-469c-dd1f-906b599be01d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X:  [[ 1  2  3  4  5]\n",
+      " [17 18 19 20 21]] \n",
+      "Y: [[ 2  3  4  5  6]\n",
+      " [18 19 20 21 22]]\n",
+      "X:  [[ 6  7  8  9 10]\n",
+      " [22 23 24 25 26]] \n",
+      "Y: [[ 7  8  9 10 11]\n",
+      " [23 24 25 26 27]]\n",
+      "X:  [[11 12 13 14 15]\n",
+      " [27 28 29 30 31]] \n",
+      "Y: [[12 13 14 15 16]\n",
+      " [28 29 30 31 32]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for X, Y in seq_data_iter_sequential(my_seq, batch_size=2, num_steps=5):\n",
+    "    print('X: ', X, '\\nY:', Y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SP96EBA-w9MF"
+   },
+   "source": [
+    "## Data iterator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_corpus_time_machine(max_tokens=-1):\n",
+    "    \"\"\"Return token indices and the vocabulary of the time machine dataset.\"\"\"\n",
+    "    lines = read_time_machine()\n",
+    "    tokens = tokenize(lines, 'char')\n",
+    "    vocab = Vocab(tokens)\n",
+    "    # Since each text line in the time machine dataset is not necessarily a\n",
+    "    # sentence or a paragraph, flatten all the text lines into a single list\n",
+    "    corpus = [vocab[token] for line in tokens for token in line]\n",
+    "    if max_tokens > 0:\n",
+    "        corpus = corpus[:max_tokens]\n",
+    "    return corpus, vocab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "id": "IpjIv8tMw-QD"
+   },
+   "outputs": [],
+   "source": [
+    "class SeqDataLoader:  #@save\n",
+    "    \"\"\"An iterator to load sequence data.\"\"\"\n",
+    "    def __init__(self, batch_size, num_steps, use_random_iter, max_tokens):\n",
+    "        if use_random_iter:\n",
+    "            self.data_iter_fn = seq_data_iter_random\n",
+    "        else:\n",
+    "            self.data_iter_fn = seq_data_iter_sequential\n",
+    "        self.corpus, self.vocab = load_corpus_time_machine(max_tokens)\n",
+    "        self.batch_size, self.num_steps = batch_size, num_steps\n",
+    "\n",
+    "    def __iter__(self):\n",
+    "        return self.data_iter_fn(self.corpus, self.batch_size, self.num_steps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "id": "pIy_YUk9w-0A"
+   },
+   "outputs": [],
+   "source": [
+    "def load_data_time_machine(batch_size, num_steps,  #@save\n",
+    "                           use_random_iter=False, max_tokens=10000):\n",
+    "    \"\"\"Return the iterator and the vocabulary of the time machine dataset.\"\"\"\n",
+    "    data_iter = SeqDataLoader(batch_size, num_steps, use_random_iter,\n",
+    "                              max_tokens)\n",
+    "    return data_iter, data_iter.vocab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "id": "Y44o8-MkxA3t"
+   },
+   "outputs": [],
+   "source": [
+    "data_iter, vocab = load_data_time_machine(2, 5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "sf-py0roxmAC",
+    "outputId": "66691d42-4905-4fe3-b906-8856e525665b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('<unk>', 0), (' ', 1), ('e', 2), ('t', 3), ('a', 4), ('i', 5), ('n', 6), ('o', 7), ('s', 8), ('h', 9)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(list(vocab.token_to_idx.items())[:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "6XhwWfMHxXTA",
+    "outputId": "a29066f2-d2e2-447c-d290-ea473ecc0ee1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "batch:  0\n",
+      "X:  [[ 3  9  2  1  3]\n",
+      " [15 12 14 11  2]] \n",
+      "Y: [[ 9  2  1  3  5]\n",
+      " [12 14 11  2  1]]\n",
+      "batch:  1\n",
+      "X:  [[ 5 13  2  1 13]\n",
+      " [ 1 17  4  8  1]] \n",
+      "Y: [[13  2  1 13  4]\n",
+      " [17  4  8  1  4]]\n",
+      "batch:  2\n",
+      "X:  [[ 4 15  9  5  6]\n",
+      " [ 4 12  7  6 18]] \n",
+      "Y: [[15  9  5  6  2]\n",
+      " [12  7  6 18  3]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "b = 0\n",
+    "for X, Y in data_iter:\n",
+    "    print('batch: ', b)\n",
+    "    print('X: ', X, '\\nY:', Y)\n",
+    "    b += 1\n",
+    "    if b > 2:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yDmK1xQ9T4IY"
+   },
+   "source": [
+    "# Machine translation\n",
+    "\n",
+    "When dealing with sequence-to-sequence tasks, such as NMT, we need to create a vocabulary for the source and target language. In addition, the input and output sequences may have different lengths, so we need to use padding to ensure that we can create fixed-size minibatches. We show how to do this below.\n",
+    "\n",
+    "This is based on sec 9.5 of \n",
+    "http://d2l.ai/chapter_recurrent-modern/machine-translation-and-dataset.html\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gBUgcAcmUdCJ"
+   },
+   "source": [
+    "## Data\n",
+    "\n",
+    "We use an English-French dataset that consists of bilingual sentence pairs from the [Tatoeba Project](http://www.manythings.org/anki/). Each line in the dataset is a tab-delimited pair of an English text sequence (source) and the translated French text sequence (target).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "UnjXAtdYUUW8",
+    "outputId": "66c19d66-217b-43ef-9877-854ea32725d0"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Go.\tVa !\n",
+      "Hi.\tSalut !\n",
+      "Run!\tCours !\n",
+      "Run!\tCourez !\n",
+      "Who?\tQui ?\n",
+      "Wow!\tÇa alors !\n",
+      "Fire!\tAu feu !\n",
+      "Help!\tÀ l'\n"
+     ]
+    }
+   ],
+   "source": [
+    "DATA_HUB['fra-eng'] = (DATA_URL + 'fra-eng.zip',\n",
+    "                           '94646ad1522d915e7b0f9296181140edcf86a4f5')\n",
+    "\n",
+    "def read_data_nmt():\n",
+    "    \"\"\"Load the English-French dataset.\"\"\"\n",
+    "    data_dir = download_extract('fra-eng')\n",
+    "    with open(os.path.join(data_dir, 'fra.txt'), 'r') as f:\n",
+    "        return f.read()\n",
+    "\n",
+    "raw_text = read_data_nmt()\n",
+    "print(raw_text[:100])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sqZImjzDVMHa"
+   },
+   "source": [
+    "## Preprocessing\n",
+    "\n",
+    "We apply several preprocessing steps: we replace non-breaking space with space, convert uppercase letters to lowercase ones, and insert space between words and punctuation marks.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "r5ZUH4ZaUquY",
+    "outputId": "316a660f-1d3a-45e4-ddb2-f97ed3128733"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "go .\tva !\n",
+      "hi .\tsalut !\n",
+      "run !\tcours !\n",
+      "run !\tcourez !\n",
+      "who ?\tqui ?\n",
+      "wow !\tça alors !\n",
+      "fire !\tau feu !\n",
+      "help !\tà l'ai\n"
+     ]
+    }
+   ],
+   "source": [
+    "def preprocess_nmt(text):\n",
+    "    \"\"\"Preprocess the English-French dataset.\"\"\"\n",
+    "    def no_space(char, prev_char):\n",
+    "        return char in set(',.!?') and prev_char != ' '\n",
+    "\n",
+    "    # Replace non-breaking space with space, and convert uppercase letters to\n",
+    "    # lowercase ones\n",
+    "    text = text.replace('\\u202f', ' ').replace('\\xa0', ' ').lower()\n",
+    "    # Insert space between words and punctuation marks\n",
+    "    out = [\n",
+    "        ' ' + char if i > 0 and no_space(char, text[i - 1]) else char\n",
+    "        for i, char in enumerate(text)]\n",
+    "    return ''.join(out)\n",
+    "\n",
+    "text = preprocess_nmt(raw_text)\n",
+    "print(text[:110])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yGChAGPjVgUn"
+   },
+   "source": [
+    "We tokenize at the word level.  The following tokenize_nmt function tokenizes the the first `num_examples` text sequence pairs, where each token is either a word or a punctuation mark. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "id": "PZ-iR79zVKM_"
+   },
+   "outputs": [],
+   "source": [
+    "def tokenize_nmt(text, num_examples=None):\n",
+    "    \"\"\"Tokenize the English-French dataset.\"\"\"\n",
+    "    source, target = [], []\n",
+    "    for i, line in enumerate(text.split('\\n')):\n",
+    "        if num_examples and i > num_examples:\n",
+    "            break\n",
+    "        parts = line.split('\\t')\n",
+    "        if len(parts) == 2:\n",
+    "            source.append(parts[0].split(' '))\n",
+    "            target.append(parts[1].split(' '))\n",
+    "    return source, target\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "v282HIgRVfza",
+    "outputId": "12cafea1-eee6-43e9-ba8d-79c6ef5affc2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([['go', '.'],\n",
+       "  ['hi', '.'],\n",
+       "  ['run', '!'],\n",
+       "  ['run', '!'],\n",
+       "  ['who', '?'],\n",
+       "  ['wow', '!'],\n",
+       "  ['fire', '!'],\n",
+       "  ['help', '!'],\n",
+       "  ['jump', '.'],\n",
+       "  ['stop', '!']],\n",
+       " [['va', '!'],\n",
+       "  ['salut', '!'],\n",
+       "  ['cours', '!'],\n",
+       "  ['courez', '!'],\n",
+       "  ['qui', '?'],\n",
+       "  ['ça', 'alors', '!'],\n",
+       "  ['au', 'feu', '!'],\n",
+       "  ['à', \"l'aide\", '!'],\n",
+       "  ['saute', '.'],\n",
+       "  ['ça', 'suffit', '!']])"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "source, target = tokenize_nmt(text)\n",
+    "source[:10], target[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LC8u2YndV6-P"
+   },
+   "source": [
+    "## Vocabulary\n",
+    "\n",
+    "We can make a source and target vocabulary. To avoid having too many unique tokens, we specify a minimum frequency of 2 - all others will get replaced by \"unk\". We also add special tags for padding, begin of sentence, and end of sentence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "v9SrJQc3VtSn",
+    "outputId": "8b0e6cd5-890d-46c5-ce79-14f256ba63b3"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10012"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "src_vocab = Vocab(source, min_freq=2,\n",
+    "                      reserved_tokens=['<pad>', '<bos>', '<eos>'])\n",
+    "len(src_vocab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "KPF2FthfV840",
+    "outputId": "f08bca8e-8564-411d-e58f-6e5b2e19f671"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17851"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# French has more high frequency words than English\n",
+    "target_vocab = Vocab(target, min_freq=2,\n",
+    "                      reserved_tokens=['<pad>', '<bos>', '<eos>'])\n",
+    "len(target_vocab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "d0DyArAtWcob"
+   },
+   "source": [
+    "## Truncation and padding\n",
+    "\n",
+    "To create minibatches of sequences, all of the same length, we truncate sentences that are too long, and pad ones that are too short."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "x2D62tczWP-2",
+    "outputId": "25ca1de2-97a6-4273-abbf-644a41562bb8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['go', '.', 'pad', 'pad', 'pad', 'pad', 'pad', 'pad', 'pad', 'pad']\n",
+      "[47, 4, 1, 1, 1, 1, 1, 1, 1, 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def truncate_pad(line, num_steps, padding_token):\n",
+    "    \"\"\"Truncate or pad sequences.\"\"\"\n",
+    "    if len(line) > num_steps:\n",
+    "        return line[:num_steps]  # Truncate\n",
+    "    return line + [padding_token] * (num_steps - len(line))  # Pad\n",
+    "\n",
+    "print(truncate_pad(source[0], 10, 'pad'))\n",
+    "print(truncate_pad(src_vocab[source[0]], 10, src_vocab['<pad>']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "id": "RgyPxL6tWvJC"
+   },
+   "outputs": [],
+   "source": [
+    "def build_array_nmt(lines, vocab, num_steps):\n",
+    "    \"\"\"Transform text sequences of machine translation into minibatches.\"\"\"\n",
+    "    lines = [vocab[l] for l in lines]\n",
+    "    lines = [l + [vocab['<eos>']] for l in lines]\n",
+    "    array = torch.tensor([\n",
+    "        truncate_pad(l, num_steps, vocab['<pad>']) for l in lines])\n",
+    "    valid_len = (array != vocab['<pad>']).type(torch.int32).sum(1)\n",
+    "    return array, valid_len"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "SlwULfBwW9ma",
+    "outputId": "51eae96b-bfd0-4325-93ef-c98315abb6b0"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(167130, 10)\n",
+      "(167130,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_steps = 10\n",
+    "src_array, src_valid_len = build_array_nmt(source, src_vocab, num_steps)\n",
+    "print(jnp.array(src_array).shape)\n",
+    "print(jnp.array(src_valid_len).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "br6L3nDbXFHY",
+    "outputId": "e70924a1-6e71-49dc-b393-364feac92296"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[47  4  3  1  1  1  1  1  1  1]\n",
+      "3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(jnp.array(src_array[0,:])) # go, ., eos, pad, ..., pad\n",
+    "print(jnp.array(src_valid_len[0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UyXmgFUvXVnA"
+   },
+   "source": [
+    "## Data iterator\n",
+    "\n",
+    "Below we combine all of the above pieces into a handy function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "id": "AkD1QMiJXKAP"
+   },
+   "outputs": [],
+   "source": [
+    "def load_array(data_arrays, batch_size, is_train=True):\n",
+    "    \"\"\"Construct a PyTorch data iterator.\"\"\"\n",
+    "    dataset = data.TensorDataset(*data_arrays)\n",
+    "    return data.DataLoader(dataset, batch_size, shuffle=is_train)\n",
+    "    \n",
+    "def load_data_nmt(batch_size, num_steps, num_examples=600):\n",
+    "    \"\"\"Return the iterator and the vocabularies of the translation dataset.\"\"\"\n",
+    "    text = preprocess_nmt(read_data_nmt())\n",
+    "    source, target = tokenize_nmt(text, num_examples)\n",
+    "    src_vocab = Vocab(source, min_freq=2,\n",
+    "                          reserved_tokens=['<pad>', '<bos>', '<eos>'])\n",
+    "    tgt_vocab = Vocab(target, min_freq=2,\n",
+    "                          reserved_tokens=['<pad>', '<bos>', '<eos>'])\n",
+    "    src_array, src_valid_len = build_array_nmt(source, src_vocab, num_steps)\n",
+    "    tgt_array, tgt_valid_len = build_array_nmt(target, tgt_vocab, num_steps)\n",
+    "    data_arrays = (src_array, src_valid_len, tgt_array, tgt_valid_len)\n",
+    "    data_iter = load_array(data_arrays, batch_size)\n",
+    "    return data_iter, src_vocab, tgt_vocab"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ARsiX21oXdOd"
+   },
+   "source": [
+    "Show the first minibatch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "vl00eydyXeYF",
+    "outputId": "a48df679-efd7-4e87-b3cd-fb66689e56e0"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X: [[95 11  3  1  1  1  1  1]\n",
+      " [ 6  0  4  3  1  1  1  1]]\n",
+      "valid lengths for X: [3 4]\n",
+      "Y: [[ 0  9  3  1  1  1  1  1]\n",
+      " [10  0  4  3  1  1  1  1]]\n",
+      "valid lengths for Y: [3 4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_iter, src_vocab, tgt_vocab = load_data_nmt(batch_size=2, num_steps=8)\n",
+    "for X, X_valid_len, Y, Y_valid_len in train_iter:\n",
+    "    print('X:', jnp.array(X).astype(jnp.int32))\n",
+    "    print('valid lengths for X:', jnp.array(X_valid_len))\n",
+    "    print('Y:', jnp.array(Y).astype(jnp.int32))\n",
+    "    print('valid lengths for Y:', jnp.array(Y_valid_len))\n",
+    "    break"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "colab": {
+   "authorship_tag": "ABX9TyPEQbJaxb2uGBL5ZwWgYmvt",
+   "include_colab_link": true,
+   "name": "text-preproc-torch.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:pyprobml]",
+   "language": "python",
+   "name": "conda-env-pyprobml-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
## Description

Converted `notebooks/text_preproc_torch.ipynb` to `notebooks/text_preproc_jax.ipynb`

### Colab link

https://colab.research.google.com/github/patel-zeel/probml-notebooks/blob/text_preproc_jax/notebooks/text_preproc_jax.ipynb 

### Issue 

<!-- Link the issue you are solving -->

<!-- If the issue is from this repo, include directly with issue number -->
<!-- For example: 

#12

-->

<!-- If the issue is from another repo, you can include it using the regular linking mechanism -->
<!-- For example:

[Issue title](Issue link) 

-->

[translate remaining torch demos to JAX](https://github.com/probml/pyprobml/issues/745)

## Checklist:

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

## Potential problems/Important remarks

* `from torch.utils import data` is used as it is. Data is converted to JAX in a for loop over `train_iter`.