### PR TITLE
Add `tree_map` and `lax.scan` examples

### DIFF
--- a/notebooks/Practical_JAX_Tips.ipynb
+++ b/notebooks/Practical_JAX_Tips.ipynb
@@ -1,318 +1,505 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Practical_JAX_Tips.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "MBsqFAPXMiqe"
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from IPython.display import display, Latex"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2JxtNUiINtTk"
+   },
+   "source": [
+    "## If else condition with `lax`\n",
+    "\n",
+    "$$\n",
+    "f(\\mathbf{x}) = \\sum_{x \\in \\mathbf{x}} \\begin{cases}\n",
+    "    x^2,& \\text{if } x \\gt 5\\\\\n",
+    "    x^3,             & \\text{otherwise}\n",
+    "\\end{cases}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 103
+    },
+    "id": "CZJJFRtvNz-f",
+    "outputId": "994e417f-d8dc-4080-aa6a-7cca12889419"
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "MBsqFAPXMiqe"
-      },
-      "outputs": [],
-      "source": [
-        "import jax\n",
-        "import jax.numpy as jnp\n",
-        "from IPython.display import display, Latex"
+     "data": {
+      "text/latex": [
+       "$f(\\mathbf{x}) = 108.0$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Latex object>"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "markdown",
-      "source": [
-        "## If else condition with `lax`\n",
-        "\n",
-        "$$\n",
-        "f(\\mathbf{x}) = \\sum_{x \\in \\mathbf{x}} \\begin{cases}\n",
-        "    x^2,& \\text{if } x \\gt 5\\\\\n",
-        "    x^3,             & \\text{otherwise}\n",
-        "\\end{cases}\n",
-        "$$"
+     "data": {
+      "text/latex": [
+       "$\\frac{df}{dx_0} = 20.0$"
       ],
-      "metadata": {
-        "id": "2JxtNUiINtTk"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "x = [jnp.array(10.0), jnp.array(2.0)]\n",
-        "\n",
-        "@jax.jit\n",
-        "@jax.value_and_grad\n",
-        "def f(x):\n",
-        "  bool_val = jax.tree_map(lambda val: val > 5.0, x)\n",
-        "  ans = jax.tree_map(lambda val, bool: jax.lax.cond(bool, lambda: val**2, lambda: val**3), x, bool_val)\n",
-        "  return jax.tree_util.tree_reduce(lambda a, b: a + b, ans)\n",
-        "\n",
-        "value, grad = f(x)\n",
-        "\n",
-        "display(Latex(f\"$f(\\mathbf{{x}}) = {value}$\"))\n",
-        "for idx in range(len(x)):\n",
-        "  display(Latex(f\"$\\\\frac{{df}}{{dx_{idx}}} = {grad[idx]}$\"))"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 103
-        },
-        "id": "CZJJFRtvNz-f",
-        "outputId": "994e417f-d8dc-4080-aa6a-7cca12889419"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Latex object>"
-            ],
-            "text/latex": "$f(\\mathbf{x}) = 108.0$"
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Latex object>"
-            ],
-            "text/latex": "$\\frac{df}{dx_0} = 20.0$"
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Latex object>"
-            ],
-            "text/latex": "$\\frac{df}{dx_1} = 12.0$"
-          },
-          "metadata": {}
-        }
+      "text/plain": [
+       "<IPython.core.display.Latex object>"
       ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-      "cell_type": "markdown",
-      "source": [
-        "## Pair-wise distance with `vmap`"
+     "data": {
+      "text/latex": [
+       "$\\frac{df}{dx_1} = 12.0$"
       ],
-      "metadata": {
-        "id": "1uMlNxkVMmVd"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# create vour pairwise function\n",
-        "def distance(a, b):\n",
-        "    return jnp.linalg.norm(a - b)\n",
-        "\n",
-        "\n",
-        "# map based combinator to operate on all pairs\n",
-        "def all_pairs(f):\n",
-        "    f = jax.vmap(f, in_axes=(None, 0))\n",
-        "    f = jax.vmap(f, in_axes=(0, None))\n",
-        "    return f\n",
-        "\n",
-        "\n",
-        "# transform to operate over sets\n",
-        "distances = all_pairs(distance)\n",
-        "\n",
-        "# Example\n",
-        "x = jnp.array([1.0, 2.0, 3.0])\n",
-        "y = jnp.array([3.0, 4.0, 5.0])\n",
-        "distances(x, y)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9FhnhGDnM6hF",
-        "outputId": "aa20bc05-13ed-4fe7-ff08-c4bc756cf1cc"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray([[2., 3., 4.],\n",
-              "             [1., 2., 3.],\n",
-              "             [0., 1., 2.]], dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 3
-        }
+      "text/plain": [
+       "<IPython.core.display.Latex object>"
       ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Compute Hessian with `jax`\n",
-        "\n",
-        "Let us consider Linear regression loss function\n",
-        "\n",
-        "\\begin{align}\n",
-        "\\mathcal{L}(\\boldsymbol{\\theta}) &= (\\boldsymbol{y} - X\\boldsymbol{\\theta})^T(\\boldsymbol{y} - X\\boldsymbol{\\theta})\\\\\n",
-        "\\frac{d\\mathcal{L}}{d\\boldsymbol{\\theta}} &= -2X^T\\boldsymbol{y} + 2X^TX\\boldsymbol{\\theta}\\\\\n",
-        "H_{\\mathcal{L}}(\\boldsymbol{\\theta}) &= 2X^TX\n",
-        "\\end{align}"
-      ],
-      "metadata": {
-        "id": "wofUJf4zQFj2"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def loss_function_per_point(theta, x, y):\n",
-        "  y_pred = x.T@theta\n",
-        "  return jnp.square(y_pred - y)\n",
-        "\n",
-        "def loss_function(theta, x, y):\n",
-        "  loss_per_point = jax.vmap(loss_function_per_point, in_axes=(None, 0, 0))(theta, x, y)\n",
-        "  return jnp.sum(loss_per_point)\n",
-        "\n",
-        "def gt_loss(theta, x, y):\n",
-        "  return jnp.sum(jnp.square(x@theta - y))\n",
-        "\n",
-        "def gt_grad(theta, x, y):\n",
-        "  return 2 * (x.T@x@theta - x.T@y)\n",
-        "\n",
-        "def gt_hess(theta, x, y):\n",
-        "  return 2 * x.T@x "
-      ],
-      "metadata": {
-        "id": "zoN-MNLQQE1L"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Simulate dataset "
-      ],
-      "metadata": {
-        "id": "DmCeqENNXNk1"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "key = jax.random.PRNGKey(0)\n",
-        "key, subkey1, subkey2 = jax.random.split(key, num=3)\n",
-        "N = 100\n",
-        "D = 11\n",
-        "x = jax.random.uniform(key, shape=(N, D))\n",
-        "y = jax.random.uniform(subkey1, shape=(N,))\n",
-        "theta = jax.random.uniform(subkey2, shape=(D,))"
-      ],
-      "metadata": {
-        "id": "j6IGQjpaUICp"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Verify loss and gradient values"
-      ],
-      "metadata": {
-        "id": "I3kkVJbfXVLy"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "loss_and_grad_function = jax.value_and_grad(loss_function)\n",
-        "\n",
-        "loss_val, grad = loss_and_grad_function(theta, x, y)\n",
-        "\n",
-        "assert jnp.allclose(loss_val, gt_loss(theta, x, y))\n",
-        "assert jnp.allclose(grad, gt_grad(theta, x, y))"
-      ],
-      "metadata": {
-        "id": "8f77RVCIUJz5"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Verify hessian matrix"
-      ],
-      "metadata": {
-        "id": "2-tcNFUfXeFw"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### Way-1 "
-      ],
-      "metadata": {
-        "id": "lx7CnyUDXq2S"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "hess = jax.hessian(loss_function)(theta, x, y)\n",
-        "\n",
-        "assert jnp.allclose(hess, gt_hess(theta, x, y))"
-      ],
-      "metadata": {
-        "id": "tr1qox7GWhqC"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### Way-2"
-      ],
-      "metadata": {
-        "id": "W06H46qdXt9_"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "hess = jax.jacfwd(jax.jacrev(loss_function))(theta, x, y)\n",
-        "\n",
-        "assert jnp.allclose(hess, gt_hess(theta, x, y))"
-      ],
-      "metadata": {
-        "id": "SYLlnalmXDqD"
-      },
-      "execution_count": null,
-      "outputs": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
-  ]
+   ],
+   "source": [
+    "x = [jnp.array(10.0), jnp.array(2.0)]\n",
+    "\n",
+    "\n",
+    "@jax.jit\n",
+    "@jax.value_and_grad\n",
+    "def f(x):\n",
+    "    bool_val = jax.tree_map(lambda val: val > 5.0, x)\n",
+    "    ans = jax.tree_map(\n",
+    "        lambda val, bool: jax.lax.cond(bool, lambda: val**2, lambda: val**3),\n",
+    "        x,\n",
+    "        bool_val,\n",
+    "    )\n",
+    "    return jax.tree_util.tree_reduce(lambda a, b: a + b, ans)\n",
+    "\n",
+    "\n",
+    "value, grad = f(x)\n",
+    "\n",
+    "display(Latex(f\"$f(\\mathbf{{x}}) = {value}$\"))\n",
+    "for idx in range(len(x)):\n",
+    "    display(Latex(f\"$\\\\frac{{df}}{{dx_{idx}}} = {grad[idx]}$\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1uMlNxkVMmVd"
+   },
+   "source": [
+    "## Pair-wise distance with `vmap`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9FhnhGDnM6hF",
+    "outputId": "aa20bc05-13ed-4fe7-ff08-c4bc756cf1cc"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray([[2., 3., 4.],\n",
+       "             [1., 2., 3.],\n",
+       "             [0., 1., 2.]], dtype=float32)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# create vour pairwise function\n",
+    "def distance(a, b):\n",
+    "    return jnp.linalg.norm(a - b)\n",
+    "\n",
+    "\n",
+    "# map based combinator to operate on all pairs\n",
+    "def all_pairs(f):\n",
+    "    f = jax.vmap(f, in_axes=(None, 0))\n",
+    "    f = jax.vmap(f, in_axes=(0, None))\n",
+    "    return f\n",
+    "\n",
+    "\n",
+    "# transform to operate over sets\n",
+    "distances = all_pairs(distance)\n",
+    "\n",
+    "# Example\n",
+    "x = jnp.array([1.0, 2.0, 3.0])\n",
+    "y = jnp.array([3.0, 4.0, 5.0])\n",
+    "distances(x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wofUJf4zQFj2"
+   },
+   "source": [
+    "## Compute Hessian with `jax`\n",
+    "\n",
+    "Let us consider Linear regression loss function\n",
+    "\n",
+    "\\begin{align}\n",
+    "\\mathcal{L}(\\boldsymbol{\\theta}) &= (\\boldsymbol{y} - X\\boldsymbol{\\theta})^T(\\boldsymbol{y} - X\\boldsymbol{\\theta})\\\\\n",
+    "\\frac{d\\mathcal{L}}{d\\boldsymbol{\\theta}} &= -2X^T\\boldsymbol{y} + 2X^TX\\boldsymbol{\\theta}\\\\\n",
+    "H_{\\mathcal{L}}(\\boldsymbol{\\theta}) &= 2X^TX\n",
+    "\\end{align}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "zoN-MNLQQE1L"
+   },
+   "outputs": [],
+   "source": [
+    "def loss_function_per_point(theta, x, y):\n",
+    "    y_pred = x.T @ theta\n",
+    "    return jnp.square(y_pred - y)\n",
+    "\n",
+    "\n",
+    "def loss_function(theta, x, y):\n",
+    "    loss_per_point = jax.vmap(loss_function_per_point, in_axes=(None, 0, 0))(\n",
+    "        theta, x, y\n",
+    "    )\n",
+    "    return jnp.sum(loss_per_point)\n",
+    "\n",
+    "\n",
+    "def gt_loss(theta, x, y):\n",
+    "    return jnp.sum(jnp.square(x @ theta - y))\n",
+    "\n",
+    "\n",
+    "def gt_grad(theta, x, y):\n",
+    "    return 2 * (x.T @ x @ theta - x.T @ y)\n",
+    "\n",
+    "\n",
+    "def gt_hess(theta, x, y):\n",
+    "    return 2 * x.T @ x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DmCeqENNXNk1"
+   },
+   "source": [
+    "### Simulate dataset "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "j6IGQjpaUICp"
+   },
+   "outputs": [],
+   "source": [
+    "key = jax.random.PRNGKey(0)\n",
+    "key, subkey1, subkey2 = jax.random.split(key, num=3)\n",
+    "N = 100\n",
+    "D = 11\n",
+    "x = jax.random.uniform(key, shape=(N, D))\n",
+    "y = jax.random.uniform(subkey1, shape=(N,))\n",
+    "theta = jax.random.uniform(subkey2, shape=(D,))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "I3kkVJbfXVLy"
+   },
+   "source": [
+    "### Verify loss and gradient values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "8f77RVCIUJz5"
+   },
+   "outputs": [],
+   "source": [
+    "loss_and_grad_function = jax.value_and_grad(loss_function)\n",
+    "\n",
+    "loss_val, grad = loss_and_grad_function(theta, x, y)\n",
+    "\n",
+    "assert jnp.allclose(loss_val, gt_loss(theta, x, y))\n",
+    "assert jnp.allclose(grad, gt_grad(theta, x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2-tcNFUfXeFw"
+   },
+   "source": [
+    "### Verify hessian matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lx7CnyUDXq2S"
+   },
+   "source": [
+    "#### Way-1 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "tr1qox7GWhqC"
+   },
+   "outputs": [],
+   "source": [
+    "hess = jax.hessian(loss_function)(theta, x, y)\n",
+    "\n",
+    "assert jnp.allclose(hess, gt_hess(theta, x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "W06H46qdXt9_"
+   },
+   "source": [
+    "#### Way-2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "SYLlnalmXDqD"
+   },
+   "outputs": [],
+   "source": [
+    "hess = jax.jacfwd(jax.jacrev(loss_function))(theta, x, y)\n",
+    "\n",
+    "assert jnp.allclose(hess, gt_hess(theta, x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `tree_map` in JAX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The only requirement for `tree_map` to work is, output should have the same structure as the first argument (as explained [here](https://github.com/deepmind/distrax/issues/147)). For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Custom node type mismatch: expected type: <class 'distrax._src.distributions.normal.Normal'>, value: DeviceArray(2., dtype=float32, weak_type=True).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import distrax\n",
+    "\n",
+    "dists = {\"Normal\": distrax.Normal(3.0, 4.0), \"Gamma\": distrax.Gamma(3.0, 4.0)}\n",
+    "samples = {\"Normal\": jnp.array(2.0), \"Gamma\": jnp.array(3.0)}\n",
+    "try:\n",
+    "    log_probs = jax.tree_map(lambda dist, sample: dist.log_prob(sample), dists, samples)\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The problem here is that `dists` do not have same structure as `log_probs` (`log_probs` structure matches with `samples`). So, we should keep `samples` as the first argument: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Gamma': DeviceArray(-6.337041, dtype=float32, weak_type=True),\n",
+       " 'Normal': DeviceArray(-2.336483, dtype=float32, weak_type=True)}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "log_probs = jax.tree_map(lambda sample, dist: dist.log_prob(sample), samples, dists)\n",
+    "log_probs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use of `lax.scan` to accelerate a training loop"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we create a dummy training loop and check the performance of `lax.scan`. The example also shows how to convert a training loop to `lax.scan` version of it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "value_and_grad_fun = jax.jit(jax.value_and_grad(lambda x: jnp.sum(x**2)))\n",
+    "\n",
+    "\n",
+    "def training_loop(n_iters, params):\n",
+    "    values = []\n",
+    "    for i in range(n_iters):\n",
+    "        value, grad = value_and_grad_fun(params)\n",
+    "        params = params - learning_rate * grad\n",
+    "        values.append(value)\n",
+    "    return value\n",
+    "\n",
+    "\n",
+    "@jax.jit\n",
+    "def one_step(params, xs):\n",
+    "    value, grad = value_and_grad_fun(params)\n",
+    "    params = params - learning_rate * grad\n",
+    "    return params, value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key = jax.random.PRNGKey(0)\n",
+    "N = 1000\n",
+    "n_iters = 10000\n",
+    "learning_rate = 0.01\n",
+    "\n",
+    "params = jax.random.uniform(key, (N,))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.27 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "training_loop(1, params)  # warn up\n",
+    "%timeit -n 1 -r 1 training_loop(n_iters, params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "225 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit -n 1 -r 1 jax.lax.scan(one_step, params, xs=None, length=n_iters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that `xs` array can be passed in case we want to scan over it. An example of it can be found in this [blackjax documentation](https://blackjax-devs.github.io/blackjax/examples/Introduction.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Practical_JAX_Tips.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:jax_gpu]",
+   "language": "python",
+   "name": "conda-env-jax_gpu-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/notebooks/Practical_JAX_Tips.ipynb
+++ b/notebooks/Practical_JAX_Tips.ipynb
@@ -339,7 +339,11 @@
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
-    "import distrax\n",
+    "try:\n",
+    "    import distrax\n",
+    "except:\n",
+    "    %pip install -qqq distrax\n",
+    "    import distrax\n",
     "\n",
     "dists = {\"Normal\": distrax.Normal(3.0, 4.0), \"Gamma\": distrax.Gamma(3.0, 4.0)}\n",
     "samples = {\"Normal\": jnp.array(2.0), \"Gamma\": jnp.array(3.0)}\n",
@@ -442,7 +446,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.27 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "1.26 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],
@@ -460,7 +464,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "225 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "221 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],


### PR DESCRIPTION
## Description

Updated [Practical_JAX_Tips](https://github.com/patel-zeel/probml-notebooks/blob/jax_tricks/notebooks/Practical_JAX_Tips.ipynb) with the following changes:

* Added a necessary condition for `jax.tree_map` to work with example.
* Added an example showing how to convert a normal training loop to `lax.scan` version of it.

### Colab link

https://colab.research.google.com/github/patel-zeel/probml-notebooks/blob/jax_tricks/notebooks/Practical_JAX_Tips.ipynb

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

Dr. @murphyk, can you please review it?